### PR TITLE
fix(i18n): apontar namespace de nav para common.nav

### DIFF
--- a/src/app/dashboard/_components/mobile-nav.tsx
+++ b/src/app/dashboard/_components/mobile-nav.tsx
@@ -18,7 +18,7 @@ import {
 const SWIPE_OPEN_THRESHOLD_PX = 50;
 
 export function MobileTopBar() {
-  const t = useTranslations("nav");
+  const t = useTranslations("common.nav");
   return (
     <div className="sticky top-0 z-30 flex items-center gap-2 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur md:hidden">
       <div className="flex h-8 w-8 items-center justify-center rounded-full bg-rose-500/10 ring-1 ring-rose-500/20">
@@ -30,7 +30,7 @@ export function MobileTopBar() {
 }
 
 export function MobileNav() {
-  const t = useTranslations("nav");
+  const t = useTranslations("common.nav");
   const pathname = usePathname();
   const canFinance = useCanViewFinance();
   const [open, setOpen] = useState(false);

--- a/src/app/dashboard/_components/nav.tsx
+++ b/src/app/dashboard/_components/nav.tsx
@@ -8,7 +8,7 @@ import { logout } from "@/app/actions/authActions";
 import { isActive, useVisibleLinks } from "./nav-links";
 
 export function Sidebar() {
-  const t = useTranslations("nav");
+  const t = useTranslations("common.nav");
   const pathname = usePathname();
   const visibleLinks = useVisibleLinks();
   return (

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -18,7 +18,7 @@ export default async function ProfilePage() {
   });
   if (!user) redirect("/login");
 
-  const t = await getTranslations("nav");
+  const t = await getTranslations("common.nav");
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">

--- a/src/app/dashboard/profile/profile-client.tsx
+++ b/src/app/dashboard/profile/profile-client.tsx
@@ -16,7 +16,7 @@ type Initial = {
 
 export default function ProfileClient({ initial }: { initial: Initial }) {
   const t = useTranslations("common");
-  const tn = useTranslations("nav");
+  const tn = useTranslations("common.nav");
   const toast = useToast();
   const [locale, setLocaleState] = useState<Locale>(initial.locale);
   const [state, formAction, pending] = useActionState(updateLocale, undefined);


### PR DESCRIPTION
## Summary

- Hotfix do que ficou de fora do PR #30: a sidebar e a mobile-nav estavam renderizando as chaves cruas (`nav.dashboard`, `nav.insights`, …) em produção.
- `useTranslations("nav")` buscava um namespace inexistente. Como `src/messages/<locale>/common.json` é carregado em `src/i18n/request.ts` como o namespace `common`, o caminho correto é `common.nav`.

Afeta `Sidebar`, `MobileTopBar`, `MobileNav`, `ProfileClient` (toast de salvar) e `ProfilePage` (título).

## Test plan

- [x] `npm run lint` e `npm run test:run` passam (sem mudanças nas suites).
- [ ] Smoke manual no server de prod após deploy: sidebar exibe "Dashboard / Insights / Relatórios / …" em vez de "nav.dashboard / nav.insights / …".

🤖 Generated with [Claude Code](https://claude.com/claude-code)