### PR TITLE
chore(rename): wfv-management-system → wedding-management-system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@
 
 # URL de conexão com o banco SQLite.
 # Em dev: arquivo local. Em prod: caminho absoluto recomendado.
-#   Ex.: "file:/var/lib/wfv/dev.db"
+#   Ex.: "file:/var/lib/wedding/dev.db"
 DATABASE_URL="file:./dev.db"
 
 # Segredo usado para assinar os tokens JWT do NextAuth.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,11 +2,11 @@ blank_issues_enabled: false
 
 contact_links:
   - name: 💬 Discussão / dúvida de uso
-    url: https://github.com/guiloklex-hub/wfv-management-system/discussions
+    url: https://github.com/guiloklex-hub/wedding-management-system/discussions
     about: Para perguntas sobre como usar o sistema, ideias ainda não maduras ou desabafos, prefira Discussions.
   - name: 🔐 Vulnerabilidade de segurança (privado)
-    url: https://github.com/guiloklex-hub/wfv-management-system/security/advisories/new
+    url: https://github.com/guiloklex-hub/wedding-management-system/security/advisories/new
     about: NÃO abra issue pública. Use o canal privado de Security Advisory.
   - name: 📚 Documentação completa
-    url: https://github.com/guiloklex-hub/wfv-management-system/tree/main/docs
+    url: https://github.com/guiloklex-hub/wedding-management-system/tree/main/docs
     about: Antes de abrir issue, dê uma olhada na pasta docs/ — pode já estar coberto.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ confirmou a presença.
 ### 🐧 Linux, macOS ou WSL2
 
 ```bash
-git clone https://github.com/guiloklex-hub/wfv-management-system.git
-cd wfv-management-system
+git clone https://github.com/guiloklex-hub/wedding-management-system.git
+cd wedding-management-system
 ./setup.sh
 npm run dev
 ```
@@ -65,8 +65,8 @@ npm run dev
 ### 🪟 Windows (PowerShell)
 
 ```powershell
-git clone https://github.com/guiloklex_hub/wfv-management-system.git
-cd wfv-management-system
+git clone https://github.com/guiloklex_hub/wedding-management-system.git
+cd wedding-management-system
 .\setup.ps1
 npm run dev
 ```
@@ -205,8 +205,8 @@ comercialmente.
 
 ## 💬 Suporte
 
