### PR TITLE
fix(contracts): primeiro PDF mantém versão atual do contrato

### DIFF
--- a/docs/anexos.md
+++ b/docs/anexos.md
@@ -86,16 +86,25 @@ Implementado em `src/lib/permissions.ts`:
 
 ## Versionamento de contratos
 
-`Contract.version` é incrementado a cada `replaceContractFile`. Fluxo:
+Regra: o **primeiro PDF** enviado a um contrato é gravado na versão
+atual do contrato (ex.: contrato criado em v1 + primeiro upload =
+attachment v1). **Substituições** posteriores incrementam (v2, v3…).
 
-1. Carrega contrato + última versão.
-2. Atomicamente (em `prisma.$transaction`):
-   - `Attachment.updateMany` setando `deletedAt = now()` em CONTRACT
-     atuais do contrato.
-   - `Attachment.create` com `version: n+1`, `kind: CONTRACT`,
-     `subdir: v{n+1}`.
-   - `Contract.update` incrementando `version`.
-3. Registra `audit("Contract", id, "REPLACE", { fromVersion, toVersion })`.
+Fluxo de `replaceContractFile`:
+
+1. Carrega contrato + conta CONTRACT attachments ativos.
+2. Define `nextVersion`:
+   - **Sem attachment ativo** (primeiro upload) → `nextVersion = contract.version`.
+   - **Com attachment ativo** (substituição) → `nextVersion = contract.version + 1`.
+3. Atomicamente (em `prisma.$transaction`):
+   - Se substituição: `Attachment.updateMany` setando `deletedAt = now()`
+     no CONTRACT ativo do contrato.
+   - `Attachment.create` com `version: nextVersion`, `kind: CONTRACT`,
+     `subdir: v{nextVersion}`.
+   - Se substituição: `Contract.update` setando `version = nextVersion`.
+4. Registra `audit("Contract", id, "UPLOAD" | "REPLACE", { fromVersion, toVersion })`.
+   - `UPLOAD` no primeiro envio (fromVersion === toVersion).
+   - `REPLACE` quando houve troca de versão.
 
 Arquivos da versão antiga **não são removidos do disco imediatamente** —
 ficam soft-deletados por 30 dias.

--- a/docs/seguranca.md
+++ b/docs/seguranca.md
@@ -204,9 +204,9 @@ detalhes completos. Resumo das proteções:
 - **Rate limit**: 10 uploads/min por usuário, 30/min por IP. Download:
   20/min por (usuário+anexo), 120/min por IP.
 - **Audit** em UPLOAD/DOWNLOAD/REPLACE/SIGN/DELETE.
-- **Versionamento de contrato**: `replaceContractFile` cria v2, v3…
-  atomicamente em `prisma.$transaction`; versão antiga soft-deletada por
-  30 dias.
+- **Versionamento de contrato**: o primeiro PDF mantém a versão atual
+  do contrato; substituições posteriores criam v2, v3… atomicamente em
+  `prisma.$transaction`; versão antiga soft-deletada por 30 dias.
 - **/api/files/[id]** ganhou ownership granular por kind
   (`canViewAttachmentKind`), headers `X-Content-Type-Options: nosniff`,
   `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: no-referrer`,

