### PR TITLE
fix(dashboard): varredura de min-w-0/flex-1 em todos os mini-cards

### DIFF
--- a/src/app/dashboard/_components/gifts-mini.tsx
+++ b/src/app/dashboard/_components/gifts-mini.tsx
@@ -36,13 +36,13 @@ export function GiftsMini({
         <Gift className="h-4 w-4 text-zinc-500" />
       </div>
       <div className="flex items-end justify-between gap-3">
-        <div>
+        <div className="min-w-0 flex-1">
           <p className="text-3xl font-bold text-zinc-100">{totalCount}</p>
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="mt-1 break-words text-xs text-zinc-500">
             {cashCount} em dinheiro · {totalCount - cashCount} em itens
           </p>
         </div>
-        <div className="text-right">
+        <div className="shrink-0 text-right">
           {cashTotal !== null ? (
             <p className="text-sm font-semibold text-emerald-300">{formatCurrency(cashTotal)}</p>
           ) : null}

--- a/src/app/dashboard/_components/risk-alert-strip.tsx
+++ b/src/app/dashboard/_components/risk-alert-strip.tsx
@@ -53,8 +53,8 @@ export function RiskAlertStrip({
               className={`flex items-start gap-2 rounded-xl border ${style.border} ${style.bg} p-3 transition-colors hover:bg-opacity-20`}
             >
               <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${style.text}`} />
-              <div className="min-w-0">
-                <p className={`text-sm font-semibold ${style.text}`}>{alert.title}</p>
+              <div className="min-w-0 flex-1">
+                <p className={`break-words text-sm font-semibold ${style.text}`}>{alert.title}</p>
                 <p className="mt-1 truncate text-xs text-zinc-400">{alert.body}</p>
               </div>
             </Link>

--- a/src/app/dashboard/_components/rsvp-mini.tsx
+++ b/src/app/dashboard/_components/rsvp-mini.tsx
@@ -30,14 +30,14 @@ export function RsvpMini({
         <h2 className="text-sm font-semibold text-zinc-200">Confirmações (RSVP)</h2>
         <UserCheck className="h-4 w-4 text-zinc-500" />
       </div>
-      <div className="flex items-end justify-between">
-        <div>
+      <div className="flex items-end justify-between gap-3">
+        <div className="min-w-0 flex-1">
           <p className="text-3xl font-bold text-zinc-100">{confirmedPct}%</p>
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="mt-1 break-words text-xs text-zinc-500">
             {rsvp.confirmed} de {total} responderam confirmando
           </p>
         </div>
-        <div className="grid grid-cols-1 gap-1 text-right text-xs">
+        <div className="grid shrink-0 grid-cols-1 gap-1 text-right text-xs">
           <span className="text-emerald-400">{rsvp.confirmed} confirmados</span>
           <span className="text-amber-400">{rsvp.maybe} talvez</span>
           <span className="text-rose-400">{rsvp.declined} recusas</span>

--- a/src/app/dashboard/_components/upcoming-tasks.tsx
+++ b/src/app/dashboard/_components/upcoming-tasks.tsx
@@ -30,9 +30,9 @@ export function UpcomingTasks({
             <Link
               key={t.id}
               href="/dashboard/tasks"
-              className="flex items-center justify-between rounded-xl border border-zinc-800/80 bg-zinc-800/50 p-3 transition-colors hover:bg-zinc-700/40"
+              className="flex items-center justify-between gap-3 rounded-xl border border-zinc-800/80 bg-zinc-800/50 p-3 transition-colors hover:bg-zinc-700/40"
             >
-              <div className="min-w-0">
+              <div className="min-w-0 flex-1">
                 <p className="truncate font-medium text-zinc-200">{t.title}</p>
                 {t.deadline ? (
                   <p className="mt-1 flex items-center gap-1 text-xs text-zinc-500">

--- a/src/app/dashboard/charts.tsx
+++ b/src/app/dashboard/charts.tsx
@@ -56,13 +56,13 @@ export default function DashboardCharts({ data }: { data: ChartDatum[] }) {
       </div>
       <ul className="custom-scrollbar mt-3 flex shrink-0 flex-wrap justify-center gap-x-3 gap-y-1.5 overflow-y-auto pr-1 text-xs text-zinc-400 max-h-[72px]">
         {data.map((entry, index) => (
-          <li key={entry.name} className="flex items-center gap-1.5">
+          <li key={entry.name} className="flex min-w-0 max-w-full items-center gap-1.5">
             <span
               aria-hidden
               className="inline-block h-2 w-2 shrink-0 rounded-sm"
               style={{ background: entry.color ?? FALLBACK_COLORS[index % FALLBACK_COLORS.length] }}
             />
-            <span className="break-words leading-tight">{entry.name}</span>
+            <span className="min-w-0 break-words leading-tight">{entry.name}</span>
           </li>
         ))}
       </ul>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -51,11 +51,11 @@ export default async function DashboardPage() {
     data.daysToEvent !== null && data.daysToEvent <= 20 && data.remainingBalance > 0;
 
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-        <div>
+        <div className="min-w-0">
           <h1 className="text-2xl font-bold tracking-tight">Visão Geral</h1>
-          <p className="text-sm text-zinc-500">{subtitle}</p>
+          <p className="break-words text-sm text-zinc-500">{subtitle}</p>
         </div>
         {data.daysToEvent !== null ? <CountdownPill days={data.daysToEvent} /> : null}
       </div>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,13 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.4.5",
+    date: "2026-05-17",
+    highlights: [
+      "📱 Varredura completa de responsividade no dashboard mobile. Componentes que tinham `min-w-0` mas faltavam `flex-1` (UpcomingTasks, RiskAlertStrip) e mini-cards (RsvpMini, GiftsMini) que não tinham nenhum dos dois ganharam ambos — agora o conteúdo encolhe corretamente em vez de empurrar o card além da viewport. Subtítulo do header e a legenda do gráfico de pizza também receberam `break-words` + `min-w-0 max-w-full` para nomes de categoria longos.",
+    ],
+  },
+  {
     version: "0.4.4",
     date: "2026-05-17",
     highlights: [


### PR DESCRIPTION
## Contexto

Após PR #27 o scroll horizontal foi bloqueado por `overflow-x-clip` no \`<html>\` e \`<body>\`. O usuário reportou que mesmo assim **o conteúdo dos cards ainda parece ser cortado** — o que indica que cards individualmente estão sendo renderizados mais largos que sua coluna do grid (o clip esconde a parte que ultrapassa, mas o conteúdo continua sendo medido com largura maior).

## Causa

Vários mini-cards e listas tinham só **parte** das constraints necessárias para encolher dentro de um pai flex:

| Componente | Tinha | Faltava |
|---|---|---|
| UpcomingTasks | min-w-0 | flex-1 |
| RsvpMini left col | — | min-w-0 + flex-1 |
| GiftsMini left col | — | min-w-0 + flex-1 |
| RiskAlertStrip body | min-w-0 | flex-1 |
| Legenda do pie chart | break-words | min-w-0 (no \`<li>\` e no \`<span>\`) |

Sem o \`flex-1\` o item não reivindica espaço; sem o \`min-w-0\` o item não pode encolher abaixo do conteúdo natural. Os dois juntos é o que permite truncate/break-words funcionar de fato e o card respeitar a largura do grid.

## Mudanças por arquivo

- **\`src/app/dashboard/_components/upcoming-tasks.tsx\`**: \`<div>\` do título recebe \`flex-1\`; \`<Link>\` ganha \`gap-3\` para o badge de prioridade não colar no texto.
- **\`src/app/dashboard/_components/rsvp-mini.tsx\`**: bloco esquerdo (% + descrição) recebe \`min-w-0 flex-1\`, bloco direito recebe \`shrink-0\`. Container flex ganha \`gap-3\`. Hint ganha \`break-words\`.
- **\`src/app/dashboard/_components/gifts-mini.tsx\`**: mesma estrutura do RsvpMini.
- **\`src/app/dashboard/_components/risk-alert-strip.tsx\`**: wrapper do texto recebe \`flex-1\`; título do alerta ganha \`break-words\` (\`alert.body\` já tinha truncate).
- **\`src/app/dashboard/charts.tsx\`** (legenda do pie chart): cada \`<li>\` recebe \`min-w-0 max-w-full\` e o \`<span>\` interno ganha \`min-w-0\`, para nomes de categoria customizados longos quebrarem em vez de esticar o card.
- **\`src/app/dashboard/page.tsx\`**: root \`<div>\` ganha \`min-w-0\`; subtítulo do header ganha \`break-words\` (concatena \`coupleNames + data\` e pode ficar comprido).
- **\`src/lib/changelog.ts\`**: entrada 0.4.5.

## Test plan

- [x] \`npm run test:run\` → 395/395 ✓
- [x] \`npm run build\` → OK
- [x] \`npx tsc --noEmit\` → limpo
- [ ] No mobile (375px ou 712px), confirmar que cards não extrapolam a viewport mesmo com:
  - [ ] Nome de tarefa longo ('Reunir documentação completa do casamento civil')
  - [ ] Nome de categoria longo ('Decoração e Ambientação Personalizada')
  - [ ] Subtítulo do header longo (casal + data)
- [ ] Desktop continua identico

🤖 Generated with [Claude Code](https://claude.com/claude-code)