### PR TITLE
feat(guests-import): importação por arquivo XLSX (Wedy) + tags M:N + PIN do grupo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ backups/
 
 # Arquivos temporarios
 temp.md
+temp/
+temp/*

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Se você é um casal querendo apenas usar o sistema, comece pelo
 | Pix nos presentes (cota lua de mel) | [pix.md](pix.md) |
 | Relatórios de BI (hub /dashboard/reports + Insights) | [relatorios.md](relatorios.md) |
 | Anexos e contratos (upload seguro, versionamento) | [anexos.md](anexos.md) |
+| Importação de convidados (XLSX, Wedy) | [importacao-convidados.md](importacao-convidados.md) |
 
 ## Para quem vai contribuir
 

--- a/docs/banco-de-dados.md
+++ b/docs/banco-de-dados.md
@@ -75,8 +75,10 @@ Arquivo: [prisma/schema.prisma](../prisma/schema.prisma).
 | `Honeymoon` | Singleton: lua de mel. |
 | `HoneymoonItem` | Itens da lua de mel (atividade, vôo, hospedagem). |
 | `TrousseauItem` | Enxoval (cômodo, prioridade, status compra). |
-| `Guest` | Convidados (RSVP, +1s, dietary, padrinho, checkin, `language` opcional para RSVP localizado, `rsvpTokenExpiresAt` opcional). |
-| `GuestGroup` | Convite de família com `rsvpToken` único e `rsvpTokenExpiresAt` opcional. |
+| `Guest` | Convidados (RSVP, +1s, dietary, padrinho, checkin, `language` opcional para RSVP localizado, `rsvpTokenExpiresAt` opcional, `age` opcional para crianças). Relação M:N com `GuestTag` via `GuestTagOnGuest`. |
+| `GuestGroup` | Convite de família com `rsvpToken` único e `rsvpTokenExpiresAt` opcional. `rsvpPin` opcional (informativo, vindo de imports externos). |
+| `GuestTag` | Tags de convidados (Padrinhos, Florista, etc.), com `name @unique` e `color` opcional. |
+| `GuestTagOnGuest` | Junction table M:N entre `Guest` e `GuestTag` (`@@id([guestId, tagId])`, cascade no delete). |
 | `SeatingTable` | Mesa do evento (capacidade, forma, posição x/y). |
 | `Gift` | Presentes (cash/item, status recebimento). |
 | `Task` | Tarefas (status, prioridade, responsável, deadline). |

--- a/docs/importacao-convidados.md
+++ b/docs/importacao-convidados.md
@@ -1,0 +1,114 @@
+# Importação de Convidados
+
+O sistema oferece **dois caminhos** para importar listas de convidados:
+
+1. **Texto colado** (legado, ainda disponível) — botão "Prefere colar texto?" dentro de `/dashboard/guests/import` ou via a Server Action `bulkImportGuests`.
+2. **Arquivo XLSX** vindo de outros sistemas de planejamento — fluxo em duas etapas (upload + preview com diff + commit).
+
+## 1. Fluxo de arquivo (`/dashboard/guests/import`)
+
+### Sistemas suportados
+
+| Origem | ID interno | Detecção |
+|--------|-----------|----------|
+| Wedy   | `wedy`    | Lê o header da primeira planilha; precisa ter ≥6 das 9 colunas conhecidas. |
+
+A detecção é automática quando o select de origem está em "Detectar automaticamente". O usuário pode forçar uma origem específica caso a planilha tenha sido editada e o header esteja parcialmente alterado.
+
+### Limites
+
+- Arquivo: até **5 MB** ([`GUEST_IMPORT_MAX_BYTES`](../src/lib/file-validation.ts)).
+- Linhas: até **2000** por importação ([`MAX_IMPORT_ROWS`](../src/app/actions/guestActions.ts)).
+- Rate limit: 5 uploads/minuto por usuário, 15/minuto por IP.
+- Sessão de preview: 10 minutos ([`GUEST_IMPORT_CACHE_TTL_MS`](../src/lib/guest-import-cache.ts)).
+
+### Etapas
+
+1. **Upload + parse**: o arquivo é validado por magic bytes (ZIP `PK\x03\x04`), parseado em memória pelo importer apropriado, e cada linha é classificada contra o banco em:
+   - `new` — não existe convidado com esse nome.
+   - `duplicate_same` — existe convidado com mesmo nome, mesmo grupo, e telefone/email batem.
+   - `duplicate_diff` — existe convidado com mesmo nome mas dados divergem.
+2. **Preview**: tela mostra contadores, tags detectadas (com aviso sobre criação automática), grupos detectados (com PIN se houver) e uma amostra de até 30 linhas filtrável por classificação.
+3. **Modo + commit**: usuário escolhe entre `CREATE_NEW_ONLY` (padrão), `UPSERT_BY_NAME` ou `CREATE_ALL_DUPLICATES`, confirma, e tudo é gravado em uma única `prisma.$transaction` com timeout de 30s.
+
+Cada commit gera um registro em `AuditLog` (`entity=Guest`, `entityId=bulk-import-file`, `action=BULK_CREATE`) com `source`, `mode` e contadores.
+
+## 2. Mapeamento Wedy → schema
+
+| Coluna Wedy | Campo no sistema | Observações |
+|-------------|------------------|-------------|
+| Nome do convite | `GuestGroup.name` + `Guest.groupName` | Cria `GuestGroup` se não existir (lookup por nome exato). |
+| Nome completo do convidado | `Guest.name` | Truncado a 160 chars. Linha sem nome é descartada. |
+| Status | `Guest.rsvpStatus` | Mapeamento: `Sem resposta`/`Convidado`→`INVITED`, `Confirmado`/`Vai`→`CONFIRMED`, `Recusado`/`Não vai`→`DECLINED`, `Talvez`→`MAYBE`, `Não convidado`→`NOT_INVITED`. Desconhecidos viram `INVITED` com badge `*` no preview. |
+| Telefone | `Guest.phone` | Truncado a 40 chars. Comparação para diff usa só dígitos. |
+| E-mail | `Guest.email` | Truncado a 160 chars. Comparação case-insensitive. |
+| Tags | `GuestTag` + `GuestTagOnGuest` | Split por vírgula, trim, máximo 20 tags por linha. Cada tag única vira `GuestTag` (case-insensitive no lookup). Tag bate regex `/^(padrinho\|padrinhos\|madrinha\|madrinhas\|padrinho\/madrinha)$/i` → marca `Guest.isPadrinho=true` (OR, nunca apaga). |
+| Faixa etária | `Guest.isChild` | `Criança`→true; demais valores→false. |
+| Idade exata | `Guest.age` | Apenas inteiros 0-17. `Idade desconhecida` e outras strings → null. |
+| Pin do convite | `GuestGroup.rsvpPin` | Aceita 4-8 chars alfanuméricos. **Informativo apenas** — o link público continua usando `rsvpToken` cuid. Em grupos que já existem, sobrescreve só quando o pin atual é null. |
+| (não importado) | `Guest.side` | Sempre `null`. O Wedy usa Tags com nomes dos noivos para indicar lado, mas isso não é universal — preencher manualmente depois. |
+
+## 3. Modos de commit
+
+| Modo | Comportamento para `duplicate_same` | Quando usar |
+|------|--------------------------------------|-------------|
+| `CREATE_NEW_ONLY` (padrão) | Pula a linha (incrementa `skipped`). | Re-importação segura. |
+| `UPSERT_BY_NAME` | Atualiza telefone, email, status, isChild, age, groupId, groupName, tags (substitui o conjunto) e seta `isPadrinho=true` se a tag de padrinho aparecer (OR). | Quando você atualizou dados no sistema externo e quer sincronizar. |
+| `CREATE_ALL_DUPLICATES` | Cria assim mesmo (incrementa `created`). | Quando há homônimos em famílias diferentes que **não** devem ser fundidos. |
+
+Linhas sem match (`new`) e linhas `duplicate_diff` sempre seguem para `create`, independentemente do modo.
+
+## 4. Schema Prisma — modelos relacionados
+
+```prisma
+model GuestTag {
+  id        String   @id @default(cuid())
+  name      String   @unique
+  color     String?
+  // ...
+  guests    GuestTagOnGuest[]
+}
+
+model GuestTagOnGuest {
+  guestId   String
+  tagId     String
+  guest     Guest    @relation(fields: [guestId], references: [id], onDelete: Cascade)
+  tag       GuestTag @relation(fields: [tagId], references: [id], onDelete: Cascade)
+  @@id([guestId, tagId])
+}
+
+model Guest {
+  // ... campos existentes
+  age   Int?
+  tags  GuestTagOnGuest[]
+}
+
+model GuestGroup {
+  // ... campos existentes
+  rsvpPin  String?
+}
+```
+
+## 5. FAQ
+
+**O lado (NOIVO/NOIVA) é importado?** Não. O Wedy usa tags com os nomes dos noivos, o que não é universal. `Guest.side` fica `null` e pode ser editado depois.
+
+**Status desconhecido vai pro lixo?** Não. Cai em `INVITED` com `rsvpStatusRaw` preservado no preview (badge `*` na coluna RSVP da amostra), e o status original aparece na payload do `AuditLog` via `rawSource`.
+
+**A comparação de nome é case-sensitive?** Sim. "joão" e "João" são tratados como pessoas diferentes. Isso é conservador — evita fundir contas sem certeza.
+
+**Posso reimportar o mesmo arquivo várias vezes?** Sim. O modo `CREATE_NEW_ONLY` é seguro: linhas duplicadas (mesmo nome + mesmo grupo) são puladas. Para atualizar dados existentes, use `UPSERT_BY_NAME`.
+
+**O PIN do Wedy funciona como login?** Não nesta versão. O PIN é armazenado em `GuestGroup.rsvpPin` apenas como referência cruzada. O link público continua sendo o `rsvpToken` cuid (`/rsvp/group/[token]`).
+
+**Como adicionar suporte a outro sistema?** Implementar um novo arquivo em `src/lib/guest-importers/<sistema>.ts` exportando um `Importer` (interface em [`types.ts`](../src/lib/guest-importers/types.ts)), adicionar a entrada em [`index.ts`](../src/lib/guest-importers/index.ts) e cobrir com testes em `<sistema>.test.ts`. A `Server Action` e a UI não precisam de mudança — o registry é descoberto automaticamente.
+
+## 6. Sincronização com `bulkImportGuests` (legado)
+
+A action de texto colado **não** foi removida. Continua disponível:
+
+- Pela página `/dashboard/guests/import` → botão "Prefere colar texto bruto?".
+- Mantém o layout fixo `Nome,Telefone,Email,Lado,Grupo`.
+- Continua criando `GuestGroup` automaticamente, mas **não** importa tags nem PIN.
+
+Considere depreciá-la em versão futura, quando a importação por arquivo cobrir todos os casos.

--- a/docs/rsvp.md
+++ b/docs/rsvp.md
@@ -77,6 +77,33 @@ UI em `/dashboard/guests/groups`:
 - Copiar link RSVP para enviar ao responsável.
 - Ver contagem (sim / pendente / não) por grupo.
 
+### Importação em massa (CSV)
+
+A action `bulkImportGuests` aceita a coluna `Grupo` na 5ª posição
+(`Nome,Telefone,Email,Lado,Grupo`). Quando preenchida:
+
+- Busca `GuestGroup` existente pelo `name` exato (case-sensitive, `deletedAt: null`).
+- Se não existir, cria o `GuestGroup` (apenas com `name` — contato fica em branco para o usuário completar depois).
+- Associa o convidado ao grupo via `Guest.groupId` (e mantém `Guest.groupName` como string redundante).
+- Linhas com o mesmo nome de grupo compartilham o mesmo `groupId`.
+
+Tudo roda dentro de `prisma.$transaction` para não deixar estado parcial. O retorno
+inclui `groupsCreated` além de `created` e `skipped`.
+
+### Importação por arquivo XLSX (Wedy)
+
+Além do texto colado, há a página `/dashboard/guests/import` que aceita arquivos
+.xlsx exportados de outros sistemas (hoje: Wedy). Ela usa as Server Actions
+`previewGuestImport` + `commitGuestImport`, traz tags (M:N via `GuestTag`), PIN
+do convite no `GuestGroup.rsvpPin` e fluxo em 2 passos (preview com diff +
+escolha de modo). Detalhes em [importacao-convidados.md](importacao-convidados.md).
+
+## Campo `GuestGroup.rsvpPin`
+
+Persistido **apenas como referência cruzada** ao convite original do Wedy ou
+sistemas similares. Aceita 4-8 chars alfanuméricos. O link público continua
+usando `rsvpToken` cuid — não há rota de login por PIN nesta versão.
+
 ## Quando usar cada um
 
 - **Indivíduo importante (padrinho, parente próximo, parceiro de trabalho):** use o link individual.
@@ -85,4 +112,7 @@ UI em `/dashboard/guests/groups`:
 
 ## Campo legado `Guest.groupName`
 
-Continua existindo como string livre. Não é usado para o link de grupo. Considere migrar entrada por entrada e remover em versão futura.
+Continua existindo como string livre, agora preenchido automaticamente em paralelo
+ao `groupId` quando a importação CSV cria/associa um grupo. O link de RSVP coletivo
+usa exclusivamente o `groupId`. Considere migrar entradas antigas (com `groupName`
+mas sem `groupId`) executando uma rotina manual e remover o campo em versão futura.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@whiskeysockets/baileys": "^7.0.0-rc11",
         "bcryptjs": "^3.0.3",
         "clsx": "^2.1.1",
+        "exceljs": "^4.4.0",
         "link-preview-js": "^3.2.0",
         "lucide-react": "^1.14.0",
         "next": "16.2.6",
@@ -1128,6 +1129,47 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -5629,6 +5671,81 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5854,6 +5971,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -5922,7 +6045,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -5946,6 +6088,45 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5956,7 +6137,6 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6008,6 +6188,56 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
       }
     },
     "node_modules/c12": {
@@ -6160,6 +6390,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6286,11 +6528,25 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -6325,6 +6581,37 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6580,6 +6867,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6827,6 +7120,51 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/effect": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
@@ -6860,6 +7198,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -7570,6 +7917,26 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -7608,6 +7975,19 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -7804,6 +8184,18 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7817,6 +8209,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/function-bind": {
@@ -7986,6 +8394,27 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -8046,7 +8475,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/happy-dom": {
@@ -8279,6 +8707,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -8325,6 +8759,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -8961,6 +9412,54 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8989,6 +9488,54 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/levn": {
@@ -9054,6 +9601,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -9330,6 +9886,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -9346,11 +9908,90 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -9498,7 +10139,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -9511,10 +10151,21 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ms": {
@@ -9886,6 +10537,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -10082,6 +10742,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10201,6 +10870,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10258,6 +10933,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -10505,6 +11189,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -10792,6 +11482,50 @@
         }
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -10994,6 +11728,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
@@ -11072,6 +11819,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -11112,6 +11879,18 @@
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
       "engines": {
         "node": ">=10"
       }
@@ -11186,6 +11965,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -11409,6 +12194,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -11688,6 +12482,22 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -11778,6 +12588,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -11807,6 +12626,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ts-api-utils": {
@@ -12089,6 +12917,60 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -12217,6 +13099,22 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vaul": {
@@ -12645,6 +13543,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
@@ -12665,6 +13569,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "4.0.3",
@@ -12777,6 +13687,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@whiskeysockets/baileys": "^7.0.0-rc11",
     "bcryptjs": "^3.0.3",
     "clsx": "^2.1.1",
+    "exceljs": "^4.4.0",
     "link-preview-js": "^3.2.0",
     "lucide-react": "^1.14.0",
     "next": "16.2.6",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -398,6 +398,7 @@ model Guest {
   isChild             Boolean   @default(false)
   isVIP               Boolean   @default(false)
   isPadrinho          Boolean   @default(false)
+  age                 Int?
   dietary             String?
   language            String?
   tableNumber         String?
@@ -412,6 +413,7 @@ model Guest {
   gifts             Gift[]
   group             GuestGroup? @relation(fields: [groupId], references: [id], onDelete: SetNull)
   table             SeatingTable? @relation(fields: [tableId], references: [id], onDelete: SetNull)
+  tags              GuestTagOnGuest[]
 
   @@index([rsvpStatus])
   @@index([deletedAt])
@@ -424,6 +426,7 @@ model GuestGroup {
   name                String
   rsvpToken           String    @unique @default(cuid())
   rsvpTokenExpiresAt  DateTime?
+  rsvpPin             String?
   contactName         String?
   contactEmail        String?
   contactPhone        String?
@@ -435,6 +438,31 @@ model GuestGroup {
   guests        Guest[]
 
   @@index([deletedAt])
+}
+
+model GuestTag {
+  id        String   @id @default(cuid())
+  name      String   @unique
+  color     String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  deletedAt DateTime?
+
+  guests    GuestTagOnGuest[]
+
+  @@index([deletedAt])
+}
+
+model GuestTagOnGuest {
+  guestId   String
+  tagId     String
+  createdAt DateTime @default(now())
+
+  guest     Guest    @relation(fields: [guestId], references: [id], onDelete: Cascade)
+  tag       GuestTag @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([guestId, tagId])
+  @@index([tagId])
 }
 
 model SeatingTable {

--- a/src/app/actions/guestActions.test.ts
+++ b/src/app/actions/guestActions.test.ts
@@ -1,18 +1,66 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { prismaMock } from "@/test-utils/prisma";
+
+const authMock = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => authMock(),
+}));
+
+import ExcelJS from "exceljs";
 import {
   bulkImportGuests,
+  commitGuestImport,
   createGuest,
   deleteGuest,
+  previewGuestImport,
   publicRsvpRespond,
   toggleCheckin,
   updateGuest,
 } from "./guestActions";
+import { __resetGuestImportCache } from "@/lib/guest-import-cache";
+import { __resetRateLimit } from "@/lib/rate-limit";
 
 beforeEach(() => {
   vi.spyOn(console, "error").mockImplementation(() => {});
   prismaMock.auditLog.create.mockResolvedValue({} as never);
+  authMock.mockReset();
+  authMock.mockResolvedValue({ user: { id: "test-user", role: "ADMIN" } });
+  __resetGuestImportCache();
+  __resetRateLimit();
 });
+
+const WEDY_HEADERS = [
+  "Nome do convite",
+  "Nome completo do convidado",
+  "Status",
+  "Telefone",
+  "E-mail",
+  "Tags",
+  "Faixa etária",
+  "Idade exata (caso for criança)",
+  "Pin do convite",
+];
+
+async function wedyXlsxFile(
+  rows: Array<Array<string | number>>,
+  filename = "lista.xlsx",
+): Promise<File> {
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet("Sheet1");
+  ws.addRow(WEDY_HEADERS);
+  for (const r of rows) ws.addRow(r);
+  const ab = await wb.xlsx.writeBuffer();
+  return new File([ab as ArrayBuffer], filename, {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+}
+
+function importForm(file: File, source = "AUTO"): FormData {
+  const fd = new FormData();
+  fd.set("file", file);
+  fd.set("source", source);
+  return fd;
+}
 
 function guestForm(overrides: Record<string, string> = {}): FormData {
   const fd = new FormData();
@@ -104,6 +152,18 @@ describe("toggleCheckin", () => {
 });
 
 describe("bulkImportGuests", () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(((arg: unknown) => {
+      if (typeof arg === "function") {
+        return (arg as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock);
+      }
+      return Promise.all(arg as Promise<unknown>[]);
+    }) as never);
+    prismaMock.guestGroup.findMany.mockResolvedValue([] as never);
+    prismaMock.guestGroup.create.mockImplementation(((args: { data: { name: string } }) =>
+      Promise.resolve({ id: `grp-${args.data.name}`, name: args.data.name })) as never);
+  });
+
   it("rejeita raw vazio", async () => {
     const fd = new FormData();
     fd.set("raw", "");
@@ -123,7 +183,7 @@ describe("bulkImportGuests", () => {
     );
     const r = await bulkImportGuests(undefined, fd);
     expect(r.success).toBe(true);
-    if (r.success) expect(r.data).toEqual({ created: 2, skipped: 0 });
+    if (r.success) expect(r.data).toEqual({ created: 2, skipped: 0, groupsCreated: 2 });
     expect(prismaMock.guest.create).toHaveBeenCalledTimes(2);
   });
 
@@ -143,6 +203,65 @@ describe("bulkImportGuests", () => {
     fd.set("separator", "TAB");
     const r = await bulkImportGuests(undefined, fd);
     expect(r.success).toBe(true);
+  });
+
+  it("cria GuestGroup por nome novo e associa via groupId", async () => {
+    prismaMock.guest.create.mockResolvedValue({ id: "g" } as never);
+    const fd = new FormData();
+    fd.set(
+      "raw",
+      ["Maria,,,,Família Silva", "João,,,,Família Silva", "Ana,,,,Trabalho"].join("\n"),
+    );
+
+    const r = await bulkImportGuests(undefined, fd);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data?.groupsCreated).toBe(2);
+
+    // 2 grupos únicos -> 2 chamadas
+    expect(prismaMock.guestGroup.create).toHaveBeenCalledTimes(2);
+
+    // guests recebem groupId resolvido
+    const calls = prismaMock.guest.create.mock.calls.map(
+      (c) => (c[0] as { data: { name: string; groupId: string | null } }).data,
+    );
+    const maria = calls.find((d) => d.name === "Maria");
+    const joao = calls.find((d) => d.name === "João");
+    const ana = calls.find((d) => d.name === "Ana");
+    expect(maria?.groupId).toBe("grp-Família Silva");
+    expect(joao?.groupId).toBe("grp-Família Silva");
+    expect(ana?.groupId).toBe("grp-Trabalho");
+  });
+
+  it("reaproveita GuestGroup existente pelo nome", async () => {
+    prismaMock.guestGroup.findMany.mockResolvedValue([
+      { id: "existing-grp", name: "Família Silva" },
+    ] as never);
+    prismaMock.guest.create.mockResolvedValue({ id: "g" } as never);
+
+    const fd = new FormData();
+    fd.set("raw", "Maria,,,,Família Silva");
+    const r = await bulkImportGuests(undefined, fd);
+
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data?.groupsCreated).toBe(0);
+    expect(prismaMock.guestGroup.create).not.toHaveBeenCalled();
+
+    const data = (prismaMock.guest.create.mock.calls[0][0] as {
+      data: { groupId: string | null };
+    }).data;
+    expect(data.groupId).toBe("existing-grp");
+  });
+
+  it("não chama guestGroup.findMany quando nenhuma linha tem grupo", async () => {
+    prismaMock.guest.create.mockResolvedValue({ id: "g" } as never);
+    const fd = new FormData();
+    fd.set("raw", "Maria,,,,\nJoão,,,,");
+    const r = await bulkImportGuests(undefined, fd);
+
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data?.groupsCreated).toBe(0);
+    expect(prismaMock.guestGroup.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.guestGroup.create).not.toHaveBeenCalled();
   });
 });
 
@@ -200,5 +319,313 @@ describe("publicRsvpRespond", () => {
     const data = (prismaMock.guest.update.mock.calls[0][0] as { data: { plusOnesConfirmed: number } })
       .data;
     expect(data.plusOnesConfirmed).toBe(0);
+  });
+});
+
+describe("previewGuestImport", () => {
+  beforeEach(() => {
+    prismaMock.guest.findMany.mockResolvedValue([] as never);
+  });
+
+  it("rejeita sem arquivo", async () => {
+    const fd = new FormData();
+    const r = await previewGuestImport(undefined, fd);
+    expect(r.success).toBe(false);
+  });
+
+  it("rejeita sem sessão", async () => {
+    authMock.mockResolvedValue(null);
+    const fd = new FormData();
+    fd.set("file", new File([Buffer.from("PK\x03\x04")], "x.xlsx"));
+    const r = await previewGuestImport(undefined, fd);
+    expect(r.success).toBe(false);
+  });
+
+  it("rejeita arquivo que não é XLSX", async () => {
+    const fd = importForm(new File([Buffer.from("hello")], "x.txt"));
+    const r = await previewGuestImport(undefined, fd);
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/xlsx/i);
+  });
+
+  it("aceita XLSX Wedy válido e classifica linhas como new", async () => {
+    const file = await wedyXlsxFile([
+      ["Família A", "Ana", "Sem resposta", "", "", "Tayná", "Adulto", "", "1234"],
+      ["Família A", "Bia", "Confirmado", "", "", "Padrinhos", "Adulto", "", "1234"],
+    ]);
+    const r = await previewGuestImport(undefined, importForm(file));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data!.source).toBe("wedy");
+      expect(r.data!.totalRows).toBe(2);
+      expect(r.data!.breakdown.new).toBe(2);
+      expect(r.data!.tagsPreview).toEqual(["Padrinhos", "Tayná"]);
+      expect(r.data!.groupsPreview).toEqual([
+        { name: "Família A", count: 2, pin: "1234" },
+      ]);
+      expect(r.data!.importToken).toMatch(/^[A-Za-z0-9_-]+$/);
+    }
+  });
+
+  it("classifica duplicate_same quando nome+grupo+phone+email batem", async () => {
+    prismaMock.guest.findMany.mockResolvedValue([
+      { id: "exist-1", name: "Ana", phone: "5511999990000", email: "ANA@x.com", groupName: "Família A" },
+    ] as never);
+    const file = await wedyXlsxFile([
+      ["Família A", "Ana", "Sem resposta", "+5511 99999-0000", "ana@x.com", "", "Adulto", "", ""],
+    ]);
+    const r = await previewGuestImport(undefined, importForm(file));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data!.breakdown.duplicateSame).toBe(1);
+      expect(r.data!.sample[0].classification).toBe("duplicate_same");
+    }
+  });
+
+  it("classifica duplicate_diff quando nome bate mas dados divergem", async () => {
+    prismaMock.guest.findMany.mockResolvedValue([
+      { id: "exist-1", name: "Ana", phone: "11999990000", email: "ana@x.com", groupName: "Família A" },
+    ] as never);
+    const file = await wedyXlsxFile([
+      ["Família A", "Ana", "Sem resposta", "11888880000", "outro@x.com", "", "Adulto", "", ""],
+    ]);
+    const r = await previewGuestImport(undefined, importForm(file));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data!.breakdown.duplicateDiff).toBe(1);
+    }
+  });
+
+  it("respeita rate limit por usuário (5/min)", async () => {
+    const file = await wedyXlsxFile([
+      ["G", "X", "Sem resposta", "", "", "", "Adulto", "", ""],
+    ]);
+    let last: Awaited<ReturnType<typeof previewGuestImport>> | null = null;
+    for (let i = 0; i < 6; i++) {
+      last = await previewGuestImport(undefined, importForm(file));
+    }
+    expect(last?.success).toBe(false);
+  });
+});
+
+describe("commitGuestImport", () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(((arg: unknown) => {
+      if (typeof arg === "function") {
+        return (arg as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock);
+      }
+      return Promise.all(arg as Promise<unknown>[]);
+    }) as never);
+    prismaMock.guestTag.findMany.mockResolvedValue([] as never);
+    prismaMock.guestTag.create.mockImplementation(((args: { data: { name: string } }) =>
+      Promise.resolve({ id: `tag-${args.data.name}`, name: args.data.name })) as never);
+    prismaMock.guestGroup.findMany.mockResolvedValue([] as never);
+    prismaMock.guestGroup.create.mockImplementation(((args: { data: { name: string; rsvpPin?: string | null } }) =>
+      Promise.resolve({
+        id: `grp-${args.data.name}`,
+        name: args.data.name,
+        rsvpPin: args.data.rsvpPin ?? null,
+      })) as never);
+    prismaMock.guestGroup.update.mockResolvedValue({} as never);
+    prismaMock.guest.findMany.mockResolvedValue([] as never);
+    prismaMock.guest.create.mockImplementation(((args: { data: { name: string } }) =>
+      Promise.resolve({ id: `g-${args.data.name}` })) as never);
+    prismaMock.guest.update.mockResolvedValue({} as never);
+    prismaMock.guestTagOnGuest.deleteMany.mockResolvedValue({ count: 0 } as never);
+    prismaMock.guestTagOnGuest.createMany.mockResolvedValue({ count: 0 } as never);
+  });
+
+  async function uploadFile(rows: Array<Array<string | number>>): Promise<string> {
+    const file = await wedyXlsxFile(rows);
+    const r = await previewGuestImport(undefined, importForm(file));
+    if (!r.success) throw new Error("preview failed");
+    return r.data!.importToken;
+  }
+
+  it("rejeita token inválido", async () => {
+    const r = await commitGuestImport({ importToken: "garbage12345", mode: "CREATE_NEW_ONLY" });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/sess[aã]o/i);
+  });
+
+  it("anti-IDOR: token criado por usuário diferente não é consumido", async () => {
+    const token = await uploadFile([
+      ["G", "Ana", "Sem resposta", "", "", "", "Adulto", "", ""],
+    ]);
+    authMock.mockResolvedValue({ user: { id: "outro-user", role: "ADMIN" } });
+    const r = await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    expect(r.success).toBe(false);
+  });
+
+  it("cria todos novos quando não há duplicatas", async () => {
+    const token = await uploadFile([
+      ["G", "Ana", "Sem resposta", "", "", "Tayná", "Adulto", "", "1111"],
+      ["G", "Bia", "Confirmado", "", "", "Padrinhos", "Adulto", "", "1111"],
+    ]);
+    const r = await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data).toMatchObject({ created: 2, updated: 0, skipped: 0, groupsCreated: 1, tagsCreated: 2 });
+    }
+  });
+
+  it("marca isPadrinho quando tag bate o regex flexível", async () => {
+    const token = await uploadFile([
+      ["G", "P1", "Sem resposta", "", "", "Padrinhos", "Adulto", "", ""],
+      ["G", "P2", "Sem resposta", "", "", "madrinha", "Adulto", "", ""],
+      ["G", "P3", "Sem resposta", "", "", "Florista", "Adulto", "", ""],
+    ]);
+    await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    const calls = prismaMock.guest.create.mock.calls.map(
+      (c) => (c[0] as { data: { name: string; isPadrinho: boolean } }).data,
+    );
+    expect(calls.find((c) => c.name === "P1")?.isPadrinho).toBe(true);
+    expect(calls.find((c) => c.name === "P2")?.isPadrinho).toBe(true);
+    expect(calls.find((c) => c.name === "P3")?.isPadrinho).toBe(false);
+  });
+
+  it("CREATE_NEW_ONLY pula sameGroup existente", async () => {
+    prismaMock.guest.findMany
+      .mockResolvedValueOnce([
+        { id: "exist-1", name: "Ana", phone: null, email: null, groupName: "G" },
+      ] as never)
+      .mockResolvedValueOnce([
+        { id: "exist-1", name: "Ana", groupName: "G" },
+      ] as never);
+    const file = await wedyXlsxFile([
+      ["G", "Ana", "Sem resposta", "", "", "", "Adulto", "", ""],
+    ]);
+    const preview = await previewGuestImport(undefined, importForm(file));
+    if (!preview.success) throw new Error();
+    const token = preview.data!.importToken;
+
+    const r = await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data!.skipped).toBe(1);
+      expect(r.data!.created).toBe(0);
+    }
+    expect(prismaMock.guest.update).not.toHaveBeenCalled();
+  });
+
+  it("UPSERT_BY_NAME atualiza sameGroup existente", async () => {
+    prismaMock.guest.findMany
+      .mockResolvedValueOnce([
+        { id: "exist-1", name: "Ana", phone: null, email: null, groupName: "G" },
+      ] as never)
+      .mockResolvedValueOnce([
+        { id: "exist-1", name: "Ana", groupName: "G" },
+      ] as never);
+    const file = await wedyXlsxFile([
+      ["G", "Ana", "Confirmado", "+5511999990000", "ana@x.com", "Padrinhos", "Adulto", "", ""],
+    ]);
+    const preview = await previewGuestImport(undefined, importForm(file));
+    if (!preview.success) throw new Error();
+    const r = await commitGuestImport({
+      importToken: preview.data!.importToken,
+      mode: "UPSERT_BY_NAME",
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data!.updated).toBe(1);
+
+    const upd = prismaMock.guest.update.mock.calls[0][0] as {
+      where: { id: string };
+      data: { rsvpStatus: string; isPadrinho?: boolean };
+    };
+    expect(upd.where.id).toBe("exist-1");
+    expect(upd.data.rsvpStatus).toBe("CONFIRMED");
+    expect(upd.data.isPadrinho).toBe(true);
+  });
+
+  it("CREATE_ALL_DUPLICATES sempre cria, mesmo com match no mesmo grupo", async () => {
+    prismaMock.guest.findMany
+      .mockResolvedValueOnce([
+        { id: "exist-1", name: "Ana", phone: null, email: null, groupName: "G" },
+      ] as never)
+      .mockResolvedValueOnce([
+        { id: "exist-1", name: "Ana", groupName: "G" },
+      ] as never);
+    const file = await wedyXlsxFile([
+      ["G", "Ana", "Sem resposta", "", "", "", "Adulto", "", ""],
+    ]);
+    const preview = await previewGuestImport(undefined, importForm(file));
+    if (!preview.success) throw new Error();
+    const r = await commitGuestImport({
+      importToken: preview.data!.importToken,
+      mode: "CREATE_ALL_DUPLICATES",
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data!.created).toBe(1);
+      expect(r.data!.skipped).toBe(0);
+      expect(r.data!.updated).toBe(0);
+    }
+  });
+
+  it("reaproveita GuestTag existente (case-insensitive)", async () => {
+    prismaMock.guestTag.findMany.mockResolvedValueOnce([
+      { id: "existing-tag", name: "Padrinhos" },
+    ] as never);
+    const token = await uploadFile([
+      ["G", "X", "Sem resposta", "", "", "padrinhos", "Adulto", "", ""],
+    ]);
+    const r = await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    expect(r.success).toBe(true);
+    expect(prismaMock.guestTag.create).not.toHaveBeenCalled();
+    const linkCall = prismaMock.guestTagOnGuest.createMany.mock.calls[0][0] as {
+      data: Array<{ tagId: string }>;
+    };
+    expect(linkCall.data[0].tagId).toBe("existing-tag");
+  });
+
+  it("propaga rsvpPin para grupo novo", async () => {
+    const token = await uploadFile([
+      ["Família X", "Ana", "Sem resposta", "", "", "", "Adulto", "", "9876"],
+    ]);
+    await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    const call = prismaMock.guestGroup.create.mock.calls[0][0] as {
+      data: { name: string; rsvpPin: string | null };
+    };
+    expect(call.data.rsvpPin).toBe("9876");
+  });
+
+  it("não sobrescreve rsvpPin existente non-null", async () => {
+    prismaMock.guestGroup.findMany.mockResolvedValueOnce([
+      { id: "g1", name: "Família X", rsvpPin: "0000" },
+    ] as never);
+    const token = await uploadFile([
+      ["Família X", "Ana", "Sem resposta", "", "", "", "Adulto", "", "9999"],
+    ]);
+    await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    expect(prismaMock.guestGroup.update).not.toHaveBeenCalled();
+  });
+
+  it("atualiza rsvpPin quando grupo existente tem pin null", async () => {
+    prismaMock.guestGroup.findMany.mockResolvedValueOnce([
+      { id: "g1", name: "Família X", rsvpPin: null },
+    ] as never);
+    const token = await uploadFile([
+      ["Família X", "Ana", "Sem resposta", "", "", "", "Adulto", "", "9999"],
+    ]);
+    await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    expect(prismaMock.guestGroup.update).toHaveBeenCalledWith({
+      where: { id: "g1" },
+      data: { rsvpPin: "9999" },
+    });
+  });
+
+  it("grava audit BULK_CREATE com source e mode", async () => {
+    const token = await uploadFile([
+      ["G", "Ana", "Sem resposta", "", "", "", "Adulto", "", ""],
+    ]);
+    await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    const auditCall = prismaMock.auditLog.create.mock.calls.find((c) => {
+      const data = (c[0] as { data: { action?: string } }).data;
+      return data.action === "BULK_CREATE";
+    });
+    expect(auditCall).toBeTruthy();
+    const payload = (auditCall![0] as { data: { payload?: string } }).data.payload;
+    expect(payload).toContain('"source":"wedy"');
+    expect(payload).toContain('"mode":"CREATE_NEW_ONLY"');
   });
 });

--- a/src/app/actions/guestActions.ts
+++ b/src/app/actions/guestActions.ts
@@ -3,10 +3,24 @@
 import { headers } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoEdit } from "@/lib/finance-access";
 import { getClientIp, rateLimit } from "@/lib/rate-limit";
+import {
+  detectMagic,
+  assertGuestImportSize,
+  FileValidationError,
+} from "@/lib/file-validation";
+import {
+  IMPORTERS,
+  detectImporter,
+  type Importer,
+  type ImporterId,
+  type ParsedRow,
+} from "@/lib/guest-importers";
+import { putImport, consumeImport } from "@/lib/guest-import-cache";
 import type { ActionResult } from "@/types";
 
 const RsvpStatusSchema = z.enum(["NOT_INVITED", "INVITED", "CONFIRMED", "DECLINED", "MAYBE"]);
@@ -173,7 +187,7 @@ function detectSeparator(firstLine: string): "\t" | "," | ";" {
 export async function bulkImportGuests(
   _state: ActionResult | undefined,
   formData: FormData,
-): Promise<ActionResult<{ created: number; skipped: number }>> {
+): Promise<ActionResult<{ created: number; skipped: number; groupsCreated: number }>> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
@@ -197,32 +211,83 @@ export async function bulkImportGuests(
           ? ";"
           : detectSeparator(lines[0]);
 
-  let created = 0;
+  type ParsedRow = {
+    name: string;
+    phone: string | null;
+    email: string | null;
+    side: "NOIVO" | "NOIVA" | "AMBOS" | null;
+    groupName: string | null;
+  };
+
+  const rows: ParsedRow[] = [];
   let skipped = 0;
-  try {
-    for (const line of lines) {
-      const parts = line.split(sep).map((p) => p.trim());
-      const [name, phone, email, side, groupName] = parts;
-      if (!name) {
-        skipped++;
-        continue;
-      }
-      await prisma.guest.create({
-        data: {
-          name,
-          phone: phone || null,
-          email: email || null,
-          side: side === "NOIVO" || side === "NOIVA" || side === "AMBOS" ? side : null,
-          groupName: groupName || null,
-        },
-      });
-      created++;
+  for (const line of lines) {
+    const parts = line.split(sep).map((p) => p.trim());
+    const [name, phone, email, side, groupName] = parts;
+    if (!name) {
+      skipped++;
+      continue;
     }
-    if (created > 0) {
-      await audit("Guest", "bulk-import", "BULK_CREATE", { created, skipped });
+    rows.push({
+      name,
+      phone: phone || null,
+      email: email || null,
+      side: side === "NOIVO" || side === "NOIVA" || side === "AMBOS" ? side : null,
+      groupName: groupName ? groupName.slice(0, 80) : null,
+    });
+  }
+
+  const uniqueGroupNames = Array.from(
+    new Set(rows.map((r) => r.groupName).filter((n): n is string => !!n)),
+  );
+
+  try {
+    const existing =
+      uniqueGroupNames.length === 0
+        ? []
+        : await prisma.guestGroup.findMany({
+            where: { name: { in: uniqueGroupNames }, deletedAt: null },
+            select: { id: true, name: true },
+          });
+    const groupIdByName = new Map<string, string>(existing.map((g) => [g.name, g.id]));
+
+    const { createdCount, groupsCreated } = await prisma.$transaction(async (tx) => {
+      let groupsCreatedInner = 0;
+      for (const groupName of uniqueGroupNames) {
+        if (!groupIdByName.has(groupName)) {
+          const newGroup = await tx.guestGroup.create({ data: { name: groupName } });
+          groupIdByName.set(groupName, newGroup.id);
+          groupsCreatedInner++;
+        }
+      }
+      let createdInner = 0;
+      for (const row of rows) {
+        const groupId = row.groupName ? (groupIdByName.get(row.groupName) ?? null) : null;
+        await tx.guest.create({
+          data: {
+            name: row.name,
+            phone: row.phone,
+            email: row.email,
+            side: row.side,
+            groupName: row.groupName,
+            groupId,
+          },
+        });
+        createdInner++;
+      }
+      return { createdCount: createdInner, groupsCreated: groupsCreatedInner };
+    });
+
+    if (createdCount > 0 || groupsCreated > 0) {
+      await audit("Guest", "bulk-import", "BULK_CREATE", {
+        created: createdCount,
+        skipped,
+        groupsCreated,
+      });
     }
     revalidatePath("/dashboard/guests");
-    return { success: true, data: { created, skipped } };
+    if (groupsCreated > 0) revalidatePath("/dashboard/guests/groups");
+    return { success: true, data: { created: createdCount, skipped, groupsCreated } };
   } catch (err) {
     console.error("[bulkImportGuests]", err);
     return { success: false, error: "Erro ao importar" };
@@ -276,5 +341,425 @@ export async function publicRsvpRespond(
   } catch (err) {
     console.error("[publicRsvpRespond]", err);
     return { success: false, error: "Erro ao registrar resposta" };
+  }
+}
+
+// =====================================================
+// Importação por arquivo (XLSX, Wedy etc.) — 2 passos
+// =====================================================
+
+export type RowClassification = "new" | "duplicate_same" | "duplicate_diff";
+
+export type ClassifiedRow = ParsedRow & {
+  classification: RowClassification;
+  existingId: string | null;
+};
+
+export type PreviewData = {
+  source: ImporterId;
+  sourceLabel: string;
+  totalRows: number;
+  breakdown: {
+    new: number;
+    duplicateSame: number;
+    duplicateDiff: number;
+  };
+  sample: ClassifiedRow[];
+  tagsPreview: string[];
+  groupsPreview: Array<{ name: string; count: number; pin: string | null }>;
+  importToken: string;
+};
+
+export type CommitMode = "CREATE_NEW_ONLY" | "UPSERT_BY_NAME" | "CREATE_ALL_DUPLICATES";
+
+export type CommitData = {
+  created: number;
+  updated: number;
+  skipped: number;
+  groupsCreated: number;
+  tagsCreated: number;
+};
+
+const MAX_PREVIEW_SAMPLE = 30;
+const MAX_IMPORT_ROWS = 2000;
+
+const PADRINHO_RE = /^(padrinho|padrinhos|madrinha|madrinhas|padrinho\/madrinha)$/i;
+
+function phoneEq(a: string | null | undefined, b: string | null | undefined): boolean {
+  const na = (a ?? "").replace(/\D+/g, "");
+  const nb = (b ?? "").replace(/\D+/g, "");
+  if (!na && !nb) return true;
+  return na === nb;
+}
+
+function emailEq(a: string | null | undefined, b: string | null | undefined): boolean {
+  const na = (a ?? "").trim().toLowerCase();
+  const nb = (b ?? "").trim().toLowerCase();
+  return na === nb;
+}
+
+function isPadrinhoTag(tags: string[]): boolean {
+  return tags.some((t) => PADRINHO_RE.test(t.trim()));
+}
+
+const SourceParamSchema = z.enum(["AUTO", ...(Object.keys(IMPORTERS) as ImporterId[])]);
+
+export async function previewGuestImport(
+  _state: ActionResult<PreviewData> | undefined,
+  formData: FormData,
+): Promise<ActionResult<PreviewData>> {
+  const denied = await denyIfNoEdit();
+  if (denied) return denied;
+
+  const session = await auth();
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) return { success: false, error: "Não autorizado" };
+
+  const ip = getClientIp(await headers());
+  if (!rateLimit(`guest-import:${userId}`, 5, 60_000).ok) {
+    return { success: false, error: "Muitos uploads em sequência. Aguarde 1 minuto." };
+  }
+  if (!rateLimit(`guest-import:ip:${ip}`, 15, 60_000).ok) {
+    return { success: false, error: "Limite de uploads excedido." };
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File) || file.size === 0) {
+    return { success: false, error: "Arquivo obrigatório" };
+  }
+
+  const sourceParam = SourceParamSchema.safeParse(formData.get("source") ?? "AUTO");
+  if (!sourceParam.success) {
+    return { success: false, error: "Origem desconhecida" };
+  }
+
+  try {
+    const bytes = Buffer.from(await file.arrayBuffer());
+    assertGuestImportSize(bytes.length);
+    const detected = detectMagic(bytes);
+    if (detected !== "xlsx") {
+      throw new FileValidationError("Apenas arquivos .xlsx são suportados nesta versão.");
+    }
+
+    let importer: Importer | null = null;
+    if (sourceParam.data === "AUTO") {
+      importer = await detectImporter(bytes);
+      if (!importer) {
+        return {
+          success: false,
+          error: "Não foi possível identificar a planilha. Suportados: Wedy.",
+        };
+      }
+    } else {
+      importer = IMPORTERS[sourceParam.data];
+    }
+
+    const rows = await importer.parse(bytes);
+    if (rows.length === 0) {
+      return { success: false, error: "Nenhuma linha válida encontrada na planilha." };
+    }
+    if (rows.length > MAX_IMPORT_ROWS) {
+      return {
+        success: false,
+        error: `Limite de ${MAX_IMPORT_ROWS} linhas por importação.`,
+      };
+    }
+
+    const uniqueNames = Array.from(new Set(rows.map((r) => r.name)));
+    const existing = await prisma.guest.findMany({
+      where: { deletedAt: null, name: { in: uniqueNames } },
+      select: {
+        id: true,
+        name: true,
+        phone: true,
+        email: true,
+        groupName: true,
+      },
+    });
+    const byName = new Map<string, typeof existing>();
+    for (const e of existing) {
+      const arr = byName.get(e.name) ?? [];
+      arr.push(e);
+      byName.set(e.name, arr);
+    }
+
+    let countNew = 0;
+    let countDupSame = 0;
+    let countDupDiff = 0;
+    const classified: ClassifiedRow[] = rows.map((r) => {
+      const matches = byName.get(r.name) ?? [];
+      if (matches.length === 0) {
+        countNew++;
+        return { ...r, classification: "new", existingId: null };
+      }
+      const sameGroup = matches.find(
+        (m) => (m.groupName ?? "") === (r.groupName ?? ""),
+      );
+      if (
+        sameGroup &&
+        phoneEq(sameGroup.phone, r.phone) &&
+        emailEq(sameGroup.email, r.email)
+      ) {
+        countDupSame++;
+        return { ...r, classification: "duplicate_same", existingId: sameGroup.id };
+      }
+      countDupDiff++;
+      return {
+        ...r,
+        classification: "duplicate_diff",
+        existingId: (sameGroup ?? matches[0]).id,
+      };
+    });
+
+    const tagsSet = new Set<string>();
+    for (const r of rows) for (const t of r.tags) tagsSet.add(t);
+
+    const groupCounts = new Map<string, { count: number; pin: string | null }>();
+    for (const r of rows) {
+      if (!r.groupName) continue;
+      const cur = groupCounts.get(r.groupName) ?? { count: 0, pin: null };
+      cur.count++;
+      if (!cur.pin && r.pin) cur.pin = r.pin;
+      groupCounts.set(r.groupName, cur);
+    }
+    const groupsPreview = Array.from(groupCounts.entries()).map(([name, v]) => ({
+      name,
+      count: v.count,
+      pin: v.pin,
+    }));
+
+    const importToken = putImport(userId, importer.id, rows);
+
+    return {
+      success: true,
+      data: {
+        source: importer.id,
+        sourceLabel: importer.label,
+        totalRows: rows.length,
+        breakdown: {
+          new: countNew,
+          duplicateSame: countDupSame,
+          duplicateDiff: countDupDiff,
+        },
+        sample: classified.slice(0, MAX_PREVIEW_SAMPLE),
+        tagsPreview: Array.from(tagsSet).sort(),
+        groupsPreview,
+        importToken,
+      },
+    };
+  } catch (err) {
+    if (err instanceof FileValidationError) {
+      return { success: false, error: err.message };
+    }
+    console.error("[previewGuestImport]", err);
+    return { success: false, error: "Erro ao processar arquivo" };
+  }
+}
+
+const CommitSchema = z.object({
+  importToken: z.string().min(8).max(40),
+  mode: z.enum(["CREATE_NEW_ONLY", "UPSERT_BY_NAME", "CREATE_ALL_DUPLICATES"]),
+});
+
+export async function commitGuestImport(input: {
+  importToken: string;
+  mode: CommitMode;
+}): Promise<ActionResult<CommitData>> {
+  const denied = await denyIfNoEdit();
+  if (denied) return denied;
+
+  const session = await auth();
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) return { success: false, error: "Não autorizado" };
+
+  const parsed = CommitSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+  }
+
+  const entry = consumeImport(userId, parsed.data.importToken);
+  if (!entry) {
+    return {
+      success: false,
+      error: "Sessão de importação expirou. Reenvie o arquivo.",
+    };
+  }
+
+  try {
+    const result = await prisma.$transaction(
+      async (tx) => {
+        // 1) Tags
+        const tagNames = Array.from(
+          new Set(
+            entry.rows.flatMap((r) => r.tags).map((t) => t.trim()).filter(Boolean),
+          ),
+        );
+        const tagIdByLowerName = new Map<string, string>();
+        if (tagNames.length > 0) {
+          const existingTags = await tx.guestTag.findMany({
+            where: { deletedAt: null, name: { in: tagNames } },
+            select: { id: true, name: true },
+          });
+          for (const t of existingTags) {
+            tagIdByLowerName.set(t.name.toLowerCase(), t.id);
+          }
+        }
+        let tagsCreated = 0;
+        for (const name of tagNames) {
+          if (!tagIdByLowerName.has(name.toLowerCase())) {
+            const created = await tx.guestTag.create({ data: { name } });
+            tagIdByLowerName.set(created.name.toLowerCase(), created.id);
+            tagsCreated++;
+          }
+        }
+
+        // 2) Grupos
+        const groupNames = Array.from(
+          new Set(entry.rows.map((r) => r.groupName).filter((n): n is string => !!n)),
+        );
+        const pinByGroupName = new Map<string, string>();
+        for (const r of entry.rows) {
+          if (r.groupName && r.pin && !pinByGroupName.has(r.groupName)) {
+            pinByGroupName.set(r.groupName, r.pin);
+          }
+        }
+        const groupByName = new Map<string, { id: string; rsvpPin: string | null }>();
+        if (groupNames.length > 0) {
+          const existingGroups = await tx.guestGroup.findMany({
+            where: { deletedAt: null, name: { in: groupNames } },
+            select: { id: true, name: true, rsvpPin: true },
+          });
+          for (const g of existingGroups) {
+            groupByName.set(g.name, { id: g.id, rsvpPin: g.rsvpPin });
+          }
+        }
+        let groupsCreated = 0;
+        for (const name of groupNames) {
+          if (!groupByName.has(name)) {
+            const created = await tx.guestGroup.create({
+              data: { name, rsvpPin: pinByGroupName.get(name) ?? null },
+            });
+            groupByName.set(name, { id: created.id, rsvpPin: created.rsvpPin });
+            groupsCreated++;
+          } else {
+            const existing = groupByName.get(name)!;
+            if (!existing.rsvpPin && pinByGroupName.has(name)) {
+              const newPin = pinByGroupName.get(name)!;
+              await tx.guestGroup.update({
+                where: { id: existing.id },
+                data: { rsvpPin: newPin },
+              });
+              existing.rsvpPin = newPin;
+            }
+          }
+        }
+
+        // 3) Guests
+        const uniqueNames = Array.from(new Set(entry.rows.map((r) => r.name)));
+        const existingGuests =
+          uniqueNames.length === 0
+            ? []
+            : await tx.guest.findMany({
+                where: { deletedAt: null, name: { in: uniqueNames } },
+                select: { id: true, name: true, groupName: true },
+              });
+        const existingByName = new Map<string, typeof existingGuests>();
+        for (const g of existingGuests) {
+          const arr = existingByName.get(g.name) ?? [];
+          arr.push(g);
+          existingByName.set(g.name, arr);
+        }
+
+        let created = 0;
+        let updated = 0;
+        let skipped = 0;
+
+        for (const row of entry.rows) {
+          const matches = existingByName.get(row.name) ?? [];
+          const sameGroup = matches.find(
+            (m) => (m.groupName ?? "") === (row.groupName ?? ""),
+          );
+          const padrinhoFlag = isPadrinhoTag(row.tags);
+          const groupId = row.groupName ? groupByName.get(row.groupName)?.id ?? null : null;
+          const tagIds = row.tags
+            .map((t) => tagIdByLowerName.get(t.toLowerCase()))
+            .filter((id): id is string => !!id);
+
+          if (sameGroup && parsed.data.mode === "CREATE_NEW_ONLY") {
+            skipped++;
+            continue;
+          }
+
+          if (sameGroup && parsed.data.mode === "UPSERT_BY_NAME") {
+            await tx.guest.update({
+              where: { id: sameGroup.id },
+              data: {
+                phone: row.phone ?? undefined,
+                email: row.email ?? undefined,
+                rsvpStatus: row.rsvpStatus,
+                isChild: row.isChild,
+                age: row.age,
+                isPadrinho: padrinhoFlag ? true : undefined,
+                groupId: groupId ?? undefined,
+                groupName: row.groupName ?? undefined,
+              },
+            });
+            await tx.guestTagOnGuest.deleteMany({ where: { guestId: sameGroup.id } });
+            if (tagIds.length > 0) {
+              await tx.guestTagOnGuest.createMany({
+                data: tagIds.map((tagId) => ({ guestId: sameGroup.id, tagId })),
+              });
+            }
+            updated++;
+            continue;
+          }
+
+          const newGuest = await tx.guest.create({
+            data: {
+              name: row.name,
+              phone: row.phone,
+              email: row.email,
+              side: null,
+              groupName: row.groupName,
+              groupId,
+              rsvpStatus: row.rsvpStatus,
+              isChild: row.isChild,
+              age: row.age,
+              isPadrinho: padrinhoFlag,
+            },
+          });
+          if (tagIds.length > 0) {
+            await tx.guestTagOnGuest.createMany({
+              data: tagIds.map((tagId) => ({ guestId: newGuest.id, tagId })),
+            });
+          }
+          created++;
+        }
+
+        return { created, updated, skipped, groupsCreated, tagsCreated };
+      },
+      { timeout: 30_000 },
+    );
+
+    if (result.created > 0 || result.updated > 0 || result.groupsCreated > 0) {
+      await audit(
+        "Guest",
+        "bulk-import-file",
+        "BULK_CREATE",
+        {
+          source: entry.source,
+          mode: parsed.data.mode,
+          ...result,
+        },
+        userId,
+      );
+    }
+
+    revalidatePath("/dashboard/guests");
+    if (result.groupsCreated > 0) revalidatePath("/dashboard/guests/groups");
+    return { success: true, data: result };
+  } catch (err) {
+    console.error("[commitGuestImport]", err);
+    return { success: false, error: "Erro ao gravar importação" };
   }
 }

--- a/src/app/dashboard/guests/groups/groups-client.tsx
+++ b/src/app/dashboard/guests/groups/groups-client.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Plus, Link2, Trash2, Edit3, Users, CheckCircle2, X } from "lucide-react";
+import { ArrowLeft, Plus, Link2, Trash2, Edit3, Users, CheckCircle2, X } from "lucide-react";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import {
@@ -125,6 +126,12 @@ export default function GroupsClient({
 
   return (
     <div className="space-y-4 p-4 md:p-6">
+      <Link
+        href="/dashboard/guests"
+        className="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-300"
+      >
+        <ArrowLeft className="h-4 w-4" /> Voltar para convidados
+      </Link>
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-xl font-semibold text-zinc-100 md:text-2xl">Grupos / Famílias</h1>

--- a/src/app/dashboard/guests/guests-client.tsx
+++ b/src/app/dashboard/guests/guests-client.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import {
   CheckCircle2,
-  ChevronDown,
   Copy,
   Download,
   Loader2,
@@ -14,10 +13,8 @@ import {
   Trash2,
   Upload,
   Users,
-  X,
 } from "lucide-react";
 import {
-  bulkImportGuests,
   createGuest,
   deleteGuest,
   toggleCheckin,
@@ -69,12 +66,10 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<Guest | null>(null);
   const [deleting, setDeleting] = useState<Guest | null>(null);
-  const [importOpen, setImportOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<"ALL" | "CONFIRMED" | "PENDING" | "PADRINHOS" | "CHILDREN" | "CHECKED_IN">("ALL");
   const [busy, setBusy] = useState(false);
   const [updatingBusy, setUpdatingBusy] = useState(false);
-  const [importBusy, setImportBusy] = useState(false);
   const [, startTransition] = useTransition();
 
   const filtered = useMemo(() => {
@@ -151,21 +146,6 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
       else toast.error("Falha", r.error);
     });
   }
-  function handleImport(formData: FormData) {
-    setImportBusy(true);
-    startTransition(async () => {
-      try {
-        const r = await bulkImportGuests(undefined, formData);
-        if (r.success && r.data) {
-          toast.success(`${r.data.created} importados`, `${r.data.skipped} linhas puladas`);
-          setImportOpen(false);
-        } else if (!r.success) toast.error("Falha", r.error);
-      } finally {
-        setImportBusy(false);
-      }
-    });
-  }
-
   function copyRsvp(guest: Guest) {
     const url = `${baseUrl}/rsvp/${guest.rsvpToken}`;
     navigator.clipboard.writeText(url).then(
@@ -266,13 +246,12 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
           >
             <Download className="h-4 w-4" /> CSV
           </button>
-          <button
-            type="button"
-            onClick={() => setImportOpen(true)}
+          <Link
+            href="/dashboard/guests/import"
             className="inline-flex items-center gap-1.5 rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm font-medium text-rose-200 hover:bg-rose-500/20"
           >
             <Upload className="h-4 w-4" /> Importar lista
-          </button>
+          </Link>
           <button
             type="button"
             onClick={() => setOpen(true)}
@@ -407,10 +386,6 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
           formAction={editing ? handleUpdate : handleCreate}
         />
       )}
-
-      {importOpen ? (
-        <ImportModal isBusy={importBusy} onClose={() => setImportOpen(false)} formAction={handleImport} />
-      ) : null}
 
       <ConfirmDialog
         open={!!deleting}
@@ -558,80 +533,6 @@ function GuestFormModal({
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
               {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-function ImportModal({
-  isBusy,
-  onClose,
-  formAction,
-}: {
-  isBusy: boolean;
-  onClose: () => void;
-  formAction: (formData: FormData) => void;
-}) {
-  return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
-      <div className="my-4 w-full max-w-2xl rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-white">Importar convidados em massa</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-lg p-1 text-zinc-300 hover:bg-zinc-800"
-            aria-label="Fechar"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-        <p className="mt-2 text-sm text-zinc-400">
-          Cole linhas no formato <code className="rounded bg-zinc-800 px-1">Nome,Telefone,Email,Lado,Grupo</code>{" "}
-          (uma linha por convidado). Telefone, email, lado e grupo são opcionais. Lado aceita NOIVO/NOIVA/AMBOS.
-        </p>
-        <form action={formAction} className="mt-4 space-y-3">
-          <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Conteúdo</label>
-            <textarea
-              name="raw"
-              required
-              rows={10}
-              placeholder={`Maria Silva,+5511999990000,maria@example.com,NOIVA,Família\nJoão Souza\nAna,,ana@example.com,,Trabalho dele`}
-              className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Separador</label>
-            <select
-              name="separator"
-              defaultValue="AUTO"
-              className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
-            >
-              <option value="AUTO">Detectar automaticamente</option>
-              <option value="COMMA">, (vírgula)</option>
-              <option value="SEMICOLON">; (ponto-vírgula)</option>
-              <option value="TAB">Tab</option>
-            </select>
-          </div>
-          <div className="flex gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
-            >
-              Cancelar
-            </button>
-            <button
-              type="submit"
-              disabled={isBusy}
-              className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
-            >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ChevronDown className="h-4 w-4 rotate-90" />}
-              Importar
             </button>
           </div>
         </form>

--- a/src/app/dashboard/guests/import/_components/paste-modal.tsx
+++ b/src/app/dashboard/guests/import/_components/paste-modal.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { ChevronDown, Loader2, X } from "lucide-react";
+import { useToast } from "@/components/toast";
+import { bulkImportGuests } from "@/app/actions/guestActions";
+
+export function PasteImportModal({ onClose }: { onClose: () => void }) {
+  const toast = useToast();
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [, startTransition] = useTransition();
+
+  function handleSubmit(formData: FormData) {
+    setBusy(true);
+    startTransition(async () => {
+      try {
+        const r = await bulkImportGuests(undefined, formData);
+        if (r.success && r.data) {
+          const groupsMsg =
+            r.data.groupsCreated > 0
+              ? `, ${r.data.groupsCreated} grupo(s) criado(s)`
+              : "";
+          toast.success(
+            `${r.data.created} importados`,
+            `${r.data.skipped} linhas puladas${groupsMsg}`,
+          );
+          onClose();
+          router.refresh();
+        } else if (!r.success) {
+          toast.error("Falha", r.error);
+        }
+      } finally {
+        setBusy(false);
+      }
+    });
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/60 p-4 backdrop-blur-sm sm:items-center">
+      <div className="my-4 w-full max-w-2xl rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white">Colar texto bruto</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-1 text-zinc-300 hover:bg-zinc-800"
+            aria-label="Fechar"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <p className="mt-2 text-sm text-zinc-400">
+          Cole linhas no formato{" "}
+          <code className="rounded bg-zinc-800 px-1">Nome,Telefone,Email,Lado,Grupo</code>{" "}
+          (uma linha por convidado). Telefone, email, lado e grupo são opcionais. Lado aceita
+          NOIVO/NOIVA/AMBOS. Quando a coluna <strong>Grupo</strong> for preenchida, grupos novos
+          são criados automaticamente (e os existentes reaproveitados, comparando pelo nome) —
+          convidados da mesma família passam a compartilhar um único link de RSVP.
+        </p>
+        <form action={handleSubmit} className="mt-4 space-y-3">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">Conteúdo</label>
+            <textarea
+              name="raw"
+              required
+              rows={10}
+              placeholder={`Maria Silva,+5511999990000,maria@example.com,NOIVA,Família\nJoão Souza\nAna,,ana@example.com,,Trabalho dele`}
+              className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">Separador</label>
+            <select
+              name="separator"
+              defaultValue="AUTO"
+              className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
+            >
+              <option value="AUTO">Detectar automaticamente</option>
+              <option value="COMMA">, (vírgula)</option>
+              <option value="SEMICOLON">; (ponto-vírgula)</option>
+              <option value="TAB">Tab</option>
+            </select>
+          </div>
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={busy}
+              className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
+            >
+              {busy ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ChevronDown className="h-4 w-4 rotate-90" />
+              )}
+              Importar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/guests/import/_components/preview-table.tsx
+++ b/src/app/dashboard/guests/import/_components/preview-table.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import type { ClassifiedRow } from "@/app/actions/guestActions";
+
+const STATUS_LABEL: Record<ClassifiedRow["classification"], string> = {
+  new: "Novo",
+  duplicate_same: "Já existe (mesmo grupo)",
+  duplicate_diff: "Já existe, dados divergem",
+};
+
+const STATUS_CHIP: Record<ClassifiedRow["classification"], string> = {
+  new: "bg-emerald-500/10 text-emerald-300 border-emerald-500/20",
+  duplicate_same: "bg-zinc-800 text-zinc-400 border-zinc-700",
+  duplicate_diff: "bg-amber-500/10 text-amber-300 border-amber-500/20",
+};
+
+const RSVP_LABEL: Record<string, string> = {
+  NOT_INVITED: "Não convidado",
+  INVITED: "Convidado",
+  CONFIRMED: "Confirmado",
+  DECLINED: "Recusou",
+  MAYBE: "Talvez",
+};
+
+export function PreviewTable({
+  rows,
+  filter,
+}: {
+  rows: ClassifiedRow[];
+  filter: "all" | ClassifiedRow["classification"];
+}) {
+  const visible = filter === "all" ? rows : rows.filter((r) => r.classification === filter);
+
+  if (visible.length === 0) {
+    return (
+      <p className="rounded-xl bg-zinc-950 px-3 py-6 text-center text-sm text-zinc-500">
+        Nenhuma linha para este filtro.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-zinc-800">
+      <table className="w-full text-left text-xs text-zinc-400">
+        <thead className="border-b border-zinc-800 bg-zinc-900/80 text-[10px] uppercase text-zinc-500">
+          <tr>
+            <th className="px-3 py-2 font-medium">Status</th>
+            <th className="px-3 py-2 font-medium">Nome</th>
+            <th className="px-3 py-2 font-medium">Grupo</th>
+            <th className="px-3 py-2 font-medium">RSVP</th>
+            <th className="px-3 py-2 font-medium">Telefone</th>
+            <th className="px-3 py-2 font-medium">Email</th>
+            <th className="px-3 py-2 font-medium">Tags</th>
+            <th className="px-3 py-2 font-medium">Criança</th>
+            <th className="px-3 py-2 font-medium">PIN</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-800">
+          {visible.map((row, idx) => (
+            <tr key={`${row.name}-${idx}`} className="hover:bg-zinc-900/60">
+              <td className="px-3 py-2">
+                <span
+                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] ${STATUS_CHIP[row.classification]}`}
+                >
+                  {STATUS_LABEL[row.classification]}
+                </span>
+              </td>
+              <td className="px-3 py-2 text-zinc-100">{row.name}</td>
+              <td className="px-3 py-2">{row.groupName ?? "—"}</td>
+              <td className="px-3 py-2">
+                {RSVP_LABEL[row.rsvpStatus] ?? row.rsvpStatus}
+                {row.rsvpStatusRaw && row.rsvpStatus === "INVITED" && row.rsvpStatusRaw !== "Sem resposta" ? (
+                  <span
+                    className="ml-1 text-[10px] text-amber-400"
+                    title={`Status original "${row.rsvpStatusRaw}" não reconhecido; tratado como Convidado.`}
+                  >
+                    *
+                  </span>
+                ) : null}
+              </td>
+              <td className="px-3 py-2">{row.phone ?? "—"}</td>
+              <td className="px-3 py-2">{row.email ?? "—"}</td>
+              <td className="px-3 py-2">
+                {row.tags.length > 0 ? row.tags.join(", ") : "—"}
+              </td>
+              <td className="px-3 py-2">
+                {row.isChild ? `Sim${row.age != null ? ` (${row.age})` : ""}` : "—"}
+              </td>
+              <td className="px-3 py-2">{row.pin ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/dashboard/guests/import/import-client.tsx
+++ b/src/app/dashboard/guests/import/import-client.tsx
@@ -1,0 +1,446 @@
+"use client";
+
+// i18n: tela ainda pendente de migração para next-intl (AGENTS.md §6.7).
+// Strings em pt-BR direto na JSX seguem o padrão do guests-client.tsx.
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronRight,
+  Loader2,
+  Upload,
+  X,
+} from "lucide-react";
+import { useToast } from "@/components/toast";
+import {
+  commitGuestImport,
+  previewGuestImport,
+  type CommitData,
+  type CommitMode,
+  type PreviewData,
+} from "@/app/actions/guestActions";
+import { IMPORTER_OPTIONS } from "@/lib/guest-importers";
+import { PreviewTable } from "./_components/preview-table";
+import { PasteImportModal } from "./_components/paste-modal";
+
+const MODE_OPTIONS: Array<{
+  id: CommitMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "CREATE_NEW_ONLY",
+    label: "Pular linhas que já existem no mesmo grupo",
+    description: "Mais seguro. Só cria os convidados novos; nada é alterado.",
+  },
+  {
+    id: "UPSERT_BY_NAME",
+    label: "Atualizar dados de quem já existe no mesmo grupo",
+    description:
+      "Sobrescreve telefone, e-mail, status e tags dos convidados que já existem. Cria os novos.",
+  },
+  {
+    id: "CREATE_ALL_DUPLICATES",
+    label: "Criar tudo, mesmo que já exista",
+    description:
+      "Use quando houver homônimos em famílias diferentes que não devem ser fundidos.",
+  },
+];
+
+type Step = "upload" | "preview" | "done";
+
+export function GuestImportClient() {
+  const router = useRouter();
+  const toast = useToast();
+  const [step, setStep] = useState<Step>("upload");
+  const [source, setSource] = useState<string>("AUTO");
+  const [file, setFile] = useState<File | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+  const [mode, setMode] = useState<CommitMode>("CREATE_NEW_ONLY");
+  const [filter, setFilter] = useState<
+    "all" | "new" | "duplicate_same" | "duplicate_diff"
+  >("all");
+  const [result, setResult] = useState<CommitData | null>(null);
+  const [showPaste, setShowPaste] = useState(false);
+  const [, startTransition] = useTransition();
+
+  async function handleUpload(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!file) {
+      toast.error("Selecione um arquivo .xlsx");
+      return;
+    }
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.set("file", file);
+      fd.set("source", source);
+      const r = await previewGuestImport(undefined, fd);
+      if (!r.success) {
+        toast.error("Falha", r.error);
+        return;
+      }
+      if (!r.data) {
+        toast.error("Resposta inesperada do servidor");
+        return;
+      }
+      setPreview(r.data);
+      setStep("preview");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function handleCancel() {
+    setPreview(null);
+    setFile(null);
+    setStep("upload");
+  }
+
+  async function handleConfirm() {
+    if (!preview) return;
+    setBusy(true);
+    try {
+      const r = await commitGuestImport({
+        importToken: preview.importToken,
+        mode,
+      });
+      if (!r.success) {
+        toast.error("Falha ao importar", r.error);
+        return;
+      }
+      if (!r.data) {
+        toast.error("Resposta inesperada do servidor");
+        return;
+      }
+      setResult(r.data);
+      setStep("done");
+      startTransition(() => router.refresh());
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <div>
+        <Link
+          href="/dashboard/guests"
+          className="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-300"
+        >
+          <ArrowLeft className="h-4 w-4" /> Voltar para convidados
+        </Link>
+        <h1 className="mt-2 text-xl font-semibold text-zinc-100 md:text-2xl">
+          Importar lista de convidados
+        </h1>
+        <p className="text-sm text-zinc-400">
+          Suba o arquivo exportado de outro sistema (hoje:{" "}
+          {IMPORTER_OPTIONS.map((o) => o.label).join(", ")}). Você verá um preview antes de
+          confirmar.
+        </p>
+      </div>
+
+      {step === "upload" ? (
+        <form
+          onSubmit={handleUpload}
+          className="space-y-4 rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5"
+        >
+          <div>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">
+              Arquivo (.xlsx)
+            </label>
+            <input
+              type="file"
+              accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              required
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 file:mr-3 file:rounded-lg file:border-0 file:bg-rose-500/20 file:px-3 file:py-1.5 file:text-rose-200 hover:file:bg-rose-500/30"
+            />
+            <p className="mt-1 text-xs text-zinc-500">
+              Tamanho máximo: 5 MB. Até 2000 linhas por importação.
+            </p>
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">Origem</label>
+            <select
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+              className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
+            >
+              <option value="AUTO">Detectar automaticamente</option>
+              {IMPORTER_OPTIONS.map((opt) => (
+                <option key={opt.id} value={opt.id}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 pt-2">
+            <button
+              type="button"
+              onClick={() => setShowPaste(true)}
+              className="text-xs text-zinc-400 underline hover:text-zinc-200"
+            >
+              Prefere colar texto bruto?
+            </button>
+            <button
+              type="submit"
+              disabled={busy || !file}
+              className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
+            >
+              {busy ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Upload className="h-4 w-4" />
+              )}
+              Analisar arquivo
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      {step === "preview" && preview ? (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
+            <StatTile label="Linhas no arquivo" value={preview.totalRows} accent="rose" />
+            <StatTile label="Novos" value={preview.breakdown.new} accent="emerald" />
+            <StatTile
+              label="Já existem (mesmo grupo)"
+              value={preview.breakdown.duplicateSame}
+              accent="zinc"
+            />
+            <StatTile
+              label="Divergentes"
+              value={preview.breakdown.duplicateDiff}
+              accent="amber"
+            />
+          </div>
+
+          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <h2 className="text-sm font-semibold text-zinc-100">Origem detectada</h2>
+            <p className="text-sm text-zinc-400">
+              {preview.sourceLabel} —{" "}
+              <span className="text-zinc-500">arquivo válido, headers reconhecidos.</span>
+            </p>
+          </section>
+
+          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <h2 className="mb-2 text-sm font-semibold text-zinc-100">
+              Grupos detectados ({preview.groupsPreview.length})
+            </h2>
+            {preview.groupsPreview.length === 0 ? (
+              <p className="text-sm text-zinc-500">Nenhum grupo na planilha.</p>
+            ) : (
+              <ul className="flex max-h-40 flex-wrap gap-1.5 overflow-y-auto">
+                {preview.groupsPreview.map((g) => (
+                  <li
+                    key={g.name}
+                    className="inline-flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300"
+                  >
+                    <span>{g.name}</span>
+                    <span className="text-zinc-500">·</span>
+                    <span className="text-zinc-500">{g.count} pessoa(s)</span>
+                    {g.pin ? (
+                      <>
+                        <span className="text-zinc-500">·</span>
+                        <span className="text-rose-300">PIN {g.pin}</span>
+                      </>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <h2 className="mb-2 text-sm font-semibold text-zinc-100">
+              Tags detectadas ({preview.tagsPreview.length})
+            </h2>
+            {preview.tagsPreview.length === 0 ? (
+              <p className="text-sm text-zinc-500">Nenhuma tag.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {preview.tagsPreview.map((t) => (
+                  <span
+                    key={t}
+                    className="inline-flex items-center rounded-full border border-rose-500/30 bg-rose-500/10 px-2.5 py-0.5 text-xs text-rose-200"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            )}
+            <p className="mt-2 text-xs text-zinc-500">
+              Tags novas serão criadas. Tags com o nome &ldquo;Padrinhos&rdquo;,
+              &ldquo;Madrinha&rdquo; etc. também marcam a flag de padrinho do convidado.
+            </p>
+          </section>
+
+          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h2 className="text-sm font-semibold text-zinc-100">
+                Amostra (até {preview.sample.length} linhas)
+              </h2>
+              <div className="flex gap-1 text-xs">
+                {([
+                  ["all", "Todas"],
+                  ["new", "Novas"],
+                  ["duplicate_same", "Já existem"],
+                  ["duplicate_diff", "Divergentes"],
+                ] as const).map(([id, label]) => (
+                  <button
+                    type="button"
+                    key={id}
+                    onClick={() => setFilter(id)}
+                    className={`rounded-lg px-2 py-1 ${
+                      filter === id
+                        ? "bg-rose-500/20 text-rose-200"
+                        : "text-zinc-400 hover:bg-zinc-800"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <PreviewTable rows={preview.sample} filter={filter} />
+          </section>
+
+          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <h2 className="mb-3 text-sm font-semibold text-zinc-100">
+              Como tratar duplicatas
+            </h2>
+            <div className="space-y-2">
+              {MODE_OPTIONS.map((opt) => (
+                <label
+                  key={opt.id}
+                  className={`flex cursor-pointer items-start gap-3 rounded-xl border p-3 ${
+                    mode === opt.id
+                      ? "border-rose-500/40 bg-rose-500/5"
+                      : "border-zinc-800 hover:bg-zinc-900"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="mode"
+                    value={opt.id}
+                    checked={mode === opt.id}
+                    onChange={() => setMode(opt.id)}
+                    className="mt-1"
+                  />
+                  <div>
+                    <div className="text-sm font-medium text-zinc-100">{opt.label}</div>
+                    <div className="text-xs text-zinc-500">{opt.description}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <div className="flex flex-wrap justify-end gap-2">
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={busy}
+              className="inline-flex items-center gap-1 rounded-xl bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-200 hover:bg-zinc-700"
+            >
+              <X className="h-4 w-4" /> Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={busy}
+              className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
+            >
+              {busy ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              Confirmar importação
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {step === "done" && result ? (
+        <div className="space-y-4 rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-5">
+          <div className="flex items-center gap-2 text-emerald-200">
+            <CheckCircle2 className="h-5 w-5" />
+            <h2 className="text-base font-semibold">Importação concluída</h2>
+          </div>
+          <ul className="text-sm text-zinc-300">
+            <li>
+              <strong className="text-zinc-100">{result.created}</strong> convidado(s) criados.
+            </li>
+            <li>
+              <strong className="text-zinc-100">{result.updated}</strong> convidado(s)
+              atualizados.
+            </li>
+            <li>
+              <strong className="text-zinc-100">{result.skipped}</strong> linha(s) puladas.
+            </li>
+            <li>
+              <strong className="text-zinc-100">{result.groupsCreated}</strong> grupo(s)
+              criados.
+            </li>
+            <li>
+              <strong className="text-zinc-100">{result.tagsCreated}</strong> tag(s) criadas.
+            </li>
+          </ul>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/dashboard/guests"
+              className="rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500"
+            >
+              Ver lista de convidados
+            </Link>
+            <button
+              type="button"
+              onClick={() => {
+                setResult(null);
+                setPreview(null);
+                setFile(null);
+                setStep("upload");
+              }}
+              className="rounded-xl bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-700"
+            >
+              Importar outra
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {showPaste ? <PasteImportModal onClose={() => setShowPaste(false)} /> : null}
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent: "rose" | "emerald" | "amber" | "zinc";
+}) {
+  const styles: Record<typeof accent, string> = {
+    rose: "bg-rose-500/10 border-rose-500/20 text-rose-200",
+    emerald: "bg-emerald-500/10 border-emerald-500/20 text-emerald-200",
+    amber: "bg-amber-500/10 border-amber-500/20 text-amber-200",
+    zinc: "bg-zinc-800/60 border-zinc-700/50 text-zinc-300",
+  };
+  return (
+    <div className={`rounded-2xl border p-3 ${styles[accent]}`}>
+      <div className="text-2xl font-semibold">{value}</div>
+      <div className="text-xs opacity-80">{label}</div>
+    </div>
+  );
+}

--- a/src/app/dashboard/guests/import/page.tsx
+++ b/src/app/dashboard/guests/import/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { GuestImportClient } from "./import-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function GuestImportPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+  return <GuestImportClient />;
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,23 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.6.2",
+    date: "2026-05-26",
+    highlights: [
+      "📥 Importação de convidados por arquivo XLSX em /dashboard/guests/import. Suporta planilhas do Wedy out-of-the-box, com preview de novos vs. duplicados, lista de grupos detectados, PINs preservados e modo configurável (pular existentes / atualizar / criar tudo).",
+      "🏷️ Novo model GuestTag (M:N). Tags vindas do import viram tags reais; 'Padrinhos', 'Madrinha' etc. ativam também a flag isPadrinho.",
+      "🔢 GuestGroup agora tem rsvpPin (4-8 chars, informativo, vindo do convite original) e Guest ganhou age (idade exata para crianças).",
+    ],
+  },
+  {
+    version: "0.6.1",
+    date: "2026-05-26",
+    highlights: [
+      "👨‍👩‍👧 Importação CSV de convidados agora cria automaticamente os grupos/famílias presentes na coluna 'Grupo' (e reaproveita os existentes pelo nome). Convidados da mesma família já saem com `groupId` preenchido — basta abrir o grupo depois para configurar contato e copiar o link de RSVP coletivo.",
+      "↩️ Tela de grupos (`/dashboard/guests/groups`) ganhou link 'Voltar para convidados' no topo, eliminando a necessidade de usar o botão do navegador.",
+    ],
+  },
+  {
     version: "0.6.0",
     date: "2026-05-23",
     highlights: [

--- a/src/lib/file-validation.test.ts
+++ b/src/lib/file-validation.test.ts
@@ -4,6 +4,8 @@ import {
   assertMagicMatchesMime,
   assertAllowedForKind,
   assertSizeForKind,
+  assertGuestImportSize,
+  GUEST_IMPORT_MAX_BYTES,
   maxBytesForKind,
   FileValidationError,
 } from "./file-validation";
@@ -75,6 +77,11 @@ describe("detectMagic", () => {
   it("retorna unknown para buffer vazio", () => {
     expect(detectMagic(Buffer.alloc(0))).toBe("unknown");
   });
+
+  it("identifica XLSX (container ZIP) pelo magic PK\\x03\\x04", () => {
+    const buf = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00]);
+    expect(detectMagic(buf)).toBe("xlsx");
+  });
 });
 
 describe("assertMagicMatchesMime", () => {
@@ -126,5 +133,16 @@ describe("assertSizeForKind", () => {
 
   it("usa limite default para kind desconhecido", () => {
     expect(maxBytesForKind("XXX_UNKNOWN")).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe("assertGuestImportSize", () => {
+  it("permite tamanho abaixo de 5MB", () => {
+    expect(() => assertGuestImportSize(1024)).not.toThrow();
+    expect(() => assertGuestImportSize(GUEST_IMPORT_MAX_BYTES)).not.toThrow();
+  });
+
+  it("rejeita acima de 5MB", () => {
+    expect(() => assertGuestImportSize(GUEST_IMPORT_MAX_BYTES + 1)).toThrow(FileValidationError);
   });
 });

--- a/src/lib/file-validation.ts
+++ b/src/lib/file-validation.ts
@@ -4,6 +4,7 @@ export type DetectedType =
   | "jpeg"
   | "webp"
   | "heic"
+  | "xlsx"
   | "unknown";
 
 const MIME_FOR_TYPE: Record<Exclude<DetectedType, "unknown">, ReadonlySet<string>> = {
@@ -12,6 +13,12 @@ const MIME_FOR_TYPE: Record<Exclude<DetectedType, "unknown">, ReadonlySet<string
   jpeg: new Set(["image/jpeg", "image/jpg"]),
   webp: new Set(["image/webp"]),
   heic: new Set(["image/heic", "image/heif"]),
+  xlsx: new Set([
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/zip",
+    "application/x-zip-compressed",
+    "application/octet-stream",
+  ]),
 };
 
 export const ALLOWED_MIME_BY_KIND: Record<string, ReadonlySet<string>> = {
@@ -61,6 +68,7 @@ const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
 const JPEG_HEADER = Buffer.from([0xff, 0xd8, 0xff]);
 const RIFF = Buffer.from("RIFF", "ascii");
 const WEBP = Buffer.from("WEBP", "ascii");
+const ZIP_HEADER = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
 const HEIC_BRANDS = ["heic", "heix", "heim", "heis", "hevc", "hevx", "mif1", "msf1"];
 
 export function detectMagic(buf: Buffer): DetectedType {
@@ -84,6 +92,7 @@ export function detectMagic(buf: Buffer): DetectedType {
     const head = buf.subarray(0, Math.min(buf.length, 1024));
     if (head.indexOf(PDF_HEADER) !== -1) return "pdf";
   }
+  if (buf.length >= 4 && buf.subarray(0, 4).equals(ZIP_HEADER)) return "xlsx";
   return "unknown";
 }
 
@@ -129,5 +138,14 @@ export function assertSizeForKind(kind: string, size: number): void {
   if (size > max) {
     const mb = Math.round(max / MB);
     throw new FileValidationError(`Arquivo excede ${mb} MB para ${kind}.`);
+  }
+}
+
+export const GUEST_IMPORT_MAX_BYTES = 5 * MB;
+
+export function assertGuestImportSize(size: number): void {
+  if (size > GUEST_IMPORT_MAX_BYTES) {
+    const mb = Math.round(GUEST_IMPORT_MAX_BYTES / MB);
+    throw new FileValidationError(`Arquivo excede ${mb} MB.`);
   }
 }

--- a/src/lib/guest-import-cache.test.ts
+++ b/src/lib/guest-import-cache.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  putImport,
+  takeImport,
+  consumeImport,
+  __resetGuestImportCache,
+  GUEST_IMPORT_CACHE_TTL_MS,
+  GUEST_IMPORT_CACHE_MAX_ENTRIES,
+} from "./guest-import-cache";
+import type { ParsedRow } from "./guest-importers";
+
+function row(name: string): ParsedRow {
+  return {
+    name,
+    groupName: null,
+    phone: null,
+    email: null,
+    rsvpStatus: "INVITED",
+    rsvpStatusRaw: null,
+    tags: [],
+    isChild: false,
+    age: null,
+    pin: null,
+    rawSource: {},
+  };
+}
+
+beforeEach(() => __resetGuestImportCache());
+afterEach(() => vi.useRealTimers());
+
+describe("guest-import-cache", () => {
+  it("put + take retorna a entry para o mesmo usuário", () => {
+    const token = putImport("u1", "wedy", [row("A")]);
+    const entry = takeImport("u1", token);
+    expect(entry).not.toBeNull();
+    expect(entry?.rows[0].name).toBe("A");
+  });
+
+  it("take com userId diferente retorna null (anti-IDOR)", () => {
+    const token = putImport("u1", "wedy", [row("A")]);
+    expect(takeImport("u2", token)).toBeNull();
+  });
+
+  it("consume remove a entry após retornar", () => {
+    const token = putImport("u1", "wedy", [row("A")]);
+    expect(consumeImport("u1", token)).not.toBeNull();
+    expect(takeImport("u1", token)).toBeNull();
+  });
+
+  it("entry expira após TTL", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T10:00:00Z"));
+    const token = putImport("u1", "wedy", [row("A")]);
+    expect(takeImport("u1", token)).not.toBeNull();
+    vi.setSystemTime(new Date(Date.now() + GUEST_IMPORT_CACHE_TTL_MS + 1));
+    expect(takeImport("u1", token)).toBeNull();
+  });
+
+  it("hard cap purga a entrada mais antiga", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T10:00:00Z"));
+    const tokens: string[] = [];
+    for (let i = 0; i < GUEST_IMPORT_CACHE_MAX_ENTRIES; i++) {
+      tokens.push(putImport(`u${i}`, "wedy", [row(`R${i}`)]));
+      vi.setSystemTime(new Date(Date.now() + 100));
+    }
+    const oldest = tokens[0];
+    expect(takeImport("u0", oldest)).not.toBeNull();
+    putImport("uNew", "wedy", [row("New")]);
+    expect(takeImport("u0", oldest)).toBeNull();
+  });
+
+  it("limita rows a 2000", () => {
+    const tooMany = Array.from({ length: 2500 }, (_, i) => row(`R${i}`));
+    const token = putImport("u1", "wedy", tooMany);
+    const entry = takeImport("u1", token);
+    expect(entry?.rows.length).toBe(2000);
+  });
+});

--- a/src/lib/guest-import-cache.ts
+++ b/src/lib/guest-import-cache.ts
@@ -1,0 +1,74 @@
+import { randomBytes } from "node:crypto";
+import type { ImporterId, ParsedRow } from "./guest-importers";
+
+export type GuestImportEntry = {
+  userId: string;
+  source: ImporterId;
+  rows: ParsedRow[];
+  createdAt: number;
+};
+
+const TTL_MS = 10 * 60_000;
+const MAX_ENTRIES = 50;
+const MAX_ROWS = 2000;
+
+const cache = new Map<string, GuestImportEntry>();
+
+function now(): number {
+  return Date.now();
+}
+
+function sweep(current: number): void {
+  for (const [k, v] of cache) {
+    if (current - v.createdAt > TTL_MS) cache.delete(k);
+  }
+}
+
+function enforceCap(): void {
+  if (cache.size <= MAX_ENTRIES) return;
+  // Remove a entrada mais antiga.
+  let oldestKey: string | null = null;
+  let oldestAt = Infinity;
+  for (const [k, v] of cache) {
+    if (v.createdAt < oldestAt) {
+      oldestAt = v.createdAt;
+      oldestKey = k;
+    }
+  }
+  if (oldestKey) cache.delete(oldestKey);
+}
+
+export function putImport(userId: string, source: ImporterId, rows: ParsedRow[]): string {
+  const current = now();
+  sweep(current);
+  const trimmed = rows.slice(0, MAX_ROWS);
+  const token = randomBytes(18).toString("base64url");
+  cache.set(token, { userId, source, rows: trimmed, createdAt: current });
+  enforceCap();
+  return token;
+}
+
+export function takeImport(userId: string, token: string): GuestImportEntry | null {
+  const entry = cache.get(token);
+  if (!entry) return null;
+  if (entry.userId !== userId) return null;
+  if (now() - entry.createdAt > TTL_MS) {
+    cache.delete(token);
+    return null;
+  }
+  return entry;
+}
+
+export function consumeImport(userId: string, token: string): GuestImportEntry | null {
+  const entry = takeImport(userId, token);
+  if (entry) cache.delete(token);
+  return entry;
+}
+
+// Utilizado apenas por testes.
+export function __resetGuestImportCache(): void {
+  cache.clear();
+}
+
+export const GUEST_IMPORT_CACHE_TTL_MS = TTL_MS;
+export const GUEST_IMPORT_CACHE_MAX_ENTRIES = MAX_ENTRIES;

--- a/src/lib/guest-importers/index.ts
+++ b/src/lib/guest-importers/index.ts
@@ -1,0 +1,24 @@
+import { wedyImporter } from "./wedy";
+import type { Importer, ImporterId } from "./types";
+
+export const IMPORTERS: Record<ImporterId, Importer> = {
+  wedy: wedyImporter,
+};
+
+export const IMPORTER_OPTIONS: Array<{ id: ImporterId; label: string }> = Object.values(
+  IMPORTERS,
+).map((imp) => ({ id: imp.id, label: imp.label }));
+
+export async function detectImporter(buf: Buffer): Promise<Importer | null> {
+  for (const importer of Object.values(IMPORTERS)) {
+    try {
+      const ok = await importer.detect(buf);
+      if (ok) return importer;
+    } catch {
+      // continua tentando os próximos
+    }
+  }
+  return null;
+}
+
+export type { Importer, ImporterId, ParsedRow, ImportedRsvpStatus } from "./types";

--- a/src/lib/guest-importers/types.ts
+++ b/src/lib/guest-importers/types.ts
@@ -1,0 +1,29 @@
+export type ImportedRsvpStatus =
+  | "NOT_INVITED"
+  | "INVITED"
+  | "CONFIRMED"
+  | "DECLINED"
+  | "MAYBE";
+
+export type ParsedRow = {
+  name: string;
+  groupName: string | null;
+  phone: string | null;
+  email: string | null;
+  rsvpStatus: ImportedRsvpStatus;
+  rsvpStatusRaw: string | null;
+  tags: string[];
+  isChild: boolean;
+  age: number | null;
+  pin: string | null;
+  rawSource: Record<string, string>;
+};
+
+export type ImporterId = "wedy";
+
+export type Importer = {
+  id: ImporterId;
+  label: string;
+  detect(buf: Buffer): Promise<boolean>;
+  parse(buf: Buffer): Promise<ParsedRow[]>;
+};

--- a/src/lib/guest-importers/wedy.test.ts
+++ b/src/lib/guest-importers/wedy.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import ExcelJS from "exceljs";
+import { wedyImporter } from "./wedy";
+
+const FULL_HEADERS = [
+  "Nome do convite",
+  "Nome completo do convidado",
+  "Status",
+  "Telefone",
+  "E-mail",
+  "Tags",
+  "Faixa etária",
+  "Idade exata (caso for criança)",
+  "Pin do convite",
+];
+
+async function buildWedyXlsx(
+  rows: Array<Array<string | number>>,
+  headers: string[] = FULL_HEADERS,
+): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet("Sheet1");
+  ws.addRow(headers);
+  for (const row of rows) ws.addRow(row);
+  const ab = await wb.xlsx.writeBuffer();
+  return Buffer.from(ab as ArrayBuffer);
+}
+
+async function buildEmptyXlsx(): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook();
+  wb.addWorksheet("Sheet1");
+  const ab = await wb.xlsx.writeBuffer();
+  return Buffer.from(ab as ArrayBuffer);
+}
+
+describe("wedyImporter.detect", () => {
+  let fullBuf: Buffer;
+  let partialBuf: Buffer;
+  let foreignBuf: Buffer;
+  let emptyBuf: Buffer;
+
+  beforeAll(async () => {
+    fullBuf = await buildWedyXlsx([["Família A", "Ana", "Sem resposta", "", "", "", "Adulto", "", ""]]);
+    // 6 colunas das esperadas presentes
+    partialBuf = await buildWedyXlsx(
+      [["A", "B", "C", "D", "E", "F"]],
+      [
+        "Nome do convite",
+        "Nome completo do convidado",
+        "Status",
+        "Telefone",
+        "E-mail",
+        "Tags",
+      ],
+    );
+    foreignBuf = await buildWedyXlsx(
+      [["x"]],
+      ["Outro Sistema", "Coluna Bizarra", "Algo Mais"],
+    );
+    emptyBuf = await buildEmptyXlsx();
+  });
+
+  it("detecta planilha com todos os headers Wedy", async () => {
+    expect(await wedyImporter.detect(fullBuf)).toBe(true);
+  });
+
+  it("detecta planilha com 6 das 9 colunas esperadas", async () => {
+    expect(await wedyImporter.detect(partialBuf)).toBe(true);
+  });
+
+  it("não detecta planilha com headers incompatíveis", async () => {
+    expect(await wedyImporter.detect(foreignBuf)).toBe(false);
+  });
+
+  it("não detecta planilha vazia", async () => {
+    expect(await wedyImporter.detect(emptyBuf)).toBe(false);
+  });
+
+  it("retorna false (não lança) para buffer inválido", async () => {
+    expect(await wedyImporter.detect(Buffer.from([0, 1, 2, 3]))).toBe(false);
+  });
+});
+
+describe("wedyImporter.parse", () => {
+  it("mapeia todos os campos básicos de uma linha completa", async () => {
+    const buf = await buildWedyXlsx([
+      ["Família Silva", "Maria Silva", "Sem resposta", "+5511999990000", "maria@x.com", "Padrinhos, Tayná", "Adulto", "", "8696"],
+    ]);
+    const rows = await wedyImporter.parse(buf);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      name: "Maria Silva",
+      groupName: "Família Silva",
+      phone: "+5511999990000",
+      email: "maria@x.com",
+      rsvpStatus: "INVITED",
+      rsvpStatusRaw: "Sem resposta",
+      tags: ["Padrinhos", "Tayná"],
+      isChild: false,
+      age: null,
+      pin: "8696",
+    });
+  });
+
+  it("mapeia status: Confirmado/Recusado/Talvez", async () => {
+    const buf = await buildWedyXlsx([
+      ["G1", "A", "Confirmado", "", "", "", "Adulto", "", ""],
+      ["G2", "B", "Recusado", "", "", "", "Adulto", "", ""],
+      ["G3", "C", "Talvez", "", "", "", "Adulto", "", ""],
+      ["G4", "D", "Não convidado", "", "", "", "Adulto", "", ""],
+    ]);
+    const rows = await wedyImporter.parse(buf);
+    expect(rows.map((r) => r.rsvpStatus)).toEqual([
+      "CONFIRMED",
+      "DECLINED",
+      "MAYBE",
+      "NOT_INVITED",
+    ]);
+  });
+
+  it("status desconhecido cai em INVITED e preserva rsvpStatusRaw", async () => {
+    const buf = await buildWedyXlsx([
+      ["G", "X", "Coisa-Estranha", "", "", "", "Adulto", "", ""],
+    ]);
+    const [row] = await wedyImporter.parse(buf);
+    expect(row.rsvpStatus).toBe("INVITED");
+    expect(row.rsvpStatusRaw).toBe("Coisa-Estranha");
+  });
+
+  it("isChild=true quando Faixa etária = Criança", async () => {
+    const buf = await buildWedyXlsx([
+      ["G", "Kid", "Sem resposta", "", "", "", "Criança", "8", ""],
+    ]);
+    const [row] = await wedyImporter.parse(buf);
+    expect(row.isChild).toBe(true);
+    expect(row.age).toBe(8);
+  });
+
+  it("ignora 'Idade desconhecida' (não-numérica) preenchendo age=null", async () => {
+    const buf = await buildWedyXlsx([
+      ["G", "Kid", "Sem resposta", "", "", "", "Criança", "Idade desconhecida", ""],
+    ]);
+    const [row] = await wedyImporter.parse(buf);
+    expect(row.age).toBeNull();
+  });
+
+  it("rejeita idade fora do range 0-17", async () => {
+    const buf = await buildWedyXlsx([
+      ["G", "X", "Sem resposta", "", "", "", "Criança", "25", ""],
+    ]);
+    const [row] = await wedyImporter.parse(buf);
+    expect(row.age).toBeNull();
+  });
+
+  it("rejeita PIN com formato inválido", async () => {
+    const buf = await buildWedyXlsx([
+      ["G", "X", "Sem resposta", "", "", "", "Adulto", "", "abc"],
+      ["G", "Y", "Sem resposta", "", "", "", "Adulto", "", "ABCDEFGHIJK"],
+      ["G", "Z", "Sem resposta", "", "", "", "Adulto", "", "1234"],
+      ["G", "W", "Sem resposta", "", "", "", "Adulto", "", "AB12"],
+    ]);
+    const rows = await wedyImporter.parse(buf);
+    expect(rows[0].pin).toBeNull();
+    expect(rows[1].pin).toBeNull();
+    expect(rows[2].pin).toBe("1234");
+    expect(rows[3].pin).toBe("AB12");
+  });
+
+  it("split e trim de tags, limita a 20", async () => {
+    const many = Array.from({ length: 25 }, (_, i) => `t${i}`).join(", ");
+    const buf = await buildWedyXlsx([
+      ["G", "X", "Sem resposta", "", "", many, "Adulto", "", ""],
+    ]);
+    const [row] = await wedyImporter.parse(buf);
+    expect(row.tags).toHaveLength(20);
+    expect(row.tags[0]).toBe("t0");
+    expect(row.tags[19]).toBe("t19");
+  });
+
+  it("descarta linha sem nome", async () => {
+    const buf = await buildWedyXlsx([
+      ["G", "  ", "Sem resposta", "", "", "", "Adulto", "", ""],
+      ["G", "Ana", "Sem resposta", "", "", "", "Adulto", "", ""],
+    ]);
+    const rows = await wedyImporter.parse(buf);
+    expect(rows.map((r) => r.name)).toEqual(["Ana"]);
+  });
+
+  it("aplica limites de tamanho a name/groupName/phone/email", async () => {
+    const buf = await buildWedyXlsx([
+      [
+        "g".repeat(200),
+        "n".repeat(200),
+        "Sem resposta",
+        "p".repeat(100),
+        `${"e".repeat(200)}@x.com`,
+        "",
+        "Adulto",
+        "",
+        "",
+      ],
+    ]);
+    const [row] = await wedyImporter.parse(buf);
+    expect(row.name.length).toBe(160);
+    expect(row.groupName?.length).toBe(80);
+    expect(row.phone?.length).toBe(40);
+    expect(row.email?.length).toBe(160);
+  });
+
+  it("preserva tags com nomes dos noivos (case original)", async () => {
+    const buf = await buildWedyXlsx([
+      ["G", "X", "Sem resposta", "", "", "Tayná, Guilherme", "Adulto", "", ""],
+    ]);
+    const [row] = await wedyImporter.parse(buf);
+    expect(row.tags).toEqual(["Tayná", "Guilherme"]);
+  });
+});

--- a/src/lib/guest-importers/wedy.ts
+++ b/src/lib/guest-importers/wedy.ts
@@ -1,0 +1,149 @@
+import ExcelJS from "exceljs";
+import type { Importer, ImportedRsvpStatus, ParsedRow } from "./types";
+
+const EXPECTED_HEADERS = [
+  "Nome do convite",
+  "Nome completo do convidado",
+  "Status",
+  "Telefone",
+  "E-mail",
+  "Tags",
+  "Faixa etária",
+  "Idade exata (caso for criança)",
+  "Pin do convite",
+] as const;
+
+const STATUS_MAP: Record<string, ImportedRsvpStatus> = {
+  "sem resposta": "INVITED",
+  "convidado": "INVITED",
+  "confirmado": "CONFIRMED",
+  "confirmada": "CONFIRMED",
+  "vai": "CONFIRMED",
+  "recusado": "DECLINED",
+  "recusada": "DECLINED",
+  "não vai": "DECLINED",
+  "nao vai": "DECLINED",
+  "talvez": "MAYBE",
+  "não convidado": "NOT_INVITED",
+  "nao convidado": "NOT_INVITED",
+};
+
+const PIN_RE = /^[A-Z0-9]{4,8}$/i;
+
+function cellText(value: ExcelJS.CellValue): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object" && "text" in value && typeof value.text === "string") {
+    return value.text;
+  }
+  if (typeof value === "object" && "richText" in value && Array.isArray(value.richText)) {
+    return value.richText.map((rt) => rt.text).join("");
+  }
+  if (typeof value === "object" && "result" in value) {
+    return cellText(value.result as ExcelJS.CellValue);
+  }
+  return String(value);
+}
+
+function readHeader(worksheet: ExcelJS.Worksheet): string[] {
+  const headerRow = worksheet.getRow(1);
+  const values = headerRow.values as unknown[];
+  // ExcelJS retorna array 1-indexed; índice 0 é undefined.
+  return values.slice(1).map((v) => cellText(v as ExcelJS.CellValue).trim());
+}
+
+async function loadWorkbook(buf: Buffer): Promise<ExcelJS.Workbook> {
+  const workbook = new ExcelJS.Workbook();
+  await workbook.xlsx.load(buf as unknown as ArrayBuffer);
+  return workbook;
+}
+
+export const wedyImporter: Importer = {
+  id: "wedy",
+  label: "Wedy",
+  async detect(buf) {
+    try {
+      const workbook = await loadWorkbook(buf);
+      const worksheet = workbook.worksheets[0];
+      if (!worksheet) return false;
+      const headers = readHeader(worksheet);
+      const matches = EXPECTED_HEADERS.filter((h) => headers.includes(h)).length;
+      return matches >= 6;
+    } catch {
+      return false;
+    }
+  },
+
+  async parse(buf) {
+    const workbook = await loadWorkbook(buf);
+    const worksheet = workbook.worksheets[0];
+    if (!worksheet) return [];
+
+    const headers = readHeader(worksheet);
+    const colIndex = new Map<string, number>();
+    headers.forEach((h, i) => {
+      if (h) colIndex.set(h, i + 1);
+    });
+
+    const get = (row: ExcelJS.Row, header: string): string => {
+      const idx = colIndex.get(header);
+      if (!idx) return "";
+      return cellText(row.getCell(idx).value).trim();
+    };
+
+    const rows: ParsedRow[] = [];
+    const totalRows = worksheet.actualRowCount;
+
+    for (let r = 2; r <= totalRows; r++) {
+      const row = worksheet.getRow(r);
+      const name = get(row, "Nome completo do convidado").slice(0, 160);
+      if (!name) continue;
+
+      const groupName = get(row, "Nome do convite").slice(0, 80) || null;
+      const phone = get(row, "Telefone").slice(0, 40) || null;
+      const email = get(row, "E-mail").slice(0, 160) || null;
+      const statusRaw = get(row, "Status");
+      const statusKey = statusRaw.toLowerCase();
+      const rsvpStatus = STATUS_MAP[statusKey] ?? "INVITED";
+
+      const tagsRaw = get(row, "Tags");
+      const tags = tagsRaw
+        ? tagsRaw
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean)
+            .slice(0, 20)
+        : [];
+
+      const isChild = get(row, "Faixa etária").toLowerCase() === "criança";
+
+      const ageRaw = get(row, "Idade exata (caso for criança)");
+      const ageNum = /^\d{1,3}$/.test(ageRaw) ? parseInt(ageRaw, 10) : null;
+      const age = ageNum != null && ageNum >= 0 && ageNum <= 17 ? ageNum : null;
+
+      const pinRaw = get(row, "Pin do convite");
+      const pin = PIN_RE.test(pinRaw) ? pinRaw : null;
+
+      const rawSource: Record<string, string> = {};
+      for (const h of EXPECTED_HEADERS) rawSource[h] = get(row, h);
+
+      rows.push({
+        name,
+        groupName,
+        phone,
+        email,
+        rsvpStatus,
+        rsvpStatusRaw: statusRaw || null,
+        tags,
+        isChild,
+        age,
+        pin,
+        rawSource,
+      });
+    }
+
+    return rows;
+  },
+};

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -17,6 +17,7 @@ import {
   ShoppingBasket,
   Sparkles,
   Target,
+  Upload,
   Users,
   Wallet,
   Wrench,
@@ -763,6 +764,42 @@ export const HELP_ARTICLES: HelpArticle[] = [
     tips: [
       "RSVP individual continua funcionando — o link de grupo é alternativa, não substituto.",
       "Cada convidado pode estar em apenas um grupo.",
+      "Importou um CSV com a coluna 'Grupo' preenchida? Os grupos são criados automaticamente (e os existentes reaproveitados pelo nome) — basta abrir o grupo depois para preencher contato e copiar o link.",
+    ],
+  },
+  {
+    id: "guest-import-wedy",
+    title: "Importar lista do Wedy (e outros .xlsx)",
+    category: "guests",
+    keywords: ["importar", "wedy", "xlsx", "planilha", "migrar", "excel"],
+    icon: Upload,
+    summary:
+      "Trazer convidados de outros sistemas de planejamento sem retrabalho. Hoje: Wedy (XLSX).",
+    steps: [
+      {
+        title: "Acesse Convidados → Importar lista",
+        body: "Vai abrir /dashboard/guests/import. Selecione o arquivo .xlsx exportado do outro sistema (até 5 MB, 2000 linhas).",
+      },
+      {
+        title: "Confira o preview",
+        body: "O sistema mostra X novos, Y já existem (mesmo grupo) e Z divergem. Grupos, tags e PINs detectados aparecem listados.",
+      },
+      {
+        title: "Escolha como tratar duplicatas",
+        body: "Pular existentes (padrão, mais seguro), atualizar os existentes com os dados do arquivo, ou criar tudo (útil para homônimos em famílias diferentes).",
+      },
+      {
+        title: "Confirme",
+        body: "Tudo é gravado em uma transação. Tags e grupos novos são criados automaticamente. Tags 'Padrinhos', 'Madrinha', etc. marcam também a flag de padrinho.",
+      },
+    ],
+    tips: [
+      "Você ainda pode importar via texto colado: dentro da página de import há um link 'Prefere colar texto?'.",
+      "O Wedy traz tags com os nomes dos noivos — elas viram tags normais, mas o lado (NOIVO/NOIVA) precisa ser ajustado manualmente em cada convidado.",
+    ],
+    warnings: [
+      "Status fora do mapeamento conhecido (Sem resposta/Confirmado/Recusado/Talvez) é tratado como 'Convidado'.",
+      "O PIN do convite (4 dígitos do Wedy) é salvo só como referência. O link público continua usando o token do sistema.",
     ],
   },
   {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -35,6 +35,12 @@ export function rateLimit(
   return { ok: true, remaining: max - b.count, resetAt: b.resetAt };
 }
 
+/** Apenas para uso em testes. */
+export function __resetRateLimit(): void {
+  buckets.clear();
+  lastSweep = 0;
+}
+
 export function getClientIp(headers: Headers): string {
   const cf = headers.get("cf-connecting-ip");
   if (cf) return cf.trim();


### PR DESCRIPTION
## Summary

- Nova página `/dashboard/guests/import` para importar listas de convidados vindas de outros sistemas de planejamento. Primeira origem suportada: **Wedy** (XLSX). Arquitetura plugável (`src/lib/guest-importers/`) permite adicionar novos sistemas sem mexer na Server Action nem na UI.
- Schema ganha `GuestTag` (M:N), `Guest.age`, `GuestGroup.rsvpPin`. Fluxo em 2 passos (upload → preview com diff → commit) com 3 modos: pular existentes, atualizar pelo arquivo, ou criar tudo. Tudo em `prisma.$transaction` com AuditLog.
- Refactor do `bulkImportGuests` legado (texto colado): agora também cria/reaproveita `GuestGroup` automaticamente pelo nome da coluna "Grupo" — não há mais sincronização manual após import por texto.
- Pequeno UX: tela `/dashboard/guests/groups` ganha link **"Voltar para convidados"** no topo.

## Mudanças principais

| Área | Arquivos |
|------|----------|
| Schema Prisma | `prisma/schema.prisma` — novos `GuestTag`, `GuestTagOnGuest`; `Guest.age`, `GuestGroup.rsvpPin` |
| Validação | `src/lib/file-validation.ts` — `detectMagic` reconhece XLSX (magic ZIP), helper `assertGuestImportSize` (5 MB) |
| Importers plugáveis | `src/lib/guest-importers/{types,wedy,index}.ts` — interface `Importer`, parser Wedy |
| Cache de sessão | `src/lib/guest-import-cache.ts` — TTL 10min, hard cap 50, isolamento por userId |
| Server Actions | `src/app/actions/guestActions.ts` — `previewGuestImport`, `commitGuestImport` (+ `bulkImportGuests` refatorado) |
| UI | `src/app/dashboard/guests/import/{page,import-client,_components/...}.tsx` |
| Dep nova | `exceljs@^4.4` (server-only) |
| Docs | `docs/importacao-convidados.md` (novo) + atualizações em README, banco-de-dados, rsvp, help-content, changelog |

## Decisões de produto (já confirmadas com o owner)

1. **Tags** → model `GuestTag` (M:N). Tag "Padrinhos"/"Madrinha"/etc. (regex flexível) também marca `Guest.isPadrinho` via OR — nunca apaga marcação manual.
2. **PIN do convite** → `GuestGroup.rsvpPin` informativo apenas; link público continua usando `rsvpToken` cuid.
3. **Lado NOIVO/NOIVA** → `Guest.side` fica `null` no import (ajuste manual depois).
4. **Re-import** → preview com diff (`new` / `duplicate_same` / `duplicate_diff`) + escolha de modo (`CREATE_NEW_ONLY` / `UPSERT_BY_NAME` / `CREATE_ALL_DUPLICATES`).

## Verificação

- ✅ `npm run lint` sem novos warnings
- ✅ `npm run test:run` — **487/487** testes verdes (era 443; +44 novos)
- ✅ `npm run build` OK; rota `/dashboard/guests/import` no manifest
- ✅ Smoke test produção: rota protegida retorna 307 → `/login?callbackUrl=...`
- ✅ Parse do arquivo Wedy real bate: **139 linhas, 58 grupos, 9 tags, 58 PINs únicos, 12 crianças**

## Test plan

- [ ] `git checkout feat/guest-import-xlsx-wedy && npm i && npm run db:push`
- [ ] `npm run test:run` (esperado: 487 passando)
- [ ] `npm run dev` → login → `/dashboard/guests` → clicar **Importar lista**
- [ ] Subir um XLSX exportado do Wedy e conferir:
  - [ ] Contadores no preview batem com a planilha
  - [ ] Grupos detectados listados com PIN
  - [ ] Tags detectadas listadas
  - [ ] Tabela de amostra filtrável por classificação
- [ ] Confirmar import com modo **CREATE_NEW_ONLY**: toast com contagens
- [ ] Em `/dashboard/guests/groups`: grupos criados aparecem com `rsvpPin` exibido como referência
- [ ] Em `/dashboard/guests`: convidados com tag "Padrinhos" marcados como Padrinho; crianças com `isChild=true` e idade preenchida quando numérica
- [ ] Re-subir o mesmo arquivo: preview mostra `N já existem (mesmo grupo)`; escolher **UPSERT_BY_NAME** e re-confirmar → toast com `updated > 0`
- [ ] Conferir `AuditLog` (Prisma Studio): duas entradas `BULK_CREATE` com `source: "wedy"` e `mode`
- [ ] Fluxo legado de texto colado (link "Prefere colar texto?") continua funcionando

## Notas

- `exceljs` é dependência **server-only** — só usada dentro de Server Actions, não vai pro bundle do client.
- Tela de convidados ainda não está internacionalizada (AGENTS.md §6.7, lista pendente), por isso a página nova usa strings pt-BR diretas. Será revisitada quando o pacote i18n do dashboard chegar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)