--- a/src/app/actions/contractActions.test.ts
+++ b/src/app/actions/contractActions.test.ts
@@ -6,6 +6,10 @@ vi.mock("@/auth", () => ({
   auth: () => authMock(),
 }));
 
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers(),
+}));
+
 const saveUploadMock = vi.fn();
 vi.mock("@/lib/storage", () => ({
   saveUpload: (...args: unknown[]) => saveUploadMock(...args),
@@ -14,6 +18,7 @@ vi.mock("@/lib/storage", () => ({
 import {
   createContract,
   deleteContract,
+  replaceContractFile,
   updateContract,
 } from "./contractActions";
 
@@ -93,5 +98,94 @@ describe("deleteContract", () => {
       where: { id: "c1", vendorId: "v1", deletedAt: null },
       data: { deletedAt: expect.any(Date) },
     });
+  });
+});
+
+describe("replaceContractFile", () => {
+  function pdfFile(name = "contrato.pdf"): File {
+    const header = Buffer.from("%PDF-1.4\nconteudo de teste", "ascii");
+    return new File([header], name, { type: "application/pdf" });
+  }
+
+  function fdWith(file: File): FormData {
+    const fd = new FormData();
+    fd.set("contractId", "c1");
+    fd.set("vendorId", "v1");
+    fd.set("file", file);
+    return fd;
+  }
+
+  function setupTransaction(): void {
+    prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
+      if (typeof arg === "function") {
+        return (arg as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock);
+      }
+      return arg;
+    });
+  }
+
+  beforeEach(() => {
+    authMock.mockResolvedValue({ user: { id: "u1", role: "ADMIN" } });
+    saveUploadMock.mockResolvedValue({
+      filename: "contrato.pdf",
+      mimeType: "application/pdf",
+      size: 1024,
+      storagePath: "uploads/contract/c1/v1/abc_contrato.pdf",
+      sha256Full: "a".repeat(64),
+    });
+    prismaMock.attachment.updateMany.mockResolvedValue({ count: 0 } as never);
+    prismaMock.attachment.create.mockResolvedValue({ id: "att1" } as never);
+    prismaMock.contract.update.mockResolvedValue({} as never);
+    setupTransaction();
+  });
+
+  it("primeiro upload mantém a versão atual do contrato (v1 → v1)", async () => {
+    prismaMock.contract.findFirst.mockResolvedValue({
+      id: "c1",
+      vendorId: "v1",
+      version: 1,
+    } as never);
+    prismaMock.attachment.count.mockResolvedValue(0 as never);
+
+    const r = await replaceContractFile(undefined, fdWith(pdfFile()));
+    expect(r.success).toBe(true);
+
+    expect(prismaMock.contract.update).not.toHaveBeenCalled();
+    expect(prismaMock.attachment.updateMany).not.toHaveBeenCalled();
+
+    const subdir = (saveUploadMock.mock.calls[0][1] as { subdir: string }).subdir;
+    expect(subdir).toBe("v1");
+
+    const createdVersion = (
+      prismaMock.attachment.create.mock.calls[0][0] as { data: { version: number } }
+    ).data.version;
+    expect(createdVersion).toBe(1);
+  });
+
+  it("substituição com PDF existente incrementa para v2", async () => {
+    prismaMock.contract.findFirst.mockResolvedValue({
+      id: "c1",
+      vendorId: "v1",
+      version: 1,
+    } as never);
+    prismaMock.attachment.count.mockResolvedValue(1 as never);
+    prismaMock.attachment.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const r = await replaceContractFile(undefined, fdWith(pdfFile()));
+    expect(r.success).toBe(true);
+
+    expect(prismaMock.attachment.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ contractId: "c1", kind: "CONTRACT", deletedAt: null }),
+        data: { deletedAt: expect.any(Date) },
+      }),
+    );
+    expect(prismaMock.contract.update).toHaveBeenCalledWith({
+      where: { id: "c1" },
+      data: { version: 2 },
+    });
+
+    const subdir = (saveUploadMock.mock.calls[0][1] as { subdir: string }).subdir;
+    expect(subdir).toBe("v2");
   });
 });

