### PR TITLE
fix(dashboard): chart height no mobile + overflow-x-clip defensivo

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -189,7 +189,7 @@ export default async function DashboardPage() {
                 <h2 className="text-sm font-semibold text-zinc-200">Distribuição do Orçamento</h2>
                 <PieChartIcon className="h-4 w-4 text-zinc-500" />
               </div>
-              <div className="min-h-0 flex-1">
+              <div className="h-[260px] lg:h-auto lg:min-h-0 lg:flex-1">
                 <DashboardCharts data={categoryData} />
               </div>
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,9 +45,9 @@ export default function RootLayout({
   return (
     <html
       lang="pt-BR"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased dark`}
+      className={`${geistSans.variable} ${geistMono.variable} h-full overflow-x-clip antialiased dark`}
     >
-      <body className="min-h-full flex flex-col bg-zinc-950 text-zinc-100">
+      <body className="min-h-full flex flex-col overflow-x-clip bg-zinc-950 text-zinc-100">
         <SessionProvider>
           <ToastProvider>{children}</ToastProvider>
         </SessionProvider>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,14 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.4.4",
+    date: "2026-05-17",
+    highlights: [
+      "📱 Reforço contra scroll horizontal no mobile: `<html>` e `<body>` agora têm `overflow-x-clip` (defesa em profundidade) — mesmo se algum descendente futuro renderizar mais largo que a viewport, o document não rola.",
+      "🥧 Gráfico de pizza 'Distribuição do Orçamento' agora aparece também no mobile. O container do chart tinha apenas `flex-1` sem altura definida em mobile (`lg:max-h-[380px]` só aplicava em desktop), o que resolvia em 0px de altura e o Recharts loga 'width(-1) and height(-1) of chart should be greater than 0' no console. Agora o wrapper recebe `h-[260px]` em mobile e mantém o comportamento `flex-1` em `lg+`.",
+    ],
+  },
+  {
     version: "0.4.3",
     date: "2026-05-17",
     highlights: [


### PR DESCRIPTION
## Contexto

Após o merge do PR #26 (fix do scroll horizontal mobile), dois pontos remanesceram:

1. O **gráfico de pizza** do dashboard não renderiza no mobile — só a legenda aparece.
2. O Recharts loga no console: \`The width(-1) and height(-1) of chart should be greater than 0\`.

## Causa

O wrapper do chart em [dashboard/page.tsx](src/app/dashboard/page.tsx#L192) é \`min-h-0 flex-1\` dentro de um card que só tem \`lg:max-h-[380px]\`. No mobile (sem max-h definido), o flex-1 resolve em 0px de altura → o \`ResponsiveContainer\` do Recharts não consegue medir → erro.

## Mudanças

- **\`src/app/dashboard/page.tsx\`**: wrapper do chart vira \`h-[260px] lg:h-auto lg:min-h-0 lg:flex-1\` — altura fixa no mobile, comportamento flex original em desktop.
- **\`src/app/layout.tsx\`**: \`<html>\` e \`<body>\` ganham \`overflow-x-clip\` como defesa em profundidade. O \`<main>\` do dashboard já tinha \`overflow-x-hidden\`, mas modais/drawers/portals fora desse escopo (ex: vaul Drawer do menu mobile) podem renderizar fora dele. Com clip no html+body, garantimos que o document nunca rola lateralmente.
- **\`src/lib/changelog.ts\`**: entrada \`0.4.4\`.

## Test plan

- [x] \`npm run test:run\` → 395/395 ✓
- [x] \`npx tsc --noEmit\` → limpo
- [ ] No mobile (375px), abrir o dashboard logado como ADMIN e confirmar:
  - [ ] gráfico de pizza visível
  - [ ] sem erros do Recharts no console
  - [ ] cards sem scroll horizontal
- [ ] No desktop (≥1024px), confirmar que o gráfico continua se ajustando ao card (max-h-[380px])

🤖 Generated with [Claude Code](https://claude.com/claude-code)