### PR TITLE
feat(guests-import): suportar CSV exportado pelo próprio sistema + telefone por grupo no Wedy

### DIFF
--- a/docs/importacao-convidados.md
+++ b/docs/importacao-convidados.md
@@ -9,11 +9,14 @@ O sistema oferece **dois caminhos** para importar listas de convidados:
 
 ### Sistemas suportados
 
-| Origem | ID interno | Detecção |
-|--------|-----------|----------|
-| Wedy   | `wedy`    | Lê o header da primeira planilha; precisa ter ≥6 das 9 colunas conhecidas. |
+| Origem | ID interno | Formato | Detecção |
+|--------|-----------|---------|----------|
+| Wedy   | `wedy`    | .xlsx   | Lê o header da primeira planilha; precisa ter ≥6 das 9 colunas conhecidas. |
+| CSV exportado pelo próprio sistema | `internal-csv` | .csv | Header com `Nome`, `Status`, `Grupo` obrigatórios e ≥8 das 13 colunas exportadas pelo botão "CSV" em `/dashboard/guests`. |
 
-A detecção é automática quando o select de origem está em "Detectar automaticamente". O usuário pode forçar uma origem específica caso a planilha tenha sido editada e o header esteja parcialmente alterado.
+A detecção é automática quando o select de origem está em "Detectar automaticamente". O usuário pode forçar uma origem específica caso o arquivo tenha sido editado e o header esteja parcialmente alterado.
+
+A leitura do arquivo é feita por helpers compartilhados em [`src/lib/guest-importers/extract.ts`](../src/lib/guest-importers/extract.ts) (`extractXlsxRecords` via ExcelJS, `extractCsvRecords` com suporte a `,` / `;` / `\t`, aspas duplas e BOM). Cada `Importer` recebe os `records` já normalizados como `Record<string, string>[]` — não precisa mexer com formato de arquivo.
 
 ### Limites
 
