### PR TITLE
fix(whatsapp): pinar versão atual do WA Web para destravar QR Code

### DIFF
--- a/src/lib/notifications/whatsapp.ts
+++ b/src/lib/notifications/whatsapp.ts
@@ -28,8 +28,11 @@ type WaGlobals = {
   _waState?: WhatsAppStatus;
   _waStarting?: Promise<void> | null;
   _waWatchdog?: ReturnType<typeof setInterval> | null;
+  _waVersion?: { value: [number, number, number]; fetchedAt: number } | null;
 };
 const g = globalThis as unknown as WaGlobals;
+
+const WA_VERSION_TTL_MS = 6 * 60 * 60_000;
 
 function getStateRef(): WhatsAppStatus {
   if (!g._waState) {
@@ -67,6 +70,44 @@ async function importBaileys() {
   return mod;
 }
 
+async function resolveWaVersion(
+  baileys: Awaited<ReturnType<typeof importBaileys>>,
+): Promise<[number, number, number] | undefined> {
+  const cached = g._waVersion;
+  if (cached && Date.now() - cached.fetchedAt < WA_VERSION_TTL_MS) {
+    return cached.value;
+  }
+
+  const fetcher = (
+    baileys as {
+      fetchLatestWaWebVersion?: (
+        options?: RequestInit,
+      ) => Promise<{ version: [number, number, number]; isLatest?: boolean; error?: unknown }>;
+      fetchLatestBaileysVersion?: (
+        options?: RequestInit,
+      ) => Promise<{ version: [number, number, number]; isLatest?: boolean; error?: unknown }>;
+    }
+  ).fetchLatestWaWebVersion ??
+    (baileys as {
+      fetchLatestBaileysVersion?: (
+        options?: RequestInit,
+      ) => Promise<{ version: [number, number, number]; isLatest?: boolean; error?: unknown }>;
+    }).fetchLatestBaileysVersion;
+
+  if (typeof fetcher !== "function") return undefined;
+
+  try {
+    const result = await fetcher();
+    if (result?.version) {
+      g._waVersion = { value: result.version, fetchedAt: Date.now() };
+      return result.version;
+    }
+  } catch (err) {
+    console.error("[whatsapp] falha ao obter versão WA Web:", err);
+  }
+  return cached?.value;
+}
+
 async function startSocket(): Promise<void> {
   const ref = getStateRef();
   if (ref.state === "CONNECTED" || ref.state === "CONNECTING" || ref.state === "WAITING_QR") {
@@ -98,12 +139,15 @@ async function startSocket(): Promise<void> {
 
     const { state, saveCreds } = await loadAuthState(AUTH_DIR);
 
+    const version = await resolveWaVersion(baileys);
+
     const sock = (makeWASocket as (opts: unknown) => unknown)({
       auth: state,
       printQRInTerminal: false,
       browser: Browsers.ubuntu("Wedding Finance"),
       syncFullHistory: false,
       markOnlineOnConnect: false,
+      ...(version ? { version } : {}),
     });
     g._waSock = sock;
 
@@ -178,6 +222,7 @@ async function startSocket(): Promise<void> {
         g._waStarting = null;
 
         if (loggedOut) {
+          rm(AUTH_DIR, { recursive: true, force: true }).catch(() => {});
           if (shouldSendDownAlert(ref)) {
             ref.downAlertSentAt = new Date();
             void maybeSendDownAlert({


### PR DESCRIPTION
## Sintoma

Tela de Ajustes → WhatsApp ficava presa em *Desconectado / Connection Failure* mesmo após clicar **Conectar** com `.whatsapp-auth/` vazio. O QR Code nunca era exibido.

## Causa

Baileys 7.0.0-rc11 envia uma versão fixa do WhatsApp Web no handshake (`[2, 3000, 1035194821]`). Como o WhatsApp atualiza essa versão server-side, o servidor passou a rejeitar o handshake antes do estágio de challenge — o evento `qr` nunca chega a ser emitido.

Log do PM2 confirma: `connected to WA → logging in… → connection errored: Connection Failure` em `noise-handler.ts`.

## Mudança

- `resolveWaVersion()` chama `fetchLatestWaWebVersion()` (com fallback para `fetchLatestBaileysVersion`) e cacheia o resultado por 6 h em `globalThis`. A versão resolvida é passada em `makeWASocket`, mantendo a conexão alinhada com a versão atual do WA Web.
- Quando o disconnect é `loggedOut`, o `.whatsapp-auth/` é apagado automaticamente. Garante que o próximo **Conectar** parta de credenciais limpas, sem precisar clicar em *Desconectar* primeiro.

## Test plan

- [ ] Deploy no servidor remoto (`pm2 restart wedding-management-system`).
- [ ] Apagar `.whatsapp-auth/` na máquina remota.
- [ ] Acessar Ajustes → WhatsApp → **Conectar** e confirmar que o QR Code aparece em poucos segundos.
- [ ] Escanear o QR e validar que o estado vai para **Conectado** com o número correto.
- [ ] Enviar mensagem de teste para validar `sendWhatsApp`.
- [ ] Desvincular o app no celular e confirmar que o próximo **Conectar** já gera QR novo (sem precisar de *Desconectar*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)