### PR TITLE
chore(deps): bump react and react-dom from 19.2.4 to 19.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,8 @@
         "nodemailer": "^7.0.13",
         "otplib": "^13.4.0",
         "qrcode": "^1.5.4",
-        "react": "19.2.4",
-        "react-dom": "19.2.4",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
         "recharts": "^3.8.1",
         "tailwind-merge": "^3.6.0",
         "zod": "^4.4.3"
@@ -9934,24 +9934,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "nodemailer": "^7.0.13",
     "otplib": "^13.4.0",
     "qrcode": "^1.5.4",
-    "react": "19.2.4",
-    "react-dom": "19.2.4",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
     "recharts": "^3.8.1",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"


### PR DESCRIPTION
## Summary

- Sobe `react` e `react-dom` de `19.2.4` para `19.2.6` em conjunto.
- Resolve o conflito de peer dep que travou o [PR #5](https://github.com/guiloklex-hub/wfv-management-system/pull/5) do Dependabot (que bumpava só `react-dom`).
- Patch release — sem mudanças de API.

## Por quê não pelo Dependabot

`react-dom@19.2.6` exige peer `react@^19.2.6`. O Dependabot abre um PR por dep, então o bump isolado de `react-dom` quebra com `ERESOLVE` no `npm ci`. O fix correto é subir os dois juntos, manualmente.

## Test plan

- [x] `npm install` resolve sem `ERESOLVE`
- [x] `npm run lint` passa
- [x] `npm run test:run` passa (324 testes)
- [x] `npm run build` passa

Substitui o PR #5 (que será fechado).