### PR TITLE
style(dashboard): padronizar altura dos cards na grid principal

### DIFF
--- a/src/app/dashboard/_components/upcoming-tasks.tsx
+++ b/src/app/dashboard/_components/upcoming-tasks.tsx
@@ -11,16 +11,18 @@ const PRIORITY_STYLES: Record<string, string> = {
 
 export function UpcomingTasks({
   tasks,
+  compact,
 }: {
   tasks: Array<{ id: string; title: string; priority: string; deadline: Date | null }>;
+  compact?: boolean;
 }) {
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-      <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-zinc-100">Próximas Tarefas</h2>
-        <ListTodo className="h-5 w-5 text-zinc-400" />
+    <div className={`rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm${compact ? " flex flex-col lg:max-h-[380px]" : ""}`}>
+      <div className="mb-3 flex shrink-0 items-center justify-between">
+        <h2 className="text-sm font-semibold text-zinc-200">Próximas Tarefas</h2>
+        <ListTodo className="h-4 w-4 text-zinc-500" />
       </div>
-      <div className="custom-scrollbar max-h-[300px] space-y-3 overflow-y-auto pr-2">
+      <div className={`custom-scrollbar space-y-3 overflow-y-auto pr-2${compact ? " min-h-0 flex-1" : " max-h-[300px]"}`}>
         {tasks.length === 0 ? (
           <p className="text-sm text-zinc-500">Nenhuma tarefa pendente.</p>
         ) : (

--- a/src/app/dashboard/charts.tsx
+++ b/src/app/dashboard/charts.tsx
@@ -24,15 +24,15 @@ const FALLBACK_COLORS = [
 export default function DashboardCharts({ data }: { data: ChartDatum[] }) {
   if (!data || data.length === 0) {
     return (
-      <div className="flex h-[300px] items-center justify-center text-sm text-zinc-500">
+      <div className="flex h-full items-center justify-center text-sm text-zinc-500">
         Sem dados suficientes para o gráfico
       </div>
     );
   }
 
   return (
-    <div className="w-full">
-      <div className="h-[180px] sm:h-[220px] w-full">
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1 w-full">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie data={data} innerRadius="55%" outerRadius="75%" paddingAngle={5} dataKey="value" stroke="none">
@@ -54,15 +54,15 @@ export default function DashboardCharts({ data }: { data: ChartDatum[] }) {
           </PieChart>
         </ResponsiveContainer>
       </div>
-      <ul className="custom-scrollbar mt-4 flex flex-wrap justify-center gap-x-3 gap-y-2 overflow-y-auto pr-1 text-xs text-zinc-400 max-h-[80px] sm:max-h-[100px]">
+      <ul className="custom-scrollbar mt-3 flex shrink-0 flex-wrap justify-center gap-x-3 gap-y-1.5 overflow-y-auto pr-1 text-xs text-zinc-400 max-h-[72px]">
         {data.map((entry, index) => (
           <li key={entry.name} className="flex items-center gap-1.5">
             <span
               aria-hidden
-              className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+              className="inline-block h-2 w-2 shrink-0 rounded-sm"
               style={{ background: entry.color ?? FALLBACK_COLORS[index % FALLBACK_COLORS.length] }}
             />
-            <span className="break-words">{entry.name}</span>
+            <span className="break-words leading-tight">{entry.name}</span>
           </li>
         ))}
       </ul>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   CreditCard,
   ListTodo,
+  PieChart as PieChartIcon,
   Sparkles,
   TrendingDown,
   Users,
@@ -182,17 +183,22 @@ export default async function DashboardPage() {
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {finance ? (
           <>
-            <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-              <h2 className="mb-4 text-lg font-semibold text-zinc-100">Distribuição do Orçamento</h2>
-              <DashboardCharts data={categoryData} />
+            <div className="flex flex-col rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm lg:max-h-[380px]">
+              <div className="mb-3 flex shrink-0 items-center justify-between">
+                <h2 className="text-sm font-semibold text-zinc-200">Distribuição do Orçamento</h2>
+                <PieChartIcon className="h-4 w-4 text-zinc-500" />
+              </div>
+              <div className="min-h-0 flex-1">
+                <DashboardCharts data={categoryData} />
+              </div>
             </div>
 
-            <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-              <div className="mb-4 flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-zinc-100">Próximos Vencimentos</h2>
-                <CalendarClock className="h-5 w-5 text-zinc-400" />
+            <div className="flex flex-col rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm lg:max-h-[380px]">
+              <div className="mb-3 flex shrink-0 items-center justify-between">
+                <h2 className="text-sm font-semibold text-zinc-200">Próximos Vencimentos</h2>
+                <CalendarClock className="h-4 w-4 text-zinc-500" />
               </div>
-              <div className="custom-scrollbar max-h-[300px] space-y-3 overflow-y-auto pr-2">
+              <div className="custom-scrollbar min-h-0 flex-1 space-y-3 overflow-y-auto pr-2">
                 {data.upcomingPayments.length === 0 ? (
                   <p className="text-sm text-zinc-500">Nenhum pagamento para os próximos 30 dias.</p>
                 ) : (
@@ -201,20 +207,20 @@ export default async function DashboardPage() {
                       key={p.id}
                       className="flex items-center justify-between rounded-xl border border-zinc-800/80 bg-zinc-800/50 p-3"
                     >
-                      <div>
-                        <p className="font-medium text-zinc-200">{p.vendorName}</p>
-                        <p className="mt-1 text-xs text-zinc-500">
-                          Vencimento: {formatDateBR(p.dueDate)}
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-medium text-zinc-200">{p.vendorName}</p>
+                        <p className="mt-0.5 text-xs text-zinc-500">
+                          Venc.: {formatDateBR(p.dueDate)}
                         </p>
                       </div>
-                      <span className="font-semibold text-rose-400">{formatCurrency(p.amount)}</span>
+                      <span className="shrink-0 pl-3 font-semibold text-rose-400">{formatCurrency(p.amount)}</span>
                     </div>
                   ))
                 )}
               </div>
             </div>
 
-            <UpcomingTasks tasks={data.upcomingTasks} />
+            <UpcomingTasks tasks={data.upcomingTasks} compact />
           </>
         ) : (
           <>
@@ -226,13 +232,7 @@ export default async function DashboardPage() {
               thankedCount={data.giftsProgress.thankedCount}
               thankedPct={data.giftsProgress.thankedPct}
             />
-            <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-              <div className="mb-3 flex items-center justify-between">
-                <h2 className="text-sm font-semibold text-zinc-200">Próximas Tarefas</h2>
-                <ListTodo className="h-4 w-4 text-zinc-500" />
-              </div>
-              <UpcomingTasks tasks={data.upcomingTasks} />
-            </div>
+            <UpcomingTasks tasks={data.upcomingTasks} />
           </>
         )}
       </div>


### PR DESCRIPTION
Padroniza a altura dos 3 cards da seção principal do dashboard (Distribuição do Orçamento, Próximos Vencimentos, Próximas Tarefas) para que fiquem uniformes.

## Mudanças

- **page.tsx**: Cards usam `flex flex-col` + `lg:max-h-[380px]` com scroll interno
- **charts.tsx**: Gráfico de pizza usa layout flex responsivo em vez de alturas fixas; legendas compactadas
- **upcoming-tasks.tsx**: Nova prop `compact` para adaptar ao layout da grid de 3 colunas