### PR TITLE
fix(dashboard,login,onboarding): scroll mobile + hydration + redirect loop

### DIFF
--- a/src/app/dashboard/_components/kpi-card.tsx
+++ b/src/app/dashboard/_components/kpi-card.tsx
@@ -45,14 +45,16 @@ export function KpiCard({
         </div>
       </div>
       <div className="mt-4 flex items-end justify-between gap-3">
-        <span className="text-3xl font-bold tracking-tight text-zinc-100">{value}</span>
+        <span className="min-w-0 flex-1 break-words text-3xl font-bold tracking-tight text-zinc-100">
+          {value}
+        </span>
         {trend && trend.length > 1 ? (
-          <div className="w-24">
+          <div className="w-24 shrink-0">
             <Sparkline data={trend} stroke={ACCENT_LINE[accent]} />
           </div>
         ) : null}
       </div>
-      {hint ? <p className="mt-2 text-xs text-zinc-500">{hint}</p> : null}
+      {hint ? <p className="mt-2 break-words text-xs text-zinc-500">{hint}</p> : null}
     </div>
   );
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -8,8 +8,8 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
       <Sidebar />
       <div className="flex min-w-0 flex-1 flex-col">
         <MobileTopBar />
-        <main className="flex-1 overflow-y-auto bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-zinc-900/40 via-zinc-950 to-zinc-950 pb-20 md:pb-0">
-          <div className="mx-auto max-w-7xl p-4 sm:p-6 md:p-10">{children}</div>
+        <main className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-zinc-900/40 via-zinc-950 to-zinc-950 pb-20 md:pb-0">
+          <div className="mx-auto w-full max-w-7xl p-4 sm:p-6 md:p-10">{children}</div>
         </main>
         <MobileNav />
       </div>

--- a/src/app/dashboard/onboarding/already-done.tsx
+++ b/src/app/dashboard/onboarding/already-done.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSession } from "next-auth/react";
+import { CheckCircle2, Loader2 } from "lucide-react";
+
+export default function AlreadyDone() {
+  const { update } = useSession();
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+    (async () => {
+      try {
+        await update({ onboardingCompleted: true });
+      } catch {
+        // Mesmo se o update falhar, o hard reload abaixo reemite o JWT pelo cookie.
+      }
+      window.location.replace("/dashboard");
+    })();
+  }, [update]);
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-8 text-center shadow-xl">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/15 ring-1 ring-emerald-500/30">
+        <CheckCircle2 className="h-6 w-6 text-emerald-300" />
+      </div>
+      <h1 className="text-lg font-semibold text-white">Onboarding já concluído</h1>
+      <p className="text-sm text-zinc-400">
+        Sincronizando sua sessão e levando você ao painel…
+      </p>
+      <Loader2 className="mt-2 h-5 w-5 animate-spin text-rose-400" />
+    </div>
+  );
+}