@@ -40,13 +43,35 @@ Cada commit gera um registro em `AuditLog` (`entity=Guest`, `entityId=bulk-impor
 | Nome do convite | `GuestGroup.name` + `Guest.groupName` | Cria `GuestGroup` se não existir (lookup por nome exato). |
 | Nome completo do convidado | `Guest.name` | Truncado a 160 chars. Linha sem nome é descartada. |
 | Status | `Guest.rsvpStatus` | Mapeamento: `Sem resposta`/`Convidado`→`INVITED`, `Confirmado`/`Vai`→`CONFIRMED`, `Recusado`/`Não vai`→`DECLINED`, `Talvez`→`MAYBE`, `Não convidado`→`NOT_INVITED`. Desconhecidos viram `INVITED` com badge `*` no preview. |
-| Telefone | `Guest.phone` | Truncado a 40 chars. Comparação para diff usa só dígitos. |
-| E-mail | `Guest.email` | Truncado a 160 chars. Comparação case-insensitive. |
+| Telefone | `GuestGroup.contactPhone` (`contactsBelongToGroup=true`) | No Wedy o telefone aparece só na primeira linha de cada grupo (responsável). Vai para o GuestGroup, **não** para o Guest individual. `Guest.phone` fica `null` para todos os membros do grupo. Não sobrescreve `contactPhone` existente non-null. |
+| E-mail | `GuestGroup.contactEmail` (`contactsBelongToGroup=true`) | Mesma lógica do telefone. Nome do responsável vai para `GuestGroup.contactName`. |
 | Tags | `GuestTag` + `GuestTagOnGuest` | Split por vírgula, trim, máximo 20 tags por linha. Cada tag única vira `GuestTag` (case-insensitive no lookup). Tag bate regex `/^(padrinho\|padrinhos\|madrinha\|madrinhas\|padrinho\/madrinha)$/i` → marca `Guest.isPadrinho=true` (OR, nunca apaga). |
 | Faixa etária | `Guest.isChild` | `Criança`→true; demais valores→false. |
 | Idade exata | `Guest.age` | Apenas inteiros 0-17. `Idade desconhecida` e outras strings → null. |
 | Pin do convite | `GuestGroup.rsvpPin` | Aceita 4-8 chars alfanuméricos. **Informativo apenas** — o link público continua usando `rsvpToken` cuid. Em grupos que já existem, sobrescreve só quando o pin atual é null. |
 | (não importado) | `Guest.side` | Sempre `null`. O Wedy usa Tags com nomes dos noivos para indicar lado, mas isso não é universal — preencher manualmente depois. |
+
+## 2.1 Mapeamento CSV interno → schema
+
+O CSV exportado pelo botão "CSV" em `/dashboard/guests` tem 13 colunas:
+`Nome, Telefone, Email, Lado, Grupo, Status, +1 confirmados, Mesa, Restrições, Cidade, Padrinho, VIP, Criança`.
+
+| Coluna | Campo no sistema | Observações |
+|--------|------------------|-------------|
+| Nome | `Guest.name` | Obrigatório. |
+| Telefone / Email | `Guest.phone` / `Guest.email` | Cada linha tem dados próprios (`contactsBelongToGroup=false`). |
+| Lado | `Guest.side` | NOIVO/NOIVA/AMBOS; outros valores → `null`. |
+| Grupo | `GuestGroup.name` + `Guest.groupName` | Mesmo upsert do Wedy. |
+| Status | `Guest.rsvpStatus` | Labels pt-BR: `Não convidado`→NOT_INVITED, `Convidado`→INVITED, `Confirmado`→CONFIRMED, `Recusou`→DECLINED, `Talvez`→MAYBE. |
+| +1 confirmados | `Guest.plusOnesAllowed` | Inteiro 0-10. O round-trip popula `plusOnesAllowed` (não `plusOnesConfirmed`) — usuário confirma novamente para refletir intenção atual. |
+| Mesa | `Guest.tableNumber` | String até 20 chars. |
+| Restrições | `Guest.dietary` | Até 200 chars. |
+| Cidade | `Guest.city` | Até 80 chars. |
+| Padrinho | `Guest.isPadrinho` + tag virtual `Padrinhos` | `sim` ativa a flag e cria/reusa a tag. |
+| VIP | `Guest.isVIP` | `sim` → true. |
+| Criança | `Guest.isChild` | `sim` → true. |
+
+Este Importer fecha o ciclo **exportar CSV → reimportar** (útil em backups manuais ou migrações entre instâncias).
 
 ## 3. Modos de commit
 

--- a/src/app/actions/guestActions.test.ts
+++ b/src/app/actions/guestActions.test.ts
@@ -628,4 +628,88 @@ describe("commitGuestImport", () => {
     expect(payload).toContain('"source":"wedy"');
     expect(payload).toContain('"mode":"CREATE_NEW_ONLY"');
   });
+
+  it("Wedy: phone/email vão para GuestGroup.contact* e Guest.phone fica null (contactsBelongToGroup)", async () => {
+    const token = await uploadFile([
+      ["Família X", "Ana", "Sem resposta", "+5511999990000", "ana@x.com", "", "Adulto", "", ""],
+      ["Família X", "Bia", "Sem resposta", "", "", "", "Adulto", "", ""],
+    ]);
+    await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+
+    const grpCall = prismaMock.guestGroup.create.mock.calls[0][0] as {
+      data: { name: string; contactPhone: string | null; contactEmail: string | null; contactName: string | null };
+    };
+    expect(grpCall.data).toMatchObject({
+      name: "Família X",
+      contactPhone: "+5511999990000",
+      contactEmail: "ana@x.com",
+      contactName: "Ana",
+    });
+
+    const guestCalls = prismaMock.guest.create.mock.calls.map(
+      (c) => (c[0] as { data: { name: string; phone: string | null; email: string | null } }).data,
+    );
+    for (const g of guestCalls) {
+      expect(g.phone).toBeNull();
+      expect(g.email).toBeNull();
+    }
+  });
+
+  it("Wedy: não sobrescreve contactPhone/contactEmail existente non-null do grupo", async () => {
+    prismaMock.guestGroup.findMany.mockResolvedValueOnce([
+      {
+        id: "g1",
+        name: "Família X",
+        rsvpPin: null,
+        contactPhone: "0000",
+        contactEmail: "old@x.com",
+        contactName: "Antigo",
+      },
+    ] as never);
+    const token = await uploadFile([
+      ["Família X", "Ana", "Sem resposta", "+5511999990000", "novo@x.com", "", "Adulto", "", ""],
+    ]);
+    await commitGuestImport({ importToken: token, mode: "CREATE_NEW_ONLY" });
+    expect(prismaMock.guestGroup.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("previewGuestImport (internal CSV)", () => {
+  beforeEach(() => {
+    prismaMock.guest.findMany.mockResolvedValue([] as never);
+  });
+
+  function csvFile(text: string, filename = "export.csv"): File {
+    return new File([text], filename, { type: "text/csv" });
+  }
+
+  function importForm(file: File, source = "AUTO"): FormData {
+    const fd = new FormData();
+    fd.set("file", file);
+    fd.set("source", source);
+    return fd;
+  }
+
+  it("detecta CSV interno pelo header e classifica linhas", async () => {
+    const csv = [
+      "Nome,Telefone,Email,Lado,Grupo,Status,+1 confirmados,Mesa,Restrições,Cidade,Padrinho,VIP,Criança",
+      `"Maria","11999","maria@x","NOIVA","Família A","Confirmado","2","5","","São Paulo","sim","","" `,
+      `"João","","","NOIVO","Família A","Convidado","0","","","","","",""`,
+    ].join("\n");
+
+    const r = await previewGuestImport(undefined, importForm(csvFile(csv)));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data!.source).toBe("internal-csv");
+      expect(r.data!.totalRows).toBe(2);
+      expect(r.data!.breakdown.new).toBe(2);
+      expect(r.data!.tagsPreview).toContain("Padrinhos");
+    }
+  });
+
+  it("rejeita arquivo .csv sem nenhum header reconhecido", async () => {
+    const csv = "x,y,z\n1,2,3";
+    const r = await previewGuestImport(undefined, importForm(csvFile(csv)));
+    expect(r.success).toBe(false);
+  });
 });

--- a/src/app/actions/guestActions.ts
+++ b/src/app/actions/guestActions.ts
@@ -16,6 +16,9 @@ import {
 import {
   IMPORTERS,
   detectImporter,
+  extractCsvRecords,
+  extractXlsxRecords,
+  type ExtractedSheet,
   type Importer,
   type ImporterId,
   type ParsedRow,
@@ -436,25 +439,40 @@ export async function previewGuestImport(
   try {
     const bytes = Buffer.from(await file.arrayBuffer());
     assertGuestImportSize(bytes.length);
-    const detected = detectMagic(bytes);
-    if (detected !== "xlsx") {
-      throw new FileValidationError("Apenas arquivos .xlsx são suportados nesta versão.");
+
+    const filename = (file.name ?? "").toLowerCase();
+    const isCsvByName = filename.endsWith(".csv");
+    const isCsvByMime =
+      file.type === "text/csv" || file.type === "application/csv";
+    const detectedMagic = detectMagic(bytes);
+    const treatAsCsv = (isCsvByName || isCsvByMime) && detectedMagic !== "xlsx";
+
+    let sheet: ExtractedSheet;
+    if (treatAsCsv) {
+      sheet = extractCsvRecords(bytes.toString("utf8"));
+    } else if (detectedMagic === "xlsx") {
+      sheet = await extractXlsxRecords(bytes);
+    } else {
+      throw new FileValidationError(
+        "Formato não suportado. Use .xlsx (Wedy) ou .csv (exportação do próprio sistema).",
+      );
     }
 
     let importer: Importer | null = null;
     if (sourceParam.data === "AUTO") {
-      importer = await detectImporter(bytes);
+      importer = detectImporter(sheet.records, sheet.headers);
       if (!importer) {
         return {
           success: false,
-          error: "Não foi possível identificar a planilha. Suportados: Wedy.",
+          error:
+            "Não foi possível identificar o formato. Suportados: Wedy (.xlsx) ou CSV exportado pelo próprio sistema.",
         };
       }
     } else {
       importer = IMPORTERS[sourceParam.data];
     }
 
-    const rows = await importer.parse(bytes);
+    const rows = importer.parseRecords(sheet.records);
     if (rows.length === 0) {
       return { success: false, error: "Nenhuma linha válida encontrada na planilha." };
     }
@@ -614,42 +632,122 @@ export async function commitGuestImport(input: {
         }
 
         // 2) Grupos
+        const importer = IMPORTERS[entry.source];
+        const contactsToGroup = importer?.contactsBelongToGroup === true;
+
         const groupNames = Array.from(
           new Set(entry.rows.map((r) => r.groupName).filter((n): n is string => !!n)),
         );
         const pinByGroupName = new Map<string, string>();
+        type GroupContact = {
+          phone?: string;
+          email?: string;
+          contactName?: string;
+        };
+        const contactByGroupName = new Map<string, GroupContact>();
         for (const r of entry.rows) {
-          if (r.groupName && r.pin && !pinByGroupName.has(r.groupName)) {
+          if (!r.groupName) continue;
+          if (r.pin && !pinByGroupName.has(r.groupName)) {
             pinByGroupName.set(r.groupName, r.pin);
           }
+          if (contactsToGroup) {
+            const cur = contactByGroupName.get(r.groupName) ?? {};
+            if (!cur.phone && r.phone) {
+              cur.phone = r.phone;
+              cur.contactName ??= r.name;
+            }
+            if (!cur.email && r.email) {
+              cur.email = r.email;
+              cur.contactName ??= r.name;
+            }
+            contactByGroupName.set(r.groupName, cur);
+          }
         }
-        const groupByName = new Map<string, { id: string; rsvpPin: string | null }>();
+
+        const groupByName = new Map<
+          string,
+          {
+            id: string;
+            rsvpPin: string | null;
+            contactPhone: string | null;
+            contactEmail: string | null;
+            contactName: string | null;
+          }
+        >();
         if (groupNames.length > 0) {
           const existingGroups = await tx.guestGroup.findMany({
             where: { deletedAt: null, name: { in: groupNames } },
-            select: { id: true, name: true, rsvpPin: true },
+            select: {
+              id: true,
+              name: true,
+              rsvpPin: true,
+              contactPhone: true,
+              contactEmail: true,
+              contactName: true,
+            },
           });
           for (const g of existingGroups) {
-            groupByName.set(g.name, { id: g.id, rsvpPin: g.rsvpPin });
+            groupByName.set(g.name, {
+              id: g.id,
+              rsvpPin: g.rsvpPin,
+              contactPhone: g.contactPhone,
+              contactEmail: g.contactEmail,
+              contactName: g.contactName,
+            });
           }
         }
         let groupsCreated = 0;
         for (const name of groupNames) {
           if (!groupByName.has(name)) {
+            const contact = contactByGroupName.get(name);
             const created = await tx.guestGroup.create({
-              data: { name, rsvpPin: pinByGroupName.get(name) ?? null },
+              data: {
+                name,
+                rsvpPin: pinByGroupName.get(name) ?? null,
+                contactPhone: contact?.phone ?? null,
+                contactEmail: contact?.email ?? null,
+                contactName: contact?.contactName ?? null,
+              },
             });
-            groupByName.set(name, { id: created.id, rsvpPin: created.rsvpPin });
+            groupByName.set(name, {
+              id: created.id,
+              rsvpPin: created.rsvpPin,
+              contactPhone: created.contactPhone,
+              contactEmail: created.contactEmail,
+              contactName: created.contactName,
+            });
             groupsCreated++;
           } else {
             const existing = groupByName.get(name)!;
+            const contact = contactByGroupName.get(name);
+            const patch: {
+              rsvpPin?: string;
+              contactPhone?: string;
+              contactEmail?: string;
+              contactName?: string;
+            } = {};
             if (!existing.rsvpPin && pinByGroupName.has(name)) {
-              const newPin = pinByGroupName.get(name)!;
-              await tx.guestGroup.update({
+              patch.rsvpPin = pinByGroupName.get(name)!;
+            }
+            if (contactsToGroup && contact) {
+              if (!existing.contactPhone && contact.phone) patch.contactPhone = contact.phone;
+              if (!existing.contactEmail && contact.email) patch.contactEmail = contact.email;
+              if (!existing.contactName && contact.contactName) {
+                patch.contactName = contact.contactName;
+              }
+            }
+            if (Object.keys(patch).length > 0) {
+              const updated = await tx.guestGroup.update({
                 where: { id: existing.id },
-                data: { rsvpPin: newPin },
+                data: patch,
               });
-              existing.rsvpPin = newPin;
+              groupByName.set(name, {
+                id: updated.id,
+                rsvpPin: updated.rsvpPin,
+                contactPhone: updated.contactPhone,
+                contactEmail: updated.contactEmail,
+                contactName: updated.contactName,
+              });
             }
           }
         }
@@ -685,6 +783,11 @@ export async function commitGuestImport(input: {
             .map((t) => tagIdByLowerName.get(t.toLowerCase()))
             .filter((id): id is string => !!id);
 
+          // Quando contatos pertencem ao grupo (ex.: Wedy), o telefone/email
+          // não fica no Guest; foi para GuestGroup.contactPhone/contactEmail.
+          const guestPhone = contactsToGroup ? null : row.phone;
+          const guestEmail = contactsToGroup ? null : row.email;
+
           if (sameGroup && parsed.data.mode === "CREATE_NEW_ONLY") {
             skipped++;
             continue;
@@ -694,12 +797,18 @@ export async function commitGuestImport(input: {
             await tx.guest.update({
               where: { id: sameGroup.id },
               data: {
-                phone: row.phone ?? undefined,
-                email: row.email ?? undefined,
+                phone: guestPhone ?? undefined,
+                email: guestEmail ?? undefined,
                 rsvpStatus: row.rsvpStatus,
                 isChild: row.isChild,
                 age: row.age,
                 isPadrinho: padrinhoFlag ? true : undefined,
+                isVIP: row.isVIP === true ? true : undefined,
+                side: row.side ?? undefined,
+                plusOnesAllowed: row.plusOnesAllowed ?? undefined,
+                tableNumber: row.tableNumber ?? undefined,
+                dietary: row.dietary ?? undefined,
+                city: row.city ?? undefined,
                 groupId: groupId ?? undefined,
                 groupName: row.groupName ?? undefined,
               },
@@ -717,15 +826,20 @@ export async function commitGuestImport(input: {
           const newGuest = await tx.guest.create({
             data: {
               name: row.name,
-              phone: row.phone,
-              email: row.email,
-              side: null,
+              phone: guestPhone,
+              email: guestEmail,
+              side: row.side ?? null,
               groupName: row.groupName,
               groupId,
               rsvpStatus: row.rsvpStatus,
               isChild: row.isChild,
               age: row.age,
               isPadrinho: padrinhoFlag,
+              isVIP: row.isVIP === true ? true : false,
+              plusOnesAllowed: row.plusOnesAllowed ?? 0,
+              tableNumber: row.tableNumber ?? null,
+              dietary: row.dietary ?? null,
+              city: row.city ?? null,
             },
           });
           if (tagIds.length > 0) {

--- a/src/app/dashboard/guests/import/import-client.tsx
+++ b/src/app/dashboard/guests/import/import-client.tsx
@@ -151,17 +151,18 @@ export function GuestImportClient() {
         >
           <div>
             <label className="mb-1 block text-sm font-medium text-zinc-400">
-              Arquivo (.xlsx)
+              Arquivo (.xlsx ou .csv)
             </label>
             <input
               type="file"
-              accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              accept=".xlsx,.csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
               required
               onChange={(e) => setFile(e.target.files?.[0] ?? null)}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 file:mr-3 file:rounded-lg file:border-0 file:bg-rose-500/20 file:px-3 file:py-1.5 file:text-rose-200 hover:file:bg-rose-500/30"
             />
             <p className="mt-1 text-xs text-zinc-500">
-              Tamanho máximo: 5 MB. Até 2000 linhas por importação.
+              Tamanho máximo: 5 MB. Até 2000 linhas por importação. Wedy exporta em
+              .xlsx; o próprio sistema exporta em .csv (botão CSV em /dashboard/guests).
             </p>
           </div>
 

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,9 +9,10 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: "0.6.2",
     date: "2026-05-26",
     highlights: [
-      "📥 Importação de convidados por arquivo XLSX em /dashboard/guests/import. Suporta planilhas do Wedy out-of-the-box, com preview de novos vs. duplicados, lista de grupos detectados, PINs preservados e modo configurável (pular existentes / atualizar / criar tudo).",
+      "📥 Importação de convidados por arquivo em /dashboard/guests/import. Suporta planilhas do Wedy (.xlsx) e o CSV exportado pelo próprio sistema (.csv) — fecha o ciclo de export/reimport. Preview de novos vs. duplicados, lista de grupos detectados, PINs preservados e modo configurável (pular existentes / atualizar / criar tudo).",
       "🏷️ Novo model GuestTag (M:N). Tags vindas do import viram tags reais; 'Padrinhos', 'Madrinha' etc. ativam também a flag isPadrinho.",
       "🔢 GuestGroup agora tem rsvpPin (4-8 chars, informativo, vindo do convite original) e Guest ganhou age (idade exata para crianças).",
+      "📞 No import do Wedy o telefone/email do responsável vai para GuestGroup.contactPhone/contactEmail (não para o Guest individual), refletindo que no Wedy o contato é por convite/família.",
     ],
   },
   {

--- a/src/lib/guest-importers/extract.test.ts
+++ b/src/lib/guest-importers/extract.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import ExcelJS from "exceljs";
+import { extractCsvRecords, extractXlsxRecords } from "./extract";
+
+describe("extractCsvRecords", () => {
+  it("detecta vírgula, parseia header + linhas", () => {
+    const csv = `Nome,Email,Grupo\nMaria,maria@x,Família A\nJoão,,Família A`;
+    const { headers, records } = extractCsvRecords(csv);
+    expect(headers).toEqual(["Nome", "Email", "Grupo"]);
+    expect(records).toEqual([
+      { Nome: "Maria", Email: "maria@x", Grupo: "Família A" },
+      { Nome: "João", Email: "", Grupo: "Família A" },
+    ]);
+  });
+
+  it("detecta ponto-vírgula", () => {
+    const csv = `Nome;Email\nMaria;maria@x`;
+    const { headers, records } = extractCsvRecords(csv);
+    expect(headers).toEqual(["Nome", "Email"]);
+    expect(records[0]).toEqual({ Nome: "Maria", Email: "maria@x" });
+  });
+
+  it("respeita aspas duplas com vírgula interna", () => {
+    const csv = `Nome,Tags\n"Maria","Padrinhos, Família"`;
+    const { records } = extractCsvRecords(csv);
+    expect(records[0].Tags).toBe("Padrinhos, Família");
+  });
+
+  it('aspas duplas escapadas ("")', () => {
+    const csv = `Nome\n"Ana ""A"" Silva"`;
+    const { records } = extractCsvRecords(csv);
+    expect(records[0].Nome).toBe('Ana "A" Silva');
+  });
+
+  it("ignora BOM UTF-8 no início", () => {
+    const csv = `﻿Nome,Email\nMaria,maria@x`;
+    const { headers } = extractCsvRecords(csv);
+    expect(headers).toEqual(["Nome", "Email"]);
+  });
+
+  it("ignora linhas totalmente vazias", () => {
+    const csv = `Nome\nMaria\n\nJoão\n`;
+    const { records } = extractCsvRecords(csv);
+    expect(records.map((r) => r.Nome)).toEqual(["Maria", "João"]);
+  });
+
+  it("aceita quebra de linha dentro de aspas", () => {
+    const csv = `Nome,Notes\n"Maria","linha 1\nlinha 2"`;
+    const { records } = extractCsvRecords(csv);
+    expect(records[0].Notes).toBe("linha 1\nlinha 2");
+  });
+
+  it("retorna vazio para entrada vazia", () => {
+    const { headers, records } = extractCsvRecords("");
+    expect(headers).toEqual([]);
+    expect(records).toEqual([]);
+  });
+});
+
+describe("extractXlsxRecords", () => {
+  it("lê primeira sheet com header + linhas", async () => {
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet("S");
+    ws.addRow(["Nome", "Email"]);
+    ws.addRow(["Maria", "maria@x"]);
+    ws.addRow(["João", ""]);
+    const buf = Buffer.from((await wb.xlsx.writeBuffer()) as ArrayBuffer);
+
+    const { headers, records } = await extractXlsxRecords(buf);
+    expect(headers).toEqual(["Nome", "Email"]);
+    expect(records).toEqual([
+      { Nome: "Maria", Email: "maria@x" },
+      { Nome: "João", Email: "" },
+    ]);
+  });
+
+  it("retorna estrutura vazia se a planilha não tem worksheets", async () => {
+    const wb = new ExcelJS.Workbook();
+    const buf = Buffer.from((await wb.xlsx.writeBuffer()) as ArrayBuffer);
+    const { records } = await extractXlsxRecords(buf);
+    expect(records).toEqual([]);
+  });
+});

--- a/src/lib/guest-importers/extract.ts
+++ b/src/lib/guest-importers/extract.ts
@@ -1,0 +1,143 @@
+import ExcelJS from "exceljs";
+import { FileValidationError } from "@/lib/file-validation";
+import type { RecordRow } from "./types";
+
+export type ExtractedSheet = {
+  headers: string[];
+  records: RecordRow[];
+};
+
+function cellToString(value: ExcelJS.CellValue): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object" && "text" in value && typeof value.text === "string") {
+    return value.text;
+  }
+  if (typeof value === "object" && "richText" in value && Array.isArray(value.richText)) {
+    return value.richText.map((rt) => rt.text).join("");
+  }
+  if (typeof value === "object" && "result" in value) {
+    return cellToString(value.result as ExcelJS.CellValue);
+  }
+  return String(value);
+}
+
+export async function extractXlsxRecords(buf: Buffer): Promise<ExtractedSheet> {
+  let workbook: ExcelJS.Workbook;
+  try {
+    workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buf as unknown as ArrayBuffer);
+  } catch {
+    throw new FileValidationError("Não foi possível ler o arquivo XLSX.");
+  }
+  const worksheet = workbook.worksheets[0];
+  if (!worksheet) return { headers: [], records: [] };
+
+  const headerRow = worksheet.getRow(1);
+  const rawHeaders = (headerRow.values as unknown[]).slice(1);
+  const headers = rawHeaders.map((v) => cellToString(v as ExcelJS.CellValue).trim());
+
+  const records: RecordRow[] = [];
+  const totalRows = worksheet.actualRowCount;
+  for (let r = 2; r <= totalRows; r++) {
+    const row = worksheet.getRow(r);
+    const rec: RecordRow = {};
+    headers.forEach((h, idx) => {
+      if (!h) return;
+      rec[h] = cellToString(row.getCell(idx + 1).value).trim();
+    });
+    records.push(rec);
+  }
+  return { headers, records };
+}
+
+function detectCsvSeparator(line: string): "," | ";" | "\t" {
+  const tabCount = (line.match(/\t/g) ?? []).length;
+  const commaCount = (line.match(/,/g) ?? []).length;
+  const semiCount = (line.match(/;/g) ?? []).length;
+  if (tabCount >= commaCount && tabCount >= semiCount && tabCount > 0) return "\t";
+  if (semiCount > commaCount) return ";";
+  return ",";
+}
+
+/** Parser CSV simples com suporte a aspas duplas (`""` escape). */
+function parseCsvLine(line: string, sep: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cur += ch;
+      }
+    } else {
+      if (ch === '"' && cur.length === 0) {
+        inQuotes = true;
+      } else if (ch === sep) {
+        out.push(cur);
+        cur = "";
+      } else {
+        cur += ch;
+      }
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+export function extractCsvRecords(text: string): ExtractedSheet {
+  // BOM UTF-8 (Excel costuma exportar com BOM).
+  const clean = text.replace(/^﻿/, "");
+  // Reagrupa linhas considerando quebras dentro de aspas.
+  const lines: string[] = [];
+  let buffer = "";
+  let inQuotes = false;
+  for (let i = 0; i < clean.length; i++) {
+    const ch = clean[i];
+    if (ch === '"') {
+      if (inQuotes && clean[i + 1] === '"') {
+        buffer += '""';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+        buffer += ch;
+      }
+    } else if ((ch === "\n" || ch === "\r") && !inQuotes) {
+      if (ch === "\r" && clean[i + 1] === "\n") i++;
+      if (buffer.length > 0) {
+        lines.push(buffer);
+        buffer = "";
+      }
+    } else {
+      buffer += ch;
+    }
+  }
+  if (buffer.length > 0) lines.push(buffer);
+
+  if (lines.length === 0) return { headers: [], records: [] };
+  const sep = detectCsvSeparator(lines[0]);
+  const headers = parseCsvLine(lines[0], sep).map((h) => h.trim());
+
+  const records: RecordRow[] = [];
+  for (let r = 1; r < lines.length; r++) {
+    const parts = parseCsvLine(lines[r], sep);
+    if (parts.every((p) => p.trim() === "")) continue;
+    const rec: RecordRow = {};
+    headers.forEach((h, idx) => {
+      if (!h) return;
+      rec[h] = (parts[idx] ?? "").trim();
+    });
+    records.push(rec);
+  }
+  return { headers, records };
+}

--- a/src/lib/guest-importers/index.ts
+++ b/src/lib/guest-importers/index.ts
@@ -1,24 +1,33 @@
 import { wedyImporter } from "./wedy";
-import type { Importer, ImporterId } from "./types";
+import { internalCsvImporter } from "./internal-csv";
+import type { Importer, ImporterId, RecordRow } from "./types";
 
 export const IMPORTERS: Record<ImporterId, Importer> = {
   wedy: wedyImporter,
+  "internal-csv": internalCsvImporter,
 };
 
 export const IMPORTER_OPTIONS: Array<{ id: ImporterId; label: string }> = Object.values(
   IMPORTERS,
 ).map((imp) => ({ id: imp.id, label: imp.label }));
 
-export async function detectImporter(buf: Buffer): Promise<Importer | null> {
+export function detectImporter(records: RecordRow[], headers: string[]): Importer | null {
   for (const importer of Object.values(IMPORTERS)) {
     try {
-      const ok = await importer.detect(buf);
-      if (ok) return importer;
+      if (importer.detect(records, headers)) return importer;
     } catch {
-      // continua tentando os próximos
+      // ignora e tenta o próximo
     }
   }
   return null;
 }
 
-export type { Importer, ImporterId, ParsedRow, ImportedRsvpStatus } from "./types";
+export { extractXlsxRecords, extractCsvRecords } from "./extract";
+export type { ExtractedSheet } from "./extract";
+export type {
+  Importer,
+  ImporterId,
+  ParsedRow,
+  ImportedRsvpStatus,
+  RecordRow,
+} from "./types";

--- a/src/lib/guest-importers/internal-csv.test.ts
+++ b/src/lib/guest-importers/internal-csv.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import { internalCsvImporter } from "./internal-csv";
+import type { RecordRow } from "./types";
+
+const FULL_HEADERS = [
+  "Nome",
+  "Telefone",
+  "Email",
+  "Lado",
+  "Grupo",
+  "Status",
+  "+1 confirmados",
+  "Mesa",
+  "Restrições",
+  "Cidade",
+  "Padrinho",
+  "VIP",
+  "Criança",
+];
+
+function rec(values: Record<string, string>): RecordRow {
+  const r: RecordRow = {};
+  for (const h of FULL_HEADERS) r[h] = values[h] ?? "";
+  return r;
+}
+
+describe("internalCsvImporter.detect", () => {
+  it("detecta header completo", () => {
+    expect(internalCsvImporter.detect([], FULL_HEADERS)).toBe(true);
+  });
+
+  it("detecta com 8 colunas (mínimo) — desde que tenha Nome, Status e Grupo", () => {
+    expect(
+      internalCsvImporter.detect([], [
+        "Nome",
+        "Telefone",
+        "Email",
+        "Grupo",
+        "Status",
+        "Mesa",
+        "Cidade",
+        "VIP",
+      ]),
+    ).toBe(true);
+  });
+
+  it("não detecta sem Nome/Status/Grupo obrigatórios", () => {
+    expect(
+      internalCsvImporter.detect([], [
+        "Nome",
+        "Telefone",
+        "Email",
+        "Lado",
+        "Mesa",
+        "Restrições",
+        "Cidade",
+        "VIP",
+      ]),
+    ).toBe(false);
+  });
+
+  it("não detecta planilha do Wedy (headers diferentes)", () => {
+    expect(
+      internalCsvImporter.detect([], [
+        "Nome do convite",
+        "Nome completo do convidado",
+        "Status",
+        "Telefone",
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("internalCsvImporter.parseRecords", () => {
+  it("mapeia uma linha completa", () => {
+    const [r] = internalCsvImporter.parseRecords([
+      rec({
+        Nome: "Maria Silva",
+        Telefone: "11999990000",
+        Email: "maria@x.com",
+        Lado: "NOIVA",
+        Grupo: "Família Silva",
+        Status: "Confirmado",
+        "+1 confirmados": "2",
+        Mesa: "5",
+        Restrições: "vegetariana",
+        Cidade: "São Paulo",
+        Padrinho: "sim",
+        VIP: "sim",
+        Criança: "",
+      }),
+    ]);
+    expect(r).toMatchObject({
+      name: "Maria Silva",
+      groupName: "Família Silva",
+      phone: "11999990000",
+      email: "maria@x.com",
+      side: "NOIVA",
+      rsvpStatus: "CONFIRMED",
+      rsvpStatusRaw: "Confirmado",
+      isVIP: true,
+      isChild: false,
+      plusOnesAllowed: 2,
+      tableNumber: "5",
+      dietary: "vegetariana",
+      city: "São Paulo",
+      pin: null,
+      age: null,
+    });
+    expect(r.tags).toEqual(["Padrinhos"]);
+  });
+
+  it("mapeia status pt-BR (Recusou, Convidado, Talvez, Não convidado)", () => {
+    const rows = internalCsvImporter.parseRecords([
+      rec({ Nome: "A", Grupo: "G", Status: "Recusou" }),
+      rec({ Nome: "B", Grupo: "G", Status: "Convidado" }),
+      rec({ Nome: "C", Grupo: "G", Status: "Talvez" }),
+      rec({ Nome: "D", Grupo: "G", Status: "Não convidado" }),
+    ]);
+    expect(rows.map((r) => r.rsvpStatus)).toEqual([
+      "DECLINED",
+      "INVITED",
+      "MAYBE",
+      "NOT_INVITED",
+    ]);
+  });
+
+  it("Padrinho='' não vira tag Padrinhos", () => {
+    const [r] = internalCsvImporter.parseRecords([
+      rec({ Nome: "X", Grupo: "G", Status: "Convidado", Padrinho: "" }),
+    ]);
+    expect(r.tags).toEqual([]);
+  });
+
+  it("isChild=true quando coluna Criança='sim'", () => {
+    const [r] = internalCsvImporter.parseRecords([
+      rec({ Nome: "K", Grupo: "G", Status: "Convidado", Criança: "sim" }),
+    ]);
+    expect(r.isChild).toBe(true);
+  });
+
+  it("ignora Lado inválido", () => {
+    const [r] = internalCsvImporter.parseRecords([
+      rec({ Nome: "X", Grupo: "G", Status: "Convidado", Lado: "ABC" }),
+    ]);
+    expect(r.side).toBeNull();
+  });
+
+  it("plusOnesAllowed só aceita 0-10 inteiro", () => {
+    const rows = internalCsvImporter.parseRecords([
+      rec({ Nome: "A", Grupo: "G", Status: "Convidado", "+1 confirmados": "11" }),
+      rec({ Nome: "B", Grupo: "G", Status: "Convidado", "+1 confirmados": "abc" }),
+      rec({ Nome: "C", Grupo: "G", Status: "Convidado", "+1 confirmados": "3" }),
+    ]);
+    expect(rows[0].plusOnesAllowed).toBeUndefined();
+    expect(rows[1].plusOnesAllowed).toBeUndefined();
+    expect(rows[2].plusOnesAllowed).toBe(3);
+  });
+
+  it("descarta linha sem nome", () => {
+    const rows = internalCsvImporter.parseRecords([
+      rec({ Nome: "  ", Grupo: "G", Status: "Convidado" }),
+      rec({ Nome: "Ana", Grupo: "G", Status: "Convidado" }),
+    ]);
+    expect(rows.map((r) => r.name)).toEqual(["Ana"]);
+  });
+
+  it("indica que contatos NÃO pertencem ao grupo (cada linha tem dados próprios)", () => {
+    expect(internalCsvImporter.contactsBelongToGroup).toBe(false);
+  });
+});

--- a/src/lib/guest-importers/internal-csv.ts
+++ b/src/lib/guest-importers/internal-csv.ts
@@ -1,0 +1,114 @@
+import type { GuestSide, Importer, ImportedRsvpStatus, ParsedRow, RecordRow } from "./types";
+
+const EXPECTED_HEADERS = [
+  "Nome",
+  "Telefone",
+  "Email",
+  "Lado",
+  "Grupo",
+  "Status",
+  "+1 confirmados",
+  "Mesa",
+  "Restrições",
+  "Cidade",
+  "Padrinho",
+  "VIP",
+  "Criança",
+] as const;
+
+// Labels que o próprio sistema usa em RSVP_LABEL no client.
+const STATUS_MAP: Record<string, ImportedRsvpStatus> = {
+  "não convidado": "NOT_INVITED",
+  "nao convidado": "NOT_INVITED",
+  "convidado": "INVITED",
+  "confirmado": "CONFIRMED",
+  "confirmada": "CONFIRMED",
+  "recusou": "DECLINED",
+  "recusado": "DECLINED",
+  "talvez": "MAYBE",
+};
+
+function get(rec: RecordRow, header: string): string {
+  return (rec[header] ?? "").trim();
+}
+
+function parseBool(v: string): boolean {
+  const n = v.trim().toLowerCase();
+  return n === "sim" || n === "true" || n === "1" || n === "yes";
+}
+
+function parseSide(v: string): GuestSide | null {
+  const n = v.trim().toUpperCase();
+  return n === "NOIVO" || n === "NOIVA" || n === "AMBOS" ? n : null;
+}
+
+export const internalCsvImporter: Importer = {
+  id: "internal-csv",
+  label: "CSV exportado pelo próprio sistema",
+  contactsBelongToGroup: false,
+
+  detect(_records, headers) {
+    // Header obrigatório: deve ter Nome, Status, Grupo e pelo menos 8 das 13.
+    const must = ["Nome", "Status", "Grupo"];
+    if (!must.every((h) => headers.includes(h))) return false;
+    const matches = EXPECTED_HEADERS.filter((h) => headers.includes(h)).length;
+    return matches >= 8;
+  },
+
+  parseRecords(records) {
+    const rows: ParsedRow[] = [];
+    for (const rec of records) {
+      const name = get(rec, "Nome").slice(0, 160);
+      if (!name) continue;
+
+      const groupName = get(rec, "Grupo").slice(0, 80) || null;
+      const phone = get(rec, "Telefone").slice(0, 40) || null;
+      const email = get(rec, "Email").slice(0, 160) || null;
+      const statusRaw = get(rec, "Status");
+      const statusKey = statusRaw.toLowerCase();
+      const rsvpStatus = STATUS_MAP[statusKey] ?? "INVITED";
+      const side = parseSide(get(rec, "Lado"));
+      const isChild = parseBool(get(rec, "Criança"));
+      const isVIP = parseBool(get(rec, "VIP"));
+      const isPadrinhoCol = parseBool(get(rec, "Padrinho"));
+
+      const plusStr = get(rec, "+1 confirmados");
+      const plusNum = /^\d{1,2}$/.test(plusStr) ? parseInt(plusStr, 10) : null;
+      const plusOnesAllowed =
+        plusNum != null && plusNum >= 0 && plusNum <= 10 ? plusNum : undefined;
+
+      const tableNumber = get(rec, "Mesa").slice(0, 20) || null;
+      const dietary = get(rec, "Restrições").slice(0, 200) || null;
+      const city = get(rec, "Cidade").slice(0, 80) || null;
+
+      // Reaproveita "Padrinho" da coluna como uma tag virtual para o pipeline
+      // de tags + isPadrinho na Server Action (commitGuestImport). Idempotente
+      // com a regex flexível usada lá.
+      const tags = isPadrinhoCol ? ["Padrinhos"] : [];
+
+      const rawSource: Record<string, string> = {};
+      for (const h of EXPECTED_HEADERS) rawSource[h] = get(rec, h);
+
+      rows.push({
+        name,
+        groupName,
+        phone,
+        email,
+        rsvpStatus,
+        rsvpStatusRaw: statusRaw || null,
+        tags,
+        isChild,
+        age: null,
+        pin: null,
+        rawSource,
+        side,
+        isVIP,
+        plusOnesAllowed,
+        tableNumber,
+        dietary,
+        city,
+      });
+    }
+    return rows;
+  },
+};

--- a/src/lib/guest-importers/types.ts
+++ b/src/lib/guest-importers/types.ts
@@ -5,6 +5,8 @@ export type ImportedRsvpStatus =
   | "DECLINED"
   | "MAYBE";
 
+export type GuestSide = "NOIVO" | "NOIVA" | "AMBOS";
+
 export type ParsedRow = {
   name: string;
   groupName: string | null;
@@ -17,13 +19,28 @@ export type ParsedRow = {
   age: number | null;
   pin: string | null;
   rawSource: Record<string, string>;
+  // Campos opcionais que só alguns importers preenchem.
+  side?: GuestSide | null;
+  isVIP?: boolean;
+  plusOnesAllowed?: number;
+  tableNumber?: string | null;
+  dietary?: string | null;
+  city?: string | null;
 };
 
-export type ImporterId = "wedy";
+export type ImporterId = "wedy" | "internal-csv";
+
+export type RecordRow = Record<string, string>;
 
 export type Importer = {
   id: ImporterId;
   label: string;
-  detect(buf: Buffer): Promise<boolean>;
-  parse(buf: Buffer): Promise<ParsedRow[]>;
+  /** Quando true, contatos (phone/email/contactName) da primeira linha
+   *  com dados preenchidos viram contato do GuestGroup, e os Guests
+   *  individuais ficam sem phone/email próprios. */
+  contactsBelongToGroup: boolean;
+  /** Decide se a planilha/CSV pertence a este importador. */
+  detect(records: RecordRow[], headers: string[]): boolean;
+  /** Converte os dicionários cabeçalho→valor em ParsedRow canônico. */
+  parseRecords(records: RecordRow[]): ParsedRow[];
 };

--- a/src/lib/guest-importers/wedy.test.ts
+++ b/src/lib/guest-importers/wedy.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeAll } from "vitest";
-import ExcelJS from "exceljs";
+import { describe, it, expect } from "vitest";
 import { wedyImporter } from "./wedy";
+import type { RecordRow } from "./types";
 
 const FULL_HEADERS = [
   "Nome do convite",
@@ -14,79 +14,59 @@ const FULL_HEADERS = [
   "Pin do convite",
 ];
 
-async function buildWedyXlsx(
-  rows: Array<Array<string | number>>,
-  headers: string[] = FULL_HEADERS,
-): Promise<Buffer> {
-  const wb = new ExcelJS.Workbook();
-  const ws = wb.addWorksheet("Sheet1");
-  ws.addRow(headers);
-  for (const row of rows) ws.addRow(row);
-  const ab = await wb.xlsx.writeBuffer();
-  return Buffer.from(ab as ArrayBuffer);
+function buildRecord(values: Record<string, string>): RecordRow {
+  const rec: RecordRow = {};
+  for (const h of FULL_HEADERS) rec[h] = values[h] ?? "";
+  return rec;
 }
 
-async function buildEmptyXlsx(): Promise<Buffer> {
-  const wb = new ExcelJS.Workbook();
-  wb.addWorksheet("Sheet1");
-  const ab = await wb.xlsx.writeBuffer();
-  return Buffer.from(ab as ArrayBuffer);
+function row(values: Record<string, string>): RecordRow {
+  return buildRecord(values);
 }
 
 describe("wedyImporter.detect", () => {
-  let fullBuf: Buffer;
-  let partialBuf: Buffer;
-  let foreignBuf: Buffer;
-  let emptyBuf: Buffer;
+  it("detecta com todos os headers Wedy", () => {
+    expect(wedyImporter.detect([], FULL_HEADERS)).toBe(true);
+  });
 
-  beforeAll(async () => {
-    fullBuf = await buildWedyXlsx([["Família A", "Ana", "Sem resposta", "", "", "", "Adulto", "", ""]]);
-    // 6 colunas das esperadas presentes
-    partialBuf = await buildWedyXlsx(
-      [["A", "B", "C", "D", "E", "F"]],
-      [
+  it("detecta com 6 das 9 colunas esperadas", () => {
+    expect(
+      wedyImporter.detect([], [
         "Nome do convite",
         "Nome completo do convidado",
         "Status",
         "Telefone",
         "E-mail",
         "Tags",
-      ],
-    );
-    foreignBuf = await buildWedyXlsx(
-      [["x"]],
-      ["Outro Sistema", "Coluna Bizarra", "Algo Mais"],
-    );
-    emptyBuf = await buildEmptyXlsx();
+      ]),
+    ).toBe(true);
   });
 
-  it("detecta planilha com todos os headers Wedy", async () => {
-    expect(await wedyImporter.detect(fullBuf)).toBe(true);
+  it("não detecta com headers incompatíveis", () => {
+    expect(
+      wedyImporter.detect([], ["Outro Sistema", "Coluna Bizarra", "Algo Mais"]),
+    ).toBe(false);
   });
 
-  it("detecta planilha com 6 das 9 colunas esperadas", async () => {
-    expect(await wedyImporter.detect(partialBuf)).toBe(true);
-  });
-
-  it("não detecta planilha com headers incompatíveis", async () => {
-    expect(await wedyImporter.detect(foreignBuf)).toBe(false);
-  });
-
-  it("não detecta planilha vazia", async () => {
-    expect(await wedyImporter.detect(emptyBuf)).toBe(false);
-  });
-
-  it("retorna false (não lança) para buffer inválido", async () => {
-    expect(await wedyImporter.detect(Buffer.from([0, 1, 2, 3]))).toBe(false);
+  it("não detecta sem headers", () => {
+    expect(wedyImporter.detect([], [])).toBe(false);
   });
 });
 
-describe("wedyImporter.parse", () => {
-  it("mapeia todos os campos básicos de uma linha completa", async () => {
-    const buf = await buildWedyXlsx([
-      ["Família Silva", "Maria Silva", "Sem resposta", "+5511999990000", "maria@x.com", "Padrinhos, Tayná", "Adulto", "", "8696"],
+describe("wedyImporter.parseRecords", () => {
+  it("mapeia todos os campos básicos de uma linha completa", () => {
+    const rows = wedyImporter.parseRecords([
+      row({
+        "Nome do convite": "Família Silva",
+        "Nome completo do convidado": "Maria Silva",
+        "Status": "Sem resposta",
+        "Telefone": "+5511999990000",
+        "E-mail": "maria@x.com",
+        "Tags": "Padrinhos, Tayná",
+        "Faixa etária": "Adulto",
+        "Pin do convite": "8696",
+      }),
     ]);
-    const rows = await wedyImporter.parse(buf);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       name: "Maria Silva",
@@ -102,14 +82,13 @@ describe("wedyImporter.parse", () => {
     });
   });
 
-  it("mapeia status: Confirmado/Recusado/Talvez", async () => {
-    const buf = await buildWedyXlsx([
-      ["G1", "A", "Confirmado", "", "", "", "Adulto", "", ""],
-      ["G2", "B", "Recusado", "", "", "", "Adulto", "", ""],
-      ["G3", "C", "Talvez", "", "", "", "Adulto", "", ""],
-      ["G4", "D", "Não convidado", "", "", "", "Adulto", "", ""],
+  it("mapeia status: Confirmado/Recusado/Talvez/Não convidado", () => {
+    const rows = wedyImporter.parseRecords([
+      row({ "Nome do convite": "G1", "Nome completo do convidado": "A", "Status": "Confirmado", "Faixa etária": "Adulto" }),
+      row({ "Nome do convite": "G2", "Nome completo do convidado": "B", "Status": "Recusado", "Faixa etária": "Adulto" }),
+      row({ "Nome do convite": "G3", "Nome completo do convidado": "C", "Status": "Talvez", "Faixa etária": "Adulto" }),
+      row({ "Nome do convite": "G4", "Nome completo do convidado": "D", "Status": "Não convidado", "Faixa etária": "Adulto" }),
     ]);
-    const rows = await wedyImporter.parse(buf);
     expect(rows.map((r) => r.rsvpStatus)).toEqual([
       "CONFIRMED",
       "DECLINED",
@@ -118,100 +97,92 @@ describe("wedyImporter.parse", () => {
     ]);
   });
 
-  it("status desconhecido cai em INVITED e preserva rsvpStatusRaw", async () => {
-    const buf = await buildWedyXlsx([
-      ["G", "X", "Coisa-Estranha", "", "", "", "Adulto", "", ""],
+  it("status desconhecido cai em INVITED e preserva rsvpStatusRaw", () => {
+    const [r] = wedyImporter.parseRecords([
+      row({ "Nome do convite": "G", "Nome completo do convidado": "X", "Status": "Coisa-Estranha", "Faixa etária": "Adulto" }),
     ]);
-    const [row] = await wedyImporter.parse(buf);
-    expect(row.rsvpStatus).toBe("INVITED");
-    expect(row.rsvpStatusRaw).toBe("Coisa-Estranha");
+    expect(r.rsvpStatus).toBe("INVITED");
+    expect(r.rsvpStatusRaw).toBe("Coisa-Estranha");
   });
 
-  it("isChild=true quando Faixa etária = Criança", async () => {
-    const buf = await buildWedyXlsx([
-      ["G", "Kid", "Sem resposta", "", "", "", "Criança", "8", ""],
+  it("isChild=true quando Faixa etária = Criança", () => {
+    const [r] = wedyImporter.parseRecords([
+      row({ "Nome do convite": "G", "Nome completo do convidado": "Kid", "Status": "Sem resposta", "Faixa etária": "Criança", "Idade exata (caso for criança)": "8" }),
     ]);
-    const [row] = await wedyImporter.parse(buf);
-    expect(row.isChild).toBe(true);
-    expect(row.age).toBe(8);
+    expect(r.isChild).toBe(true);
+    expect(r.age).toBe(8);
   });
 
-  it("ignora 'Idade desconhecida' (não-numérica) preenchendo age=null", async () => {
-    const buf = await buildWedyXlsx([
-      ["G", "Kid", "Sem resposta", "", "", "", "Criança", "Idade desconhecida", ""],
+  it("ignora 'Idade desconhecida' (não-numérica) preenchendo age=null", () => {
+    const [r] = wedyImporter.parseRecords([
+      row({ "Nome do convite": "G", "Nome completo do convidado": "Kid", "Status": "Sem resposta", "Faixa etária": "Criança", "Idade exata (caso for criança)": "Idade desconhecida" }),
     ]);
-    const [row] = await wedyImporter.parse(buf);
-    expect(row.age).toBeNull();
+    expect(r.age).toBeNull();
   });
 
-  it("rejeita idade fora do range 0-17", async () => {
-    const buf = await buildWedyXlsx([
-      ["G", "X", "Sem resposta", "", "", "", "Criança", "25", ""],
+  it("rejeita idade fora do range 0-17", () => {
+    const [r] = wedyImporter.parseRecords([
+      row({ "Nome do convite": "G", "Nome completo do convidado": "X", "Status": "Sem resposta", "Faixa etária": "Criança", "Idade exata (caso for criança)": "25" }),
     ]);
-    const [row] = await wedyImporter.parse(buf);
-    expect(row.age).toBeNull();
+    expect(r.age).toBeNull();
   });
 
-  it("rejeita PIN com formato inválido", async () => {
-    const buf = await buildWedyXlsx([
-      ["G", "X", "Sem resposta", "", "", "", "Adulto", "", "abc"],
-      ["G", "Y", "Sem resposta", "", "", "", "Adulto", "", "ABCDEFGHIJK"],
-      ["G", "Z", "Sem resposta", "", "", "", "Adulto", "", "1234"],
-      ["G", "W", "Sem resposta", "", "", "", "Adulto", "", "AB12"],
+  it("rejeita PIN com formato inválido", () => {
+    const rows = wedyImporter.parseRecords([
+      row({ "Nome do convite": "G", "Nome completo do convidado": "X", "Status": "Sem resposta", "Faixa etária": "Adulto", "Pin do convite": "abc" }),
+      row({ "Nome do convite": "G", "Nome completo do convidado": "Y", "Status": "Sem resposta", "Faixa etária": "Adulto", "Pin do convite": "ABCDEFGHIJK" }),
+      row({ "Nome do convite": "G", "Nome completo do convidado": "Z", "Status": "Sem resposta", "Faixa etária": "Adulto", "Pin do convite": "1234" }),
+      row({ "Nome do convite": "G", "Nome completo do convidado": "W", "Status": "Sem resposta", "Faixa etária": "Adulto", "Pin do convite": "AB12" }),
     ]);
-    const rows = await wedyImporter.parse(buf);
     expect(rows[0].pin).toBeNull();
     expect(rows[1].pin).toBeNull();
     expect(rows[2].pin).toBe("1234");
     expect(rows[3].pin).toBe("AB12");
   });
 
-  it("split e trim de tags, limita a 20", async () => {
+  it("split e trim de tags, limita a 20", () => {
     const many = Array.from({ length: 25 }, (_, i) => `t${i}`).join(", ");
-    const buf = await buildWedyXlsx([
-      ["G", "X", "Sem resposta", "", "", many, "Adulto", "", ""],
+    const [r] = wedyImporter.parseRecords([
+      row({ "Nome do convite": "G", "Nome completo do convidado": "X", "Status": "Sem resposta", "Faixa etária": "Adulto", "Tags": many }),
     ]);
-    const [row] = await wedyImporter.parse(buf);
-    expect(row.tags).toHaveLength(20);
-    expect(row.tags[0]).toBe("t0");
-    expect(row.tags[19]).toBe("t19");
+    expect(r.tags).toHaveLength(20);
+    expect(r.tags[0]).toBe("t0");
+    expect(r.tags[19]).toBe("t19");
   });
 
-  it("descarta linha sem nome", async () => {
-    const buf = await buildWedyXlsx([
-      ["G", "  ", "Sem resposta", "", "", "", "Adulto", "", ""],
-      ["G", "Ana", "Sem resposta", "", "", "", "Adulto", "", ""],
+  it("descarta linha sem nome", () => {
+    const rows = wedyImporter.parseRecords([
+      row({ "Nome do convite": "G", "Nome completo do convidado": "  ", "Status": "Sem resposta", "Faixa etária": "Adulto" }),
+      row({ "Nome do convite": "G", "Nome completo do convidado": "Ana", "Status": "Sem resposta", "Faixa etária": "Adulto" }),
     ]);
-    const rows = await wedyImporter.parse(buf);
     expect(rows.map((r) => r.name)).toEqual(["Ana"]);
   });
 
-  it("aplica limites de tamanho a name/groupName/phone/email", async () => {
-    const buf = await buildWedyXlsx([
-      [
-        "g".repeat(200),
-        "n".repeat(200),
-        "Sem resposta",
-        "p".repeat(100),
-        `${"e".repeat(200)}@x.com`,
-        "",
-        "Adulto",
-        "",
-        "",
-      ],
+  it("aplica limites de tamanho a name/groupName/phone/email", () => {
+    const [r] = wedyImporter.parseRecords([
+      row({
+        "Nome do convite": "g".repeat(200),
+        "Nome completo do convidado": "n".repeat(200),
+        "Status": "Sem resposta",
+        "Telefone": "p".repeat(100),
+        "E-mail": `${"e".repeat(200)}@x.com`,
+        "Faixa etária": "Adulto",
+      }),
     ]);
-    const [row] = await wedyImporter.parse(buf);
-    expect(row.name.length).toBe(160);
-    expect(row.groupName?.length).toBe(80);
-    expect(row.phone?.length).toBe(40);
-    expect(row.email?.length).toBe(160);
+    expect(r.name.length).toBe(160);
+    expect(r.groupName?.length).toBe(80);
+    expect(r.phone?.length).toBe(40);
+    expect(r.email?.length).toBe(160);
   });
 
-  it("preserva tags com nomes dos noivos (case original)", async () => {
-    const buf = await buildWedyXlsx([
-      ["G", "X", "Sem resposta", "", "", "Tayná, Guilherme", "Adulto", "", ""],
+  it("preserva tags com nomes dos noivos (case original)", () => {
+    const [r] = wedyImporter.parseRecords([
+      row({ "Nome do convite": "G", "Nome completo do convidado": "X", "Status": "Sem resposta", "Faixa etária": "Adulto", "Tags": "Tayná, Guilherme" }),
     ]);
-    const [row] = await wedyImporter.parse(buf);
-    expect(row.tags).toEqual(["Tayná", "Guilherme"]);
+    expect(r.tags).toEqual(["Tayná", "Guilherme"]);
+  });
+
+  it("indica que contatos pertencem ao grupo (não ao indivíduo)", () => {
+    expect(wedyImporter.contactsBelongToGroup).toBe(true);
   });
 });

--- a/src/lib/guest-importers/wedy.ts
+++ b/src/lib/guest-importers/wedy.ts
@@ -1,5 +1,4 @@
-import ExcelJS from "exceljs";
-import type { Importer, ImportedRsvpStatus, ParsedRow } from "./types";
+import type { Importer, ImportedRsvpStatus, ParsedRow, RecordRow } from "./types";
 
 const EXPECTED_HEADERS = [
   "Nome do convite",
@@ -30,85 +29,34 @@ const STATUS_MAP: Record<string, ImportedRsvpStatus> = {
 
 const PIN_RE = /^[A-Z0-9]{4,8}$/i;
 
-function cellText(value: ExcelJS.CellValue): string {
-  if (value == null) return "";
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
-  if (value instanceof Date) return value.toISOString();
-  if (typeof value === "object" && "text" in value && typeof value.text === "string") {
-    return value.text;
-  }
-  if (typeof value === "object" && "richText" in value && Array.isArray(value.richText)) {
-    return value.richText.map((rt) => rt.text).join("");
-  }
-  if (typeof value === "object" && "result" in value) {
-    return cellText(value.result as ExcelJS.CellValue);
-  }
-  return String(value);
-}
-
-function readHeader(worksheet: ExcelJS.Worksheet): string[] {
-  const headerRow = worksheet.getRow(1);
-  const values = headerRow.values as unknown[];
-  // ExcelJS retorna array 1-indexed; índice 0 é undefined.
-  return values.slice(1).map((v) => cellText(v as ExcelJS.CellValue).trim());
-}
-
-async function loadWorkbook(buf: Buffer): Promise<ExcelJS.Workbook> {
-  const workbook = new ExcelJS.Workbook();
-  await workbook.xlsx.load(buf as unknown as ArrayBuffer);
-  return workbook;
+function get(rec: RecordRow, header: string): string {
+  return (rec[header] ?? "").trim();
 }
 
 export const wedyImporter: Importer = {
   id: "wedy",
   label: "Wedy",
-  async detect(buf) {
-    try {
-      const workbook = await loadWorkbook(buf);
-      const worksheet = workbook.worksheets[0];
-      if (!worksheet) return false;
-      const headers = readHeader(worksheet);
-      const matches = EXPECTED_HEADERS.filter((h) => headers.includes(h)).length;
-      return matches >= 6;
-    } catch {
-      return false;
-    }
+  contactsBelongToGroup: true,
+
+  detect(_records, headers) {
+    const matches = EXPECTED_HEADERS.filter((h) => headers.includes(h)).length;
+    return matches >= 6;
   },
 
-  async parse(buf) {
-    const workbook = await loadWorkbook(buf);
-    const worksheet = workbook.worksheets[0];
-    if (!worksheet) return [];
-
-    const headers = readHeader(worksheet);
-    const colIndex = new Map<string, number>();
-    headers.forEach((h, i) => {
-      if (h) colIndex.set(h, i + 1);
-    });
-
-    const get = (row: ExcelJS.Row, header: string): string => {
-      const idx = colIndex.get(header);
-      if (!idx) return "";
-      return cellText(row.getCell(idx).value).trim();
-    };
-
+  parseRecords(records) {
     const rows: ParsedRow[] = [];
-    const totalRows = worksheet.actualRowCount;
-
-    for (let r = 2; r <= totalRows; r++) {
-      const row = worksheet.getRow(r);
-      const name = get(row, "Nome completo do convidado").slice(0, 160);
+    for (const rec of records) {
+      const name = get(rec, "Nome completo do convidado").slice(0, 160);
       if (!name) continue;
 
-      const groupName = get(row, "Nome do convite").slice(0, 80) || null;
-      const phone = get(row, "Telefone").slice(0, 40) || null;
-      const email = get(row, "E-mail").slice(0, 160) || null;
-      const statusRaw = get(row, "Status");
+      const groupName = get(rec, "Nome do convite").slice(0, 80) || null;
+      const phone = get(rec, "Telefone").slice(0, 40) || null;
+      const email = get(rec, "E-mail").slice(0, 160) || null;
+      const statusRaw = get(rec, "Status");
       const statusKey = statusRaw.toLowerCase();
       const rsvpStatus = STATUS_MAP[statusKey] ?? "INVITED";
 
-      const tagsRaw = get(row, "Tags");
+      const tagsRaw = get(rec, "Tags");
       const tags = tagsRaw
         ? tagsRaw
             .split(",")
@@ -117,17 +65,16 @@ export const wedyImporter: Importer = {
             .slice(0, 20)
         : [];
 
-      const isChild = get(row, "Faixa etária").toLowerCase() === "criança";
-
-      const ageRaw = get(row, "Idade exata (caso for criança)");
+      const isChild = get(rec, "Faixa etária").toLowerCase() === "criança";
+      const ageRaw = get(rec, "Idade exata (caso for criança)");
       const ageNum = /^\d{1,3}$/.test(ageRaw) ? parseInt(ageRaw, 10) : null;
       const age = ageNum != null && ageNum >= 0 && ageNum <= 17 ? ageNum : null;
 
-      const pinRaw = get(row, "Pin do convite");
+      const pinRaw = get(rec, "Pin do convite");
       const pin = PIN_RE.test(pinRaw) ? pinRaw : null;
 
       const rawSource: Record<string, string> = {};
-      for (const h of EXPECTED_HEADERS) rawSource[h] = get(row, h);
+      for (const h of EXPECTED_HEADERS) rawSource[h] = get(rec, h);
 
       rows.push({
         name,
@@ -143,7 +90,6 @@ export const wedyImporter: Importer = {
         rawSource,
       });
     }
-
     return rows;
   },
 };

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -769,16 +769,16 @@ export const HELP_ARTICLES: HelpArticle[] = [
   },
   {
     id: "guest-import-wedy",
-    title: "Importar lista do Wedy (e outros .xlsx)",
+    title: "Importar lista do Wedy (.xlsx) ou do próprio sistema (.csv)",
     category: "guests",
-    keywords: ["importar", "wedy", "xlsx", "planilha", "migrar", "excel"],
+    keywords: ["importar", "wedy", "xlsx", "csv", "planilha", "migrar", "excel"],
     icon: Upload,
     summary:
-      "Trazer convidados de outros sistemas de planejamento sem retrabalho. Hoje: Wedy (XLSX).",
+      "Trazer convidados de outros sistemas (Wedy) ou reimportar um CSV exportado pelo próprio sistema.",
     steps: [
       {
         title: "Acesse Convidados → Importar lista",
-        body: "Vai abrir /dashboard/guests/import. Selecione o arquivo .xlsx exportado do outro sistema (até 5 MB, 2000 linhas).",
+        body: "Vai abrir /dashboard/guests/import. Selecione o arquivo .xlsx (Wedy) ou .csv (exportado pelo próprio sistema). Até 5 MB, 2000 linhas.",
       },
       {
         title: "Confira o preview",
@@ -796,6 +796,8 @@ export const HELP_ARTICLES: HelpArticle[] = [
     tips: [
       "Você ainda pode importar via texto colado: dentro da página de import há um link 'Prefere colar texto?'.",
       "O Wedy traz tags com os nomes dos noivos — elas viram tags normais, mas o lado (NOIVO/NOIVA) precisa ser ajustado manualmente em cada convidado.",
+      "Importou do Wedy? O telefone/email vai automaticamente para o contato do grupo (cabeça da família), não para cada convidado.",
+      "Reimportar o CSV exportado pelo botão 'CSV' funciona como um backup manual — fecha o ciclo export/import.",
     ],
     warnings: [
       "Status fora do mapeamento conhecido (Sem resposta/Confirmado/Recusado/Talvez) é tratado como 'Convidado'.",


### PR DESCRIPTION
## Summary

Dois ajustes pedidos no review do PR #48 (já mergeado):

### 1. Telefone/email do Wedy passam a ser do **grupo**, não do convidado

No Wedy, o telefone só aparece na primeira linha de cada convite (o responsável) — refletindo que o contato é por convite/família, não por pessoa. A `commitGuestImport` detecta isso via `importer.contactsBelongToGroup` e:

- Popula `GuestGroup.contactPhone / contactEmail / contactName` com os dados da primeira linha do grupo que tenha valores preenchidos.
- Deixa `Guest.phone / Guest.email = null` para **todos** os membros (inclusive o responsável) — não duplica o dado.
- Não sobrescreve `contactPhone` / `contactEmail` / `contactName` existente non-null em grupos que já estão no banco.

Como o `GuestGroup` do nosso schema já tinha esses campos, não houve mudança de schema.

### 2. CSV exportado pelo próprio sistema agora é importável

Fecha o ciclo **export ↔ import** (útil em backups manuais ou migrações entre instâncias):

- Novo Importer `internal-csv` (label "CSV exportado pelo próprio sistema").
- Detecta header com `Nome` + `Status` + `Grupo` obrigatórios e ≥8 das 13 colunas que o `exportCsv` em [guests-client.tsx](src/app/dashboard/guests/guests-client.tsx#L157) gera (Lado, +1 confirmados, Mesa, Restrições, Cidade, Padrinho, VIP, Criança…).
- Mapeia status pt-BR de volta pro enum: `Não convidado`/`Convidado`/`Confirmado`/`Recusou`/`Talvez`.
- `Padrinho="sim"` gera tag virtual `Padrinhos` — idempotente com a regex flexível já usada pra setar `isPadrinho`.
- `contactsBelongToGroup=false` (cada linha tem dados próprios).

### 3. Refactor estrutural da arquitetura de Importers

Interface `Importer` agora expõe `parseRecords(records: RecordRow[])` em vez de `parse(buf)`. Helpers `extractXlsxRecords` / `extractCsvRecords` (em [src/lib/guest-importers/extract.ts](src/lib/guest-importers/extract.ts)) cuidam da leitura — cada Importer só precisa saber mapear records. Adicionar novo sistema fica trivial: implementar `detect(records, headers)` + `parseRecords(records)`.

`ParsedRow` ganhou campos opcionais (`side`, `isVIP`, `plusOnesAllowed`, `tableNumber`, `dietary`, `city`) que o CSV interno popula e o commit aplica quando definidos.

A Server Action detecta extensão `.csv` vs `.xlsx` (com fallback por MIME) e invoca o `extract` correto antes de passar pros importers. UI: input aceita `.xlsx` e `.csv`; texto de ajuda explica os 2 caminhos.

**Wedy continua XLSX-only** (não tentamos parsear o XML do Wedy como CSV).

## Mudanças

| Área | Arquivos |
|------|----------|
| Helper de leitura | `src/lib/guest-importers/extract.ts` + teste (CSV com aspas/BOM/quebras-de-linha, XLSX via ExcelJS) |
| Novo importer | `src/lib/guest-importers/internal-csv.ts` + teste (13 cenários cobrindo status pt-BR, side, plusOnes, Padrinho="sim"...) |
| Refactor Importer/Wedy | `types.ts`, `wedy.ts`, `wedy.test.ts`, `index.ts` |
| Server Action | `src/app/actions/guestActions.ts` (extração + `contactsBelongToGroup` no commit) + 4 testes novos no `.test.ts` |
| UI | `src/app/dashboard/guests/import/import-client.tsx` (`accept=".xlsx,.csv"` + texto) |
| Docs | `docs/importacao-convidados.md`, `src/lib/changelog.ts`, `src/lib/help-content.ts` |

## Verificação

- ✅ `npm run lint` sem novos warnings
- ✅ `npm run test:run` — **513/513** verdes (era 487 no PR #48; +26 novos)
- ✅ `npm run build` OK
- ✅ Smoke E2E manual com o XLSX real do Wedy + simulação do CSV interno → ambos parseados corretamente

## Test plan

- [ ] `git checkout feat/guest-import-csv-and-wedy-group-contact && npm i`
- [ ] `npm run test:run` (esperado: 513 passando)
- [ ] `npm run dev` → login → `/dashboard/guests` → exportar a lista atual via botão "CSV"
- [ ] `/dashboard/guests/import` → subir o CSV exportado → preview mostra todas as colunas (status pt-BR, lado, padrinho, VIP, etc.)
- [ ] Confirmar com `CREATE_NEW_ONLY` → toast com contagens
- [ ] Subir novamente o XLSX do Wedy (do PR #48) → conferir em `/dashboard/guests/groups` que cada grupo tem `contactPhone` e `contactName` preenchidos (vindos da primeira linha de cada convite)
- [ ] Em `/dashboard/guests`: conferir que membros de grupos do Wedy estão com `phone`/`email` em branco (foi pro grupo)
- [ ] Reimportar o mesmo CSV com `UPSERT_BY_NAME` → linhas existentes têm side/VIP/Mesa atualizados

## Histórico

- Esta é a continuação do PR #48 (já mergeado). Os ajustes deste PR são:
  - **Observação do owner**: "Percebeu que no Wedy o número de telefone é usado um por grupo? O que acha de deixar o telefone apenas para o grupo e não por contato?"
  - **Pergunta do owner**: "O CSV que comentei foi o que o próprio sistema exporta, ele ainda é aceito? É possível colocar na lista de importação uma opção para ele, pode deixar o Wedy como xlsx apenas."

🤖 Generated with [Claude Code](https://claude.com/claude-code)