### PR TITLE
chore: ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ backups/
 
 # Plan files (Claude Code)
 .claude/plans/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Adiciona `.claude/settings.local.json` ao `.gitignore`.
- Esse arquivo contém permissões locais do Claude Code (Bash allow-rules para `gh pr review`, `gh pr merge`, etc.) usadas em sessões específicas e não deve ser versionado.

## Test plan

- [x] `.gitignore` mantém as entradas existentes (`.claude/plans/`) e adiciona apenas a nova linha
- [x] Nenhum arquivo de código alterado