--- a/src/app/actions/contractActions.ts
+++ b/src/app/actions/contractActions.ts
@@ -250,7 +250,11 @@ export async function replaceContractFile(
     assertMagicMatchesMime(detected, file.type);
     assertAllowedForKind("CONTRACT", file.type);
 
-    const nextVersion = contract.version + 1;
+    const existingActive = await prisma.attachment.count({
+      where: { contractId: contract.id, kind: "CONTRACT", deletedAt: null },
+    });
+    const isFirstUpload = existingActive === 0;
+    const nextVersion = isFirstUpload ? contract.version : contract.version + 1;
     const stored = await saveUpload(file, {
       ownerType: "CONTRACT",
       ownerId: contract.id,
@@ -258,14 +262,16 @@ export async function replaceContractFile(
     });
 
     const result = await prisma.$transaction(async (tx) => {
-      await tx.attachment.updateMany({
-        where: {
-          contractId: contract.id,
-          kind: "CONTRACT",
-          deletedAt: null,
-        },
-        data: { deletedAt: new Date() },
-      });
+      if (!isFirstUpload) {
+        await tx.attachment.updateMany({
+          where: {
+            contractId: contract.id,
+            kind: "CONTRACT",
+            deletedAt: null,
+          },
+          data: { deletedAt: new Date() },
+        });
+      }
 
       const newAtt = await tx.attachment.create({
         data: {
@@ -284,10 +290,12 @@ export async function replaceContractFile(
         },
       });
 
-      await tx.contract.update({
-        where: { id: contract.id },
-        data: { version: nextVersion },
-      });
+      if (!isFirstUpload) {
+        await tx.contract.update({
+          where: { id: contract.id },
+          data: { version: nextVersion },
+        });
+      }
 
       return newAtt;
     });
@@ -295,7 +303,7 @@ export async function replaceContractFile(
     await audit(
       "Contract",
       contract.id,
-      "REPLACE",
+      isFirstUpload ? "UPLOAD" : "REPLACE",
       {
         fromVersion: contract.version,
         toVersion: nextVersion,

--- a/src/app/dashboard/vendors/[id]/vendor-detail-client.tsx
+++ b/src/app/dashboard/vendors/[id]/vendor-detail-client.tsx
@@ -1023,25 +1023,37 @@ function ContractFileBlock({
     );
   }
 
-  function submitReplace(formData: FormData) {
-    setConfirmReplace(formData);
-  }
-
-  function confirmDoReplace() {
-    const fd = confirmReplace;
-    if (!fd) return;
+  function doUpload(fd: FormData) {
     setBusy(true);
     startTransition(async () => {
       try {
         const r = await replaceContractFile(undefined, fd);
         if (r.success) {
-          toast.success("Contrato atualizado", `Nova versão v${contract.version + 1}`);
+          if (current) {
+            toast.success("Contrato atualizado", `Nova versão v${contract.version + 1}`);
+          } else {
+            toast.success("PDF do contrato enviado", `Mantido como v${contract.version}`);
+          }
         } else toast.error("Falha", r.error);
       } finally {
         setBusy(false);
         setConfirmReplace(null);
       }
     });
+  }
+
+  function submitReplace(formData: FormData) {
+    if (!current) {
+      doUpload(formData);
+      return;
+    }
+    setConfirmReplace(formData);
+  }
+
+  function confirmDoReplace() {
+    const fd = confirmReplace;
+    if (!fd) return;
+    doUpload(fd);
   }
 
   function handleSign(method: "DIGITAL" | "PHYSICAL") {

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,14 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.4.2",
+    date: "2026-05-16",
+    highlights: [
+      "📎 Primeiro PDF anexado a um contrato agora respeita a versão atual do contrato — antes, criar o contrato (v1) e enviar o PDF imediatamente já saltava para v2 sem motivo. Substituições posteriores continuam incrementando v2, v3…",
+      "💬 O confirm dialog 'Criar nova versão?' só aparece quando já existe PDF anexado — primeiro upload é direto.",
+    ],
+  },
+  {
     version: "0.4.1",
     date: "2026-05-16",
     highlights: [

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -843,19 +843,19 @@ export const HELP_ARTICLES: HelpArticle[] = [
     keywords: ["contrato", "pdf", "upload", "anexar", "versão", "assinar"],
     icon: FileText,
     summary:
-      "Cada contrato aceita um PDF (até 8 MB). Substituir cria uma nova versão e arquiva a anterior automaticamente.",
+      "Cada contrato aceita um PDF (até 8 MB). O primeiro envio fica na versão atual do contrato; só a substituição posterior cria uma nova versão.",
     steps: [
       {
         title: "Crie o contrato primeiro",
-        body: "Em Fornecedores › abra o fornecedor › seção Contratos › Novo. Preencha título, valor, etc.",
+        body: "Em Fornecedores › abra o fornecedor › seção Contratos › Novo. Preencha título, valor, etc. O contrato começa em v1.",
       },
       {
-        title: "Envie o PDF",
-        body: "Dentro do contrato criado, o bloco 'Arquivo do contrato' aceita PDF até 8 MB. O preview aparece embutido logo após o envio. Se o navegador não conseguir renderizar inline (ex.: extensões bloqueando), use o link 'Baixar PDF' ou 'Abrir em nova aba'.",
+        title: "Envie o PDF (continua v1)",
+        body: "Dentro do contrato criado, o bloco 'Arquivo do contrato' aceita PDF até 8 MB. O primeiro PDF é gravado na mesma versão do contrato — se você criou em v1, o PDF também fica como v1. O preview aparece embutido logo após o envio.",
       },
       {
         title: "Substituir = nova versão",
-        body: "Subir um novo PDF arquiva o anterior e gera v2, v3… O histórico fica acessível para ADMIN/GROOM/BRIDE.",
+        body: "Subir um PDF novo no lugar de um já anexado arquiva o anterior e gera v2, v3… O histórico fica acessível para ADMIN/GROOM/BRIDE.",
       },
       {
         title: "Registrar assinatura",


### PR DESCRIPTION
## Contexto

Reportado: ao criar um contrato preenchendo os campos (vira v1) e em seguida anexar o PDF, ele saltava para v2 — sem o usuário ter substituído nada. O esperado é que o **primeiro upload** continue na versão atual do contrato e só a **substituição** posterior crie uma nova versão.

## Causa

Em `src/app/actions/contractActions.ts`, a função `replaceContractFile` sempre fazia `nextVersion = contract.version + 1`, mesmo quando ainda não existia nenhum `Attachment` do tipo `CONTRACT` ativo para aquele contrato.

## Mudança

- **Server Action** (`src/app/actions/contractActions.ts`): conta `Attachment.count` ativos antes da transação. Se for 0 (primeiro upload), mantém `contract.version`, pula o `attachment.updateMany` e o `contract.update`. Caso contrário, incrementa como antes.
- **Auditoria**: distingue `UPLOAD` (primeiro envio, `fromVersion === toVersion`) de `REPLACE` (substituição).
- **UI** (`vendor-detail-client.tsx`): confirm dialog "Criar nova versão?" só aparece quando já existe PDF anexado; primeiro upload é direto. Toast também é diferenciado por caso.
- **Testes** (`contractActions.test.ts`): 2 casos novos
  - primeiro upload **não** chama `contract.update` nem `attachment.updateMany`, e o attachment é criado em `v1`
  - substituição arquiva o anterior, incrementa contrato para `v2` e usa `subdir: v2`
- **Docs sincronizadas** (`docs/anexos.md`, `docs/seguranca.md`) e **central de ajuda** (`src/lib/help-content.ts`) com a regra ajustada.
- **Changelog** (`src/lib/changelog.ts`): entrada **0.4.2**.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 395 testes (incluindo os 2 novos)
- [x] `npm run build` — compila
- [ ] Manual: criar fornecedor → criar contrato com campos preenchidos → conferir que aparece como `v1` → anexar PDF → conferir que continua `v1` e que **não** aparece histórico de versões.
- [ ] Manual: subir um PDF novo no mesmo contrato → confirmar que pede confirmação "Criar nova versão v2?" → após confirmar, contrato vira `v2` e o `v1` aparece no histórico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)