### PR TITLE
fix(guests-import): UPSERT_BY_NAME zera Guest.phone/email quando contatos pertencem ao grupo

### DIFF
--- a/src/app/actions/guestActions.test.ts
+++ b/src/app/actions/guestActions.test.ts
@@ -537,6 +537,40 @@ describe("commitGuestImport", () => {
     expect(upd.data.isPadrinho).toBe(true);
   });
 
+  it("UPSERT_BY_NAME no Wedy zera Guest.phone/email (contactsBelongToGroup=true) — evita dado duplicado", async () => {
+    // Guest existente tem phone/email antigos (cenário: import anterior antes do
+    // PR que move contatos pro grupo). UPSERT precisa forçar null pra não ficar
+    // duplicado em Guest.phone + GuestGroup.contactPhone.
+    prismaMock.guest.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "exist-1",
+          name: "Ana",
+          phone: "antigo-no-guest",
+          email: "antigo@x.com",
+          groupName: "G",
+        },
+      ] as never)
+      .mockResolvedValueOnce([
+        { id: "exist-1", name: "Ana", groupName: "G" },
+      ] as never);
+    const file = await wedyXlsxFile([
+      ["G", "Ana", "Sem resposta", "+5511999990000", "ana@x.com", "", "Adulto", "", ""],
+    ]);
+    const preview = await previewGuestImport(undefined, importForm(file));
+    if (!preview.success) throw new Error();
+    await commitGuestImport({
+      importToken: preview.data!.importToken,
+      mode: "UPSERT_BY_NAME",
+    });
+    const upd = prismaMock.guest.update.mock.calls[0][0] as {
+      data: { phone: string | null; email: string | null };
+    };
+    // Importante: null explícito (não undefined), senão o Prisma deixa o antigo.
+    expect(upd.data.phone).toBeNull();
+    expect(upd.data.email).toBeNull();
+  });
+
   it("CREATE_ALL_DUPLICATES sempre cria, mesmo com match no mesmo grupo", async () => {
     prismaMock.guest.findMany
       .mockResolvedValueOnce([

--- a/src/app/actions/guestActions.ts
+++ b/src/app/actions/guestActions.ts
@@ -797,8 +797,11 @@ export async function commitGuestImport(input: {
             await tx.guest.update({
               where: { id: sameGroup.id },
               data: {
-                phone: guestPhone ?? undefined,
-                email: guestEmail ?? undefined,
+                // Quando contatos pertencem ao grupo, força null no Guest mesmo
+                // que o registro existente tenha valor antigo — caso contrário
+                // o dado fica duplicado (Guest.phone + GuestGroup.contactPhone).
+                phone: contactsToGroup ? null : (row.phone ?? undefined),
+                email: contactsToGroup ? null : (row.email ?? undefined),
                 rsvpStatus: row.rsvpStatus,
                 isChild: row.isChild,
                 age: row.age,


### PR DESCRIPTION
## Summary

Fix para o cenário pós-merge do #50: quem importou o XLSX do Wedy **antes** do #50 tem `Guest.phone` populado para o responsável de cada família. Reimportar com `UPSERT_BY_NAME` agora deveria mover esse dado pra `GuestGroup.contactPhone` — mas sem este fix, o `Guest.phone` antigo continua lá em paralelo, ficando duplicado.

## Bug

Em [guestActions.ts:800-801](src/app/actions/guestActions.ts#L800-L801) (estado pré-fix), o `update` passa:

```ts
phone: guestPhone ?? undefined,
email: guestEmail ?? undefined,
```

Quando `contactsBelongToGroup=true` (Wedy), `guestPhone === null`. O coalescing `null ?? undefined` vira `undefined`, e o Prisma **ignora** o campo no UPDATE — o valor antigo permanece intocado.

O caminho `CREATE` (linha 829-830) não tinha o problema porque grava direto sem coalescing.

## Fix

```ts
phone: contactsToGroup ? null : (row.phone ?? undefined),
email: contactsToGroup ? null : (row.email ?? undefined),
```

Força `null` explícito quando contatos pertencem ao grupo, garantindo `UPDATE ... SET phone = NULL`.

## Teste de regressão

Adicionado em [guestActions.test.ts](src/app/actions/guestActions.test.ts): existing-guest com `phone='antigo-no-guest'` → após UPSERT_BY_NAME com importer Wedy → `update.data.phone === null` (não undefined).

## Verificação

- ✅ `npm run lint` sem novos warnings
- ✅ `npm run test:run` — **514/514** verdes (+1 novo)
- ✅ `npm run build` OK

## Test plan

- [ ] `git checkout fix/guest-import-upsert-clears-phone-email && npm i && npm run test:run`
- [ ] `npm run dev` → `/dashboard/guests/import` → reenviar o XLSX do Wedy com modo `UPSERT_BY_NAME`
- [ ] Em `/dashboard/guests`: TODOS os guests do Wedy devem estar com phone/email em branco
- [ ] Em `/dashboard/guests/groups`: cada grupo deve ter `contactPhone`/`contactName`/`contactEmail` populado (vindo do responsável)
- [ ] Edições manuais anteriores (side, mesa, RSVPs confirmados) devem permanecer intactas

## Quem é afetado

Quem importou do Wedy **antes** do merge do PR #50. Para limpar o estado: reimportar o mesmo XLSX com `UPSERT_BY_NAME` após este PR. Sem perder edições manuais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)