--- a/src/app/dashboard/onboarding/onboarding-client.tsx
+++ b/src/app/dashboard/onboarding/onboarding-client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { useSession } from "next-auth/react";
 import {
@@ -38,7 +37,6 @@ const STEPS: Array<{ id: Step; title: string; subtitle: string; icon: React.Comp
 ];
 
 export default function OnboardingClient({ initial }: { initial: Initial }) {
-  const router = useRouter();
   const { update } = useSession();
   const toast = useToast();
 
@@ -87,11 +85,16 @@ export default function OnboardingClient({ initial }: { initial: Initial }) {
       try {
         const r = await finishOnboarding();
         if (r.success) {
-          await update({ onboardingCompleted: true });
+          try {
+            await update({ onboardingCompleted: true });
+          } catch {
+            // Silenciar: o hard reload abaixo força o JWT a ser reemitido pelo cookie.
+          }
           toast.success("Tudo pronto! Bom planejamento ✨");
-          router.push("/dashboard");
-          router.refresh();
-        } else toast.error("Falha", r.error);
+          window.location.assign("/dashboard");
+          return;
+        }
+        toast.error("Falha", r.error);
       } finally {
         setBusy(false);
       }

--- a/src/app/dashboard/onboarding/page.tsx
+++ b/src/app/dashboard/onboarding/page.tsx
@@ -3,6 +3,7 @@ import { auth } from "@/auth";
 import { getEventConfig, isOnboardingComplete } from "@/lib/event-config";
 import { toIsoDate } from "@/lib/format";
 import OnboardingClient from "./onboarding-client";
+import AlreadyDone from "./already-done";
 
 export const dynamic = "force-dynamic";
 
@@ -12,7 +13,9 @@ export default async function OnboardingPage() {
   if (role !== "ADMIN") redirect("/dashboard");
 
   const cfg = await getEventConfig();
-  if (isOnboardingComplete(cfg)) redirect("/dashboard");
+  if (isOnboardingComplete(cfg)) {
+    return <AlreadyDone />;
+  }
 
   return (
     <OnboardingClient

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -63,6 +63,7 @@ export default async function DashboardPage() {
       {!data.eventDate ? (
         <Link
           href="/dashboard/onboarding"
+          prefetch={false}
           className="flex items-start gap-3 rounded-2xl border border-rose-500/30 bg-gradient-to-br from-rose-500/15 via-rose-500/5 to-zinc-900/30 p-5 shadow-sm transition-colors hover:from-rose-500/25"
         >
           <Sparkles className="mt-0.5 h-5 w-5 shrink-0 text-rose-300" />

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -56,7 +56,7 @@ export default function LoginForm() {
     >
       <input ref={redirectRef} type="hidden" name="redirectTo" defaultValue="/dashboard" />
       <div className="space-y-4">
-        <div>
+        <div suppressHydrationWarning>
           <label className="mb-2 block text-sm font-medium text-zinc-300" htmlFor="email">
             Email
           </label>
@@ -70,9 +70,10 @@ export default function LoginForm() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
+            suppressHydrationWarning
           />
         </div>
-        <div>
+        <div suppressHydrationWarning>
           <label className="mb-2 block text-sm font-medium text-zinc-300" htmlFor="password">
             Senha
           </label>
@@ -87,6 +88,7 @@ export default function LoginForm() {
             minLength={1}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            suppressHydrationWarning
           />
         </div>
         {needs2fa ? (

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,16 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.4.3",
+    date: "2026-05-17",
+    highlights: [
+      "📱 Dashboard no mobile não rola mais lateralmente: cards do KPI ('Resumo do Orçamento', 'Total Já Pago' etc.) e o conteúdo principal ficavam mais largos que a viewport por causa do espaço inquebrável que o `R$` recebe no `Intl.NumberFormat` pt-BR — corrigido com `min-w-0` + `break-words` no valor e `overflow-x-hidden` no container principal.",
+      "🔐 Tela de login não acusa mais 'Hydration mismatch' quando o navegador tem Keeper/1Password/LastPass instalado — os inputs e seus wrappers ganharam `suppressHydrationWarning`, ignorando os elementos que a extensão injeta antes do React rehydratar.",
+      "🎯 Fim do loop de redirect no onboarding: quando o JWT estava com `onboardingCompleted: false` mas o banco já tinha o onboarding finalizado, a página fazia `redirect('/dashboard')` e o middleware mandava de volta para `/dashboard/onboarding`, derrubando o RSC com 'An unexpected response was received from the server'. Agora a página renderiza uma tela de transição que força o refresh do JWT via `window.location.assign` para o dashboard.",
+      "🚀 Conclusão do onboarding usa `window.location.assign('/dashboard')` em vez de `router.push` + `router.refresh` — garante que o cookie da sessão seja reemitido antes da navegação, mesmo se o `useSession().update()` falhar no NextAuth v5 beta.",
+    ],
+  },
+  {
     version: "0.4.2",
     date: "2026-05-16",
     highlights: [


### PR DESCRIPTION
## Summary

- **Dashboard mobile**: elimina scroll horizontal. O `Intl.NumberFormat("pt-BR")` insere U+00A0 entre `R$` e o número, tratando a string como indivisível. No `KpiCard`, com `text-3xl font-bold` em flex sem `min-w-0`, isso empurra o card além da viewport. Combinado com `overflow-y-auto` no `<main>` (que promove `overflow-x` a `auto`), virava scroll lateral cortando títulos e valores.
- **Login hydration mismatch**: extensões de gerenciador de senha (Keeper, 1Password, LastPass, Bitwarden) injetam `data-keeper-lock-id` no `<input>` e `<keeper-lock>` como sibling antes do React rehydratar. Adicionado `suppressHydrationWarning` nos inputs e wrappers de email/senha.
- **Onboarding "An unexpected response was received from the server"**: redirect loop entre middleware (lê JWT `onboardingCompleted`) e a página (lê `EventSettings.onboardingCompletedAt` do DB). Quando o JWT estava stale (`false`) mas o DB já marcava como completo, a página fazia `redirect("/dashboard")` → middleware mandava de volta → loop → Next.js retorna response inválida.

## Mudanças

- `src/app/dashboard/_components/kpi-card.tsx`: `min-w-0 flex-1 break-words` no valor, `shrink-0` na sparkline, `break-words` no hint.
- `src/app/dashboard/layout.tsx`: `<main>` com `min-w-0 overflow-x-hidden` + wrapper interno com `w-full`.
- `src/app/login/login-form.tsx`: `suppressHydrationWarning` nos dois inputs e seus `<div>` wrappers.
- `src/app/dashboard/onboarding/already-done.tsx` *(novo)*: client component que faz `useSession().update({ onboardingCompleted: true })` + `window.location.replace("/dashboard")` para forçar reemissão do cookie.
- `src/app/dashboard/onboarding/page.tsx`: troca `redirect()` por `<AlreadyDone />` quando DB diz que onboarding está completo.
- `src/app/dashboard/onboarding/onboarding-client.tsx`: `finish()` agora usa `window.location.assign("/dashboard")` em vez de `router.push + router.refresh`, com try/catch tolerante a falhas do `update()` do NextAuth v5 beta.
- `src/app/dashboard/page.tsx`: link de onboarding com `prefetch={false}` para evitar RSC prefetch em rota que pode redirecionar.
- `src/lib/changelog.ts`: entrada `0.4.3` na central de ajuda.

## Test plan

- [x] `npm run test:run` → 395/395 ✓
- [x] `npx tsc --noEmit` → limpo
- [x] `npx eslint` → apenas warning pré-existente
- [x] `npm run build` → OK
- [ ] Verificar no mobile (375px) que dashboard não rola lateralmente
- [ ] Verificar no /login com Keeper instalado que não aparece mais o erro de hydration
- [ ] Verificar no /dashboard/onboarding com JWT stale que a tela `AlreadyDone` aparece e redireciona

🤖 Generated with [Claude Code](https://claude.com/claude-code)