### PR TITLE
style(dashboard): ajustar responsividade e limites de altura do grafi…

### DIFF
--- a/src/app/dashboard/charts.tsx
+++ b/src/app/dashboard/charts.tsx
@@ -32,10 +32,10 @@ export default function DashboardCharts({ data }: { data: ChartDatum[] }) {
 
   return (
     <div className="w-full">
-      <div className="h-[260px] w-full">
+      <div className="h-[180px] sm:h-[220px] w-full">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
-            <Pie data={data} innerRadius={70} outerRadius={100} paddingAngle={5} dataKey="value" stroke="none">
+            <Pie data={data} innerRadius="55%" outerRadius="75%" paddingAngle={5} dataKey="value" stroke="none">
               {data.map((entry, index) => (
                 <Cell key={`cell-${index}`} fill={entry.color ?? FALLBACK_COLORS[index % FALLBACK_COLORS.length]} />
               ))}
@@ -54,7 +54,7 @@ export default function DashboardCharts({ data }: { data: ChartDatum[] }) {
           </PieChart>
         </ResponsiveContainer>
       </div>
-      <ul className="mt-4 flex flex-wrap justify-center gap-x-3 gap-y-2 text-xs text-zinc-400">
+      <ul className="custom-scrollbar mt-4 flex flex-wrap justify-center gap-x-3 gap-y-2 overflow-y-auto pr-1 text-xs text-zinc-400 max-h-[80px] sm:max-h-[100px]">
         {data.map((entry, index) => (
           <li key={entry.name} className="flex items-center gap-1.5">
             <span


### PR DESCRIPTION
## 📝 Descrição

Este Pull Request corrige um problema de experiência de usuário e layout responsivo no dashboard principal. O card de **"Distribuição do Orçamento"** crescia verticalmente de forma desordenada à medida que novas categorias de fornecedores eram adicionadas, gerando rolagem excessiva no mobile e esticando de forma desproporcional os cards vizinhos (como o de Próximos Vencimentos e Tarefas) no grid de desktop.

---

## 🛠️ Mudanças Realizadas

### 1. Ajuste de Altura e Gráfico Responsivo
- Reduzida a altura do container do gráfico de pizza de `260px` fixo para `180px` no mobile (`h-[180px]`) e `220px` a partir de telas médias (`sm:h-[220px]`).
- Alteradas as propriedades `innerRadius` e `outerRadius` do componente `<Pie />` de valores absolutos em pixels (`70` e `100`) para porcentagens dinâmicas (`"55%"` e `"75%"`). Isso garante que o gráfico se redimensione de forma fluida sem nunca sofrer cortes em telas menores.

### 2. Limitação e Scroll na Legenda
- Adicionado um limite de altura máxima na tag `<ul>` da legenda (`max-h-[80px]` no mobile e `sm:max-h-[100px]` no desktop).
- Aplicadas as classes `overflow-y-auto` e a `.custom-scrollbar` nativa do projeto. Com isso, caso o casamento possua muitas categorias registradas, a legenda se mantém contida com uma rolagem vertical fina e elegante, preservando a altura uniforme e o design premium do painel.

---

## 🧪 Testes Realizados

- **ESLint:** Execução do comando `npm run lint` retornando código `0` (sem erros ou avisos).
- **Next.js Build:** Compilação do build de produção (`npm run build`) executada com sucesso absoluto, sem erros de compilação estática ou de tipagem do TypeScript.

---

## 📸 Antes vs. Depois (Visual)

- **Antes:** O card crescia verticalmente sem controle se houvesse um número alto de categorias de orçamento, desalinhando o grid do desktop e esticando a página no mobile de forma desconfortável.
- **Depois:** Altura do card perfeitamente contida no mobile e alinhada com as tarefas e pagamentos pendentes no desktop, contando com uma rolagem interna ultra-fina na legenda caso necessário.