-- 🐛 **Bugs:** abra uma [issue](https://github.com/guiloklex-hub/wfv-management-system/issues/new?template=bug.md)
-- 💡 **Ideias:** abra uma [issue de feature](https://github.com/guiloklex-hub/wfv-management-system/issues/new?template=feature.md)
+- 🐛 **Bugs:** abra uma [issue](https://github.com/guiloklex-hub/wedding-management-system/issues/new?template=bug.md)
+- 💡 **Ideias:** abra uma [issue de feature](https://github.com/guiloklex-hub/wedding-management-system/issues/new?template=feature.md)
 - ❓ **Dúvidas de uso:** veja a **Central de Ajuda** dentro do app
   (`/dashboard/help`) ou [docs/troubleshooting.md](docs/troubleshooting.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Este documento explica como reportar vulnerabilidades de forma responsável.
 
 Use o canal privado do GitHub:
 
-➡️ <https://github.com/guiloklex-hub/wfv-management-system/security/advisories/new>
+➡️ <https://github.com/guiloklex-hub/wedding-management-system/security/advisories/new>
 
 Ao reportar, inclua:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -113,7 +113,7 @@ ou BRIDE). Outras roles recebem `403`.
 
 **Headers:**
 - `Content-Type: application/json; charset=utf-8`
-- `Content-Disposition: attachment; filename="wfv-backup-YYYY-MM-DD.json"`
+- `Content-Disposition: attachment; filename="wedding-backup-YYYY-MM-DD.json"`
 - `Cache-Control: no-store`
 
 Cada chamada grava `AuditLog` com action `BACKUP_EXPORT` e contagem por
@@ -263,5 +263,5 @@ exemplo), configure `next.config.ts` cuidadosamente.
 Não há `v1`/`v2` na URL. Mudanças de contrato são feitas conforme necessário
 — o frontend é o único cliente atualmente.
 
-Se isto mudar (clientes terceiros), adote `Accept: application/vnd.wfv.v1+json`
+Se isto mudar (clientes terceiros), adote `Accept: application/vnd.wedding.v1+json`
 ou prefixo `/api/v1/...`.

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -55,7 +55,7 @@ cp prisma/dev.db backups/dev-$(date +%F).db
 Em **produção**, recomendo um cron diário:
 
 ```cron
-0 3 * * * /usr/bin/cp /var/lib/wfv/prisma/dev.db /var/backups/wfv-$(date +\%F).db && find /var/backups -name "wfv-*.db" -mtime +30 -delete
+0 3 * * * /usr/bin/cp /var/lib/wedding/prisma/dev.db /var/backups/wedding-$(date +\%F).db && find /var/backups -name "wedding-*.db" -mtime +30 -delete
 ```
 
 Isso mantém 30 dias de retenção.
@@ -75,12 +75,12 @@ Por enquanto, o JSON serve principalmente como **referência humana** e
 
 ```bash
 # parar o servidor antes!
-cp /var/backups/wfv-2025-10-12.db prisma/dev.db
+cp /var/backups/wedding-2025-10-12.db prisma/dev.db
 # reaplicar o schema (caso tenha mudado depois do backup):
 npx prisma db push --skip-generate
 npx prisma generate
 # reiniciar o servidor
-pm2 reload wfv-management-system
+pm2 reload wedding-management-system
 ```
 
 ## Onde fica o banco?
@@ -89,10 +89,10 @@ pm2 reload wfv-management-system
 |---|---|
 | Dev (Linux/macOS/WSL) | `./prisma/dev.db` |
 | Dev (Windows nativo) | `.\prisma\dev.db` |
-| Prod | recomenda-se setar `DATABASE_URL="file:/var/lib/wfv/dev.db"` |
+| Prod | recomenda-se setar `DATABASE_URL="file:/var/lib/wedding/dev.db"` |
 
 Em produção, configure `DATABASE_URL` para um diretório persistente fora do
-deploy (não dentro de `/var/www/wfv/...` se você costuma fazer
+deploy (não dentro de `/var/www/wedding/...` se você costuma fazer
 `git pull && npm run build`).
 
 ## Backup do `.whatsapp-auth/`
@@ -109,7 +109,7 @@ Restaurar:
 
 ```bash
 tar xzf backups/whatsapp-auth-2025-10-12.tar.gz
-pm2 restart wfv-management-system
+pm2 restart wedding-management-system
 ```
 
 > ⚠️ Trate esse diretório como **secret** — quem tem o arquivo pode se passar
@@ -138,7 +138,7 @@ tar czf migration.tar.gz prisma/dev.db .env .whatsapp-auth/
 
 # máquina nova
 git clone ...
-cd wfv-management-system
+cd wedding-management-system
 tar xzf ../migration.tar.gz
 ./setup.sh --skip-seed
 npm run dev   # ou: ./setup.sh --prod --skip-seed

--- a/docs/contribuindo.md
+++ b/docs/contribuindo.md
@@ -26,8 +26,8 @@ tradução, testes, sugestões.
 ## Setup local
 
 ```bash
-git clone https://github.com/guiloklex-hub/wfv-management-system.git
-cd wfv-management-system
+git clone https://github.com/guiloklex-hub/wedding-management-system.git
+cd wedding-management-system
 ./setup.sh        # ou .\setup.ps1 no Windows
 npm run dev
 ```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -31,9 +31,9 @@ npm install -g pm2
 
 ```bash
 cd /var/www
-sudo git clone https://github.com/guiloklex-hub/wfv-management-system.git wfv
-sudo chown -R $USER:$USER wfv
-cd wfv
+sudo git clone https://github.com/guiloklex-hub/wedding-management-system.git wedding
+sudo chown -R $USER:$USER wedding
+cd wedding
 ```
 
 ## 3. Configurar `.env` para produção
@@ -46,7 +46,7 @@ nano .env
 Edite:
 
 ```env
-DATABASE_URL="file:/var/lib/wfv/dev.db"   # fora do diretório do código
+DATABASE_URL="file:/var/lib/wedding/dev.db"   # fora do diretório do código
 NEXTAUTH_URL="https://casamento.seudominio.com"
 APP_URL="https://casamento.seudominio.com"
 AUTH_TRUST_HOST="true"
@@ -58,8 +58,8 @@ CRON_SECRET="<gerado pelo setup>"
 Garanta o diretório persistente:
 
 ```bash
-sudo mkdir -p /var/lib/wfv
-sudo chown $USER:$USER /var/lib/wfv
+sudo mkdir -p /var/lib/wedding
+sudo chown $USER:$USER /var/lib/wedding
 ```
 
 ## 4. Build + PM2
@@ -72,7 +72,7 @@ Esse comando:
 1. roda `npm install` (caso não tenha rodado);
 2. aplica o schema (`prisma db push`);
 3. faz `npm run build`;
-4. inicia/reinicia via PM2 com nome `wfv-management-system`.
+4. inicia/reinicia via PM2 com nome `wedding-management-system`.
 
 Para fazer o PM2 subir junto com o boot do sistema:
 
@@ -148,19 +148,19 @@ crontab -e
 ```
 
 ```cron
-*/30 * * * * curl -fsS -H "Authorization: Bearer SEU_CRON_SECRET" http://localhost:3005/api/cron/reminders >> /var/log/wfv-cron.log 2>&1
+*/30 * * * * curl -fsS -H "Authorization: Bearer SEU_CRON_SECRET" http://localhost:3005/api/cron/reminders >> /var/log/wedding-cron.log 2>&1
 ```
 
 ## 7. Cron de backup
 
 ```bash
-sudo mkdir -p /var/backups/wfv
-sudo chown $USER:$USER /var/backups/wfv
+sudo mkdir -p /var/backups/wedding
+sudo chown $USER:$USER /var/backups/wedding
 crontab -e
 ```
 
 ```cron
-0 3 * * * /usr/bin/cp /var/lib/wfv/dev.db /var/backups/wfv/wfv-$(date +\%F).db && find /var/backups/wfv -name "wfv-*.db" -mtime +30 -delete
+0 3 * * * /usr/bin/cp /var/lib/wedding/dev.db /var/backups/wedding/wedding-$(date +\%F).db && find /var/backups/wedding -name "wedding-*.db" -mtime +30 -delete
 ```
 
 ## 8. Conectar WhatsApp
@@ -175,10 +175,10 @@ do projeto.
 ## 9. Atualização (deploy de nova versão)
 
 ```bash
-cd /var/www/wfv
+cd /var/www/wedding
 git pull
 ./setup.sh --prod --skip-seed
-pm2 reload wfv-management-system
+pm2 reload wedding-management-system
 ```
 
 PM2 reinicia o processo Node com graceful reload — zero downtime na maioria
@@ -188,7 +188,7 @@ dos casos.
 
 ```bash
 pm2 status                          # estado geral
-pm2 logs wfv-management-system      # logs em tempo real
+pm2 logs wedding-management-system      # logs em tempo real
 pm2 monit                           # dashboard interativo no terminal
 ```
 

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -3,7 +3,7 @@
 Lista completa de configurações para fazer **uma vez** no repositório
 público no GitHub. Cada item linka para a tela exata.
 
-Substitua `guiloklex-hub/wfv-management-system` pelo caminho real do repo.
+Substitua `guiloklex-hub/wedding-management-system` pelo caminho real do repo.
 
 ---
 
@@ -247,8 +247,8 @@ Após ativar Discussions (passo 2), crie estas categorias:
 No README, atualize para apontar para o seu user real:
 
 ```markdown
-[![CI](https://github.com/guiloklex-hub/wfv-management-system/actions/workflows/ci.yml/badge.svg)](https://github.com/guiloklex-hub/wfv-management-system/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/guiloklex-hub/wfv-management-system/actions/workflows/codeql.yml/badge.svg)](https://github.com/guiloklex-hub/wfv-management-system/actions/workflows/codeql.yml)
+[![CI](https://github.com/guiloklex-hub/wedding-management-system/actions/workflows/ci.yml/badge.svg)](https://github.com/guiloklex-hub/wedding-management-system/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/guiloklex-hub/wedding-management-system/actions/workflows/codeql.yml/badge.svg)](https://github.com/guiloklex-hub/wedding-management-system/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ```
 

--- a/docs/instalacao-linux.md
+++ b/docs/instalacao-linux.md
@@ -41,8 +41,8 @@ node -v   # esperado: v20.x.x
 ## 2. Clone o projeto
 
 ```bash
-git clone https://github.com/guiloklex-hub/wfv-management-system.git
-cd wfv-management-system
+git clone https://github.com/guiloklex-hub/wedding-management-system.git
+cd wedding-management-system
 ```
 
 > ⚠️ Substitua `guiloklex-hub` pela conta dona do repositório no GitHub.
@@ -118,7 +118,7 @@ Para que lembretes automáticos sejam enviados, adicione ao seu crontab
 
 ```cron
 */30 * * * * curl -fsS -H "Authorization: Bearer SEU_CRON_SECRET" \
-  http://localhost:3005/api/cron/reminders >> /var/log/wfv-cron.log 2>&1
+  http://localhost:3005/api/cron/reminders >> /var/log/wedding-cron.log 2>&1
 ```
 
 Substitua `SEU_CRON_SECRET` pelo valor de `CRON_SECRET` no `.env`.

--- a/docs/instalacao-windows.md
+++ b/docs/instalacao-windows.md
@@ -53,8 +53,8 @@ projeto (ex.: `C:\Projetos`):
 
 ```powershell
 cd C:\Projetos
-git clone https://github.com/guiloklex-hub/wfv-management-system.git
-cd wfv-management-system
+git clone https://github.com/guiloklex-hub/wedding-management-system.git
+cd wedding-management-system
 ```
 
 ---
@@ -162,7 +162,7 @@ pm2 save
 3. Configure:
    - **Path:** `C:\Program Files\nodejs\npm.cmd`
    - **Arguments:** `start`
-   - **Startup directory:** `C:\Projetos\wfv-management-system`
+   - **Startup directory:** `C:\Projetos\wedding-management-system`
 4. Inicie: `nssm start WeddingFinance`.
 
 ---

--- a/docs/instalacao-wsl.md
+++ b/docs/instalacao-wsl.md
@@ -69,8 +69,8 @@ git --version
 ```bash
 mkdir -p ~/projetos
 cd ~/projetos
-git clone https://github.com/guiloklex-hub/wfv-management-system.git
-cd wfv-management-system
+git clone https://github.com/guiloklex-hub/wedding-management-system.git
+cd wedding-management-system
 ```
 
 ---

--- a/docs/notificacoes.md
+++ b/docs/notificacoes.md
@@ -172,7 +172,7 @@ idempotência não vaza entre dias mesmo se o servidor estiver em UTC.
 
 ```cron
 */30 * * * * curl -fsS -H "Authorization: Bearer SEU_CRON_SECRET" \
-  http://localhost:3005/api/cron/reminders >> /var/log/wfv-cron.log 2>&1
+  http://localhost:3005/api/cron/reminders >> /var/log/wedding-cron.log 2>&1
 ```
 
 ### Windows — Agendador de Tarefas

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -219,7 +219,7 @@ Eventualmente Baileys reconecta sozinho. Se persistir:
 
 ```bash
 rm -rf .whatsapp-auth/
-pm2 restart wfv-management-system
+pm2 restart wedding-management-system
 # acessar Ajustes › WhatsApp e escanear de novo
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wfv-management-system",
+  "name": "wedding-management-system",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wfv-management-system",
+      "name": "wedding-management-system",
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wfv-management-system",
+  "name": "wedding-management-system",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service worker básico — instala sem cache pré-carregado.
 // Lança um network-first com fallback offline simples para a navegação.
 
-const CACHE_NAME = "wfv-cache-v1";
+const CACHE_NAME = "wedding-cache-v1";
 const OFFLINE_URL = "/offline.html";
 
 self.addEventListener("install", (event) => {

--- a/setup.ps1
+++ b/setup.ps1
@@ -33,7 +33,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$AppName = "wfv-management-system"
+$AppName = "wedding-management-system"
 $RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location $RootDir
 

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-APP_NAME="wfv-management-system"
+APP_NAME="wedding-management-system"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$ROOT_DIR"
 

--- a/src/app/api/backup/route.test.ts
+++ b/src/app/api/backup/route.test.ts
@@ -53,7 +53,7 @@ describe("GET /api/backup", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
     expect(res.headers.get("Content-Disposition")).toMatch(
-      /attachment; filename="wfv-backup-\d{4}-\d{2}-\d{2}\.json"/,
+      /attachment; filename="wedding-backup-\d{4}-\d{2}-\d{2}\.json"/,
     );
     expect(res.headers.get("Cache-Control")).toBe("no-store");
   });

--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -120,7 +120,7 @@ export async function GET() {
     (session.user as { id?: string }).id,
   );
 
-  const filename = `wfv-backup-${new Date().toISOString().slice(0, 10)}.json`;
+  const filename = `wedding-backup-${new Date().toISOString().slice(0, 10)}.json`;
 
   return new NextResponse(JSON.stringify(payload, null, 2), {
     status: 200,

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -8,7 +8,7 @@ const realCwd = process.cwd();
 let tmpRoot: string;
 
 beforeAll(async () => {
-  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "wfv-uploads-"));
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "wedding-uploads-"));
   process.chdir(tmpRoot);
   await fs.mkdir(path.join(tmpRoot, "uploads"), { recursive: true });
 });


### PR DESCRIPTION
## Summary

- Renomeia o projeto de **wfv-management-system** para **wedding-management-system** em todos os arquivos: `package.json`, `setup.sh`, `setup.ps1`, README, docs, `.env.example`, testes, service worker e config de issue templates.
- Atualiza os caminhos sugeridos em produção nos docs: `/var/lib/wfv` → `/var/lib/wedding`, `/var/www/wfv` → `/var/www/wedding`, `/var/backups/wfv` → `/var/backups/wedding`, `/var/log/wfv-cron.log` → `/var/log/wedding-cron.log`.
- Renomeia o processo PM2 referenciado nos docs: `pm2 reload wfv-management-system` → `pm2 reload wedding-management-system`.

## Impacto em produção

⚠️ Não é uma mudança puramente cosmética. Em servidores existentes que seguem a recomendação dos docs, será necessário rodar um roteiro de migração para:

1. Mover o diretório do banco (`/var/lib/wfv` → `/var/lib/wedding`) e backups.
2. Atualizar `DATABASE_URL` no `.env`.
3. Recriar o processo PM2 com o novo nome (`pm2 delete wfv-management-system` + `setup.sh --prod`).
4. Atualizar entradas no `crontab` (lembretes + backup).

## Test plan

- [ ] `npm run lint` passa
- [ ] `npm run test:run` passa
- [ ] `npm run build` passa
- [ ] Verificar manualmente que `setup.sh` e `setup.ps1` criam o processo PM2 com o nome novo
- [ ] Verificar que `.env.example` referencia o caminho `/var/lib/wedding/dev.db`
- [ ] Procurar resquícios de "wfv" no repo: `grep -ri "wfv" --exclude-dir=node_modules --exclude-dir=.git`

🤖 Generated with [Claude Code](https://claude.com/claude-code)