### PR TITLE
feat(seating): acesso na UI + reordenação de mesas por arrasto

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ confirmou a presença.
 - 🌴 **Lua de mel** (destino, atividades, hospedagens, vôos)
 - 🛏️ **Enxoval** por cômodo
 - 💍 **Painel do Dia D** (cronograma, plano B chuva, contatos críticos, check-in)
+- 🪑 **Mapa de assentos** — arraste convidados confirmados para as mesas e reordene as mesas pela alça; capacidade considera +1s
 - 📊 **Insights** financeiros (health score, heatmap, detector de creep)
 - 📨 **Notificações por email + WhatsApp** (Baileys) — no idioma do destinatário
 - 🌐 **Multi-idioma** (pt-BR, inglês, espanhol) — escolhido por usuário e respeitado em emails/WhatsApp/RSVP

--- a/docs/seating-chart.md
+++ b/docs/seating-chart.md
@@ -2,9 +2,11 @@
 
 A partir da v0.3.0 o sistema tem uma tela visual para distribuir convidados em mesas. Acesse em `/dashboard/wedding-day/seating`.
 
+**Acesso na UI:** item "Mapa de assentos" no menu lateral (grupo Casamento, logo abaixo de "Dia D") e card de atalho no topo da página `/dashboard/wedding-day`.
+
 ## Modelo de dados
 
-- **`SeatingTable`** — uma mesa do salão. Tem `name`, `capacity` (assentos disponíveis), `shape` (`ROUND` | `RECT` | `SQUARE`), `x`/`y` (posição no canvas) e `notes`. Soft delete via `deletedAt`.
+- **`SeatingTable`** — uma mesa do salão. Tem `name`, `capacity` (assentos disponíveis), `shape` (`ROUND` | `RECT` | `SQUARE`), `sortOrder` (ordem de exibição no grid), `x`/`y` (reservados para um futuro canvas livre — não usados pela UI atual) e `notes`. Soft delete via `deletedAt`.
 - **`Guest.tableId`** — FK opcional para `SeatingTable`. Quando o convidado é desalocado, vira `null`.
 
 > O campo legado `Guest.tableNumber` (string) continua existindo mas não é mais usado para alocação. Considere migrar entrada por entrada e remover em versão futura.
@@ -14,24 +16,35 @@ A partir da v0.3.0 o sistema tem uma tela visual para distribuir convidados em m
 1. **Criar mesa** — botão "Nova mesa", informa nome, capacidade e formato. A mesa nasce sem convidados.
 2. **Alocar convidado** — o pool lateral lista convidados com `rsvpStatus = CONFIRMED` e `tableId = null`, ordenados por nome. Arraste o chip para uma mesa.
 3. **Capacidade** — considera +1 confirmados. Convidado com `plusOnesConfirmed = 2` ocupa 3 assentos. Drop em mesa cheia falha silenciosamente com toast.
-4. **Desalocar** — solte o chip de volta no pool. O `tableId` volta a ser `null`.
-5. **Excluir mesa** — soft delete. Convidados que estavam nela são desalocados em transação.
+4. **Reordenar mesas** — cada card tem uma alça (ícone `GripVertical` no cabeçalho). Arraste pela alça para mudar a ordem das mesas no grid; a nova ordem é persistida em `sortOrder`. Só a alça inicia o arrasto da mesa, então os chips de convidado dentro do card continuam clicáveis/arrastáveis.
+5. **Desalocar** — solte o chip de volta no pool. O `tableId` volta a ser `null`.
+6. **Excluir mesa** — soft delete. Convidados que estavam nela são desalocados em transação.
 
 ## Server actions ([src/app/actions/seatingTableActions.ts](../src/app/actions/seatingTableActions.ts))
 
 - `createSeatingTable(_, formData)` — cria mesa.
 - `updateSeatingTable(_, formData)` — edita nome/capacidade/formato/notas.
 - `deleteSeatingTable(tableId)` — soft delete + desaloca convidados em transação.
-- `updateTablePosition(tableId, x, y)` — para arrastar mesas no canvas (futuro).
+- `reorderSeatingTables(orderedIds)` — grava `sortOrder` sequencial (índice no array) para cada mesa, em transação. Valida a lista com Zod (1–200 ids, cada um ≤ 64 chars).
+- `updateTablePosition(tableId, x, y)` — reservada para um futuro canvas livre; não é usada pela UI atual.
 - `assignGuestToTable(guestId, tableId | null)` — valida capacidade antes de gravar.
 
-Todas exigem sessão (`auth()`) e gravam `AuditLog` (entity `SeatingTable` ou `Guest`, action `ASSIGN_TABLE` / `UNASSIGN_TABLE`).
+Todas exigem permissão de edição (`denyIfNoEdit`) e gravam `AuditLog` (entity `SeatingTable` ou `Guest`, action `CREATE` / `UPDATE` / `DELETE` / `REORDER` / `ASSIGN_TABLE` / `UNASSIGN_TABLE`).
+
+A ordenação inicial em [page.tsx](../src/app/dashboard/wedding-day/seating/page.tsx) é `orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }]` — mesas antigas (todas com `sortOrder = 0`) caem no desempate por data de criação.
 
 ## Dependência
 
 - `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` — biblioteca de drag-and-drop. Sensores: PointerSensor + KeyboardSensor para acessibilidade.
 
+## Coexistência de dois arrastos no mesmo `DndContext`
+
+Cada card de mesa é, ao mesmo tempo, um item **sortable** (reordenável) e um **droppable** que recebe convidados. Para o `over` nunca ficar ambíguo, o `DndContext` usa uma `collisionDetection` customizada (`seatingCollision` em [seating-client.tsx](../src/app/dashboard/wedding-day/seating/seating-client.tsx)) que filtra os candidatos pelo tipo do item ativo:
+
+- arrastando um **convidado** (`type: "guest"`) → considera só droppables de convidado (`type: "table"` e `type: "pool"`) via `pointerWithin`;
+- arrastando uma **mesa** (`type: "table-sort"`) → considera só os itens sortable via `closestCenter`.
+
 ## Limitações conhecidas
 
-- Posição x/y das mesas no canvas ainda não é arrastável (campos existem; UI não usa).
+- A reordenação é por grid (não há canvas com posição livre x/y). Os campos `x`/`y` existem no schema mas ficam reservados para uma evolução futura.
 - Sem regras automáticas de proximidade (ex.: "criança junto ao responsável") — pode virar feature.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -472,6 +472,7 @@ model SeatingTable {
   shape       String   @default("ROUND")
   x           Float    @default(0)
   y           Float    @default(0)
+  sortOrder   Int      @default(0)
   notes       String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt

--- a/src/app/actions/seatingTableActions.test.ts
+++ b/src/app/actions/seatingTableActions.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prismaMock } from "@/test-utils/prisma";
+
+const authMock = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => authMock(),
+}));
+
+import { assignGuestToTable, reorderSeatingTables } from "./seatingTableActions";
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  authMock.mockReset();
+  authMock.mockResolvedValue({ user: { id: "test-user", role: "ADMIN" } });
+  prismaMock.auditLog.create.mockResolvedValue({} as never);
+  // Suporta as duas formas usadas pelas actions: callback (assign) e array (reorder).
+  prismaMock.$transaction.mockImplementation((arg: unknown) => {
+    if (typeof arg === "function") {
+      return (arg as (tx: typeof prismaMock) => unknown)(prismaMock);
+    }
+    return Promise.all(arg as Promise<unknown>[]);
+  });
+});
+
+describe("assignGuestToTable", () => {
+  it("rejeita guestId inválido sem tocar o banco", async () => {
+    const res = await assignGuestToTable("", "t1");
+    expect(res.success).toBe(false);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejeita tableId inválido (acima de 64 chars)", async () => {
+    const res = await assignGuestToTable("g1", "x".repeat(65));
+    expect(res.success).toBe(false);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("erro quando a mesa não existe", async () => {
+    prismaMock.seatingTable.findUnique.mockResolvedValue(null as never);
+    const res = await assignGuestToTable("g1", "t1");
+    expect(res).toEqual({ success: false, error: "Mesa não encontrada" });
+  });
+
+  it("erro quando o convidado não existe ou está arquivado", async () => {
+    prismaMock.seatingTable.findUnique.mockResolvedValue({ id: "t1", name: "Mesa 1", capacity: 8 } as never);
+    prismaMock.guest.findMany.mockResolvedValue([] as never);
+    prismaMock.guest.findUnique.mockResolvedValue({ plusOnesConfirmed: 0, deletedAt: new Date() } as never);
+    const res = await assignGuestToTable("g1", "t1");
+    expect(res).toEqual({ success: false, error: "Convidado não encontrado" });
+    expect(prismaMock.guest.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("recusa quando os +1 do novo convidado estouram a capacidade", async () => {
+    // cap 3, 1 assento ocupado, novo convidado precisa de 3 (1 + 2 acompanhantes) -> 4 > 3
+    prismaMock.seatingTable.findUnique.mockResolvedValue({ id: "t1", name: "Mesa 1", capacity: 3 } as never);
+    prismaMock.guest.findMany.mockResolvedValue([{ id: "g2", plusOnesConfirmed: 0 }] as never);
+    prismaMock.guest.findUnique.mockResolvedValue({ plusOnesConfirmed: 2, deletedAt: null } as never);
+    const res = await assignGuestToTable("g1", "t1");
+    expect(res.success).toBe(false);
+    expect(prismaMock.guest.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("conta os +1 dos convidados já alocados ao validar capacidade", async () => {
+    // cap 4, um convidado com +3 já ocupa 4 assentos; novo simples (1) -> 5 > 4
+    prismaMock.seatingTable.findUnique.mockResolvedValue({ id: "t1", name: "Mesa 1", capacity: 4 } as never);
+    prismaMock.guest.findMany.mockResolvedValue([{ id: "g2", plusOnesConfirmed: 3 }] as never);
+    prismaMock.guest.findUnique.mockResolvedValue({ plusOnesConfirmed: 0, deletedAt: null } as never);
+    const res = await assignGuestToTable("g1", "t1");
+    expect(res.success).toBe(false);
+  });
+
+  it("exclui o próprio convidado da contagem ao reatribuir", async () => {
+    prismaMock.seatingTable.findUnique.mockResolvedValue({ id: "t1", name: "Mesa 1", capacity: 8 } as never);
+    prismaMock.guest.findMany.mockResolvedValue([] as never);
+    prismaMock.guest.findUnique.mockResolvedValue({ plusOnesConfirmed: 0, deletedAt: null } as never);
+    prismaMock.guest.updateMany.mockResolvedValue({ count: 1 } as never);
+    await assignGuestToTable("g1", "t1");
+    expect(prismaMock.guest.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ tableId: "t1", NOT: { id: "g1" } }),
+      }),
+    );
+  });
+
+  it("aloca com sucesso e registra audit ASSIGN_TABLE", async () => {
+    prismaMock.seatingTable.findUnique.mockResolvedValue({ id: "t1", name: "Mesa 1", capacity: 8 } as never);
+    prismaMock.guest.findMany.mockResolvedValue([] as never);
+    prismaMock.guest.findUnique.mockResolvedValue({ plusOnesConfirmed: 1, deletedAt: null } as never);
+    prismaMock.guest.updateMany.mockResolvedValue({ count: 1 } as never);
+    const res = await assignGuestToTable("g1", "t1");
+    expect(res).toEqual({ success: true });
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: "ASSIGN_TABLE", entity: "Guest", entityId: "g1" }),
+      }),
+    );
+  });
+
+  it("desaloca (tableId null) sem validar capacidade e registra UNASSIGN_TABLE", async () => {
+    prismaMock.guest.updateMany.mockResolvedValue({ count: 1 } as never);
+    const res = await assignGuestToTable("g1", null);
+    expect(res).toEqual({ success: true });
+    expect(prismaMock.seatingTable.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ action: "UNASSIGN_TABLE" }) }),
+    );
+  });
+
+  it("erro quando o convidado some entre a checagem e o update (count 0)", async () => {
+    prismaMock.guest.updateMany.mockResolvedValue({ count: 0 } as never);
+    const res = await assignGuestToTable("g1", null);
+    expect(res).toEqual({ success: false, error: "Convidado não encontrado" });
+    expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("reorderSeatingTables", () => {
+  it("rejeita lista vazia sem tocar o banco", async () => {
+    const res = await reorderSeatingTables([]);
+    expect(res.success).toBe(false);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejeita id acima de 64 chars", async () => {
+    const res = await reorderSeatingTables(["x".repeat(65)]);
+    expect(res.success).toBe(false);
+  });
+
+  it("persiste sortOrder sequencial e registra audit REORDER", async () => {
+    prismaMock.seatingTable.updateMany.mockResolvedValue({ count: 1 } as never);
+    const res = await reorderSeatingTables(["t3", "t1", "t2"]);
+    expect(res).toEqual({ success: true });
+    expect(prismaMock.seatingTable.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ id: "t3" }), data: { sortOrder: 0 } }),
+    );
+    expect(prismaMock.seatingTable.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ id: "t2" }), data: { sortOrder: 2 } }),
+    );
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ action: "REORDER" }) }),
+    );
+  });
+});

--- a/src/app/actions/seatingTableActions.test.ts
+++ b/src/app/actions/seatingTableActions.test.ts
@@ -14,9 +14,9 @@ beforeEach(() => {
   authMock.mockResolvedValue({ user: { id: "test-user", role: "ADMIN" } });
   prismaMock.auditLog.create.mockResolvedValue({} as never);
   // Suporta as duas formas usadas pelas actions: callback (assign) e array (reorder).
-  prismaMock.$transaction.mockImplementation((arg: unknown) => {
+  prismaMock.$transaction.mockImplementation(async (arg: unknown) => {
     if (typeof arg === "function") {
-      return (arg as (tx: typeof prismaMock) => unknown)(prismaMock);
+      return (arg as (tx: typeof prismaMock) => Promise<unknown>)(prismaMock);
     }
     return Promise.all(arg as Promise<unknown>[]);
   });

--- a/src/app/actions/seatingTableActions.ts
+++ b/src/app/actions/seatingTableActions.ts
@@ -109,6 +109,35 @@ export async function deleteSeatingTable(tableId: string): Promise<ActionResult>
   }
 }
 
+const ReorderSchema = z.array(z.string().min(1).max(64)).min(1).max(200);
+
+export async function reorderSeatingTables(orderedIds: string[]): Promise<ActionResult> {
+  const denied = await denyIfNoEdit();
+  if (denied) return denied;
+
+  const parsed = ReorderSchema.safeParse(orderedIds);
+  if (!parsed.success) {
+    return { success: false, error: "Ordem inválida" };
+  }
+  const ids = parsed.data;
+  try {
+    await prisma.$transaction(
+      ids.map((id, i) =>
+        prisma.seatingTable.updateMany({
+          where: { id, deletedAt: null },
+          data: { sortOrder: i },
+        }),
+      ),
+    );
+    await audit("SeatingTable", ids[0], "REORDER", { count: ids.length });
+    revalidatePath("/dashboard/wedding-day/seating");
+    return { success: true };
+  } catch (err) {
+    console.error("[reorderSeatingTables]", err);
+    return { success: false, error: "Erro ao reordenar mesas" };
+  }
+}
+
 export async function updateTablePosition(
   tableId: string,
   x: number,

--- a/src/app/dashboard/_components/nav-links.ts
+++ b/src/app/dashboard/_components/nav-links.ts
@@ -3,6 +3,7 @@
 import { useSession } from "next-auth/react";
 import { canViewSensitiveFinance } from "@/lib/permissions";
 import {
+  Armchair,
   BarChart3,
   Building2,
   CalendarHeart,
@@ -42,7 +43,8 @@ export const LINKS: NavLink[] = [
   { href: "/dashboard/goals", labelKey: "nav.goals", icon: Target, finance: true },
   { href: "/dashboard/guests", labelKey: "nav.guests", icon: UserPlus },
   { href: "/dashboard/gifts", labelKey: "nav.gifts", icon: Gift },
-  { href: "/dashboard/wedding-day", labelKey: "nav.weddingDay", icon: CalendarHeart },
+  { href: "/dashboard/wedding-day", labelKey: "nav.weddingDay", icon: CalendarHeart, exact: true },
+  { href: "/dashboard/wedding-day/seating", labelKey: "nav.seating", icon: Armchair },
   { href: "/dashboard/honeymoon", labelKey: "nav.honeymoon", icon: Plane },
   { href: "/dashboard/trousseau", labelKey: "nav.trousseau", icon: ShoppingBasket },
   { href: "/dashboard/settings", labelKey: "nav.settings", icon: SettingsIcon },
@@ -80,7 +82,12 @@ export const NAV_CATEGORIES: NavCategory[] = [
   {
     id: "wedding",
     labelKey: "nav.cat.wedding",
-    hrefs: ["/dashboard/wedding-day", "/dashboard/honeymoon", "/dashboard/trousseau"],
+    hrefs: [
+      "/dashboard/wedding-day",
+      "/dashboard/wedding-day/seating",
+      "/dashboard/honeymoon",
+      "/dashboard/trousseau",
+    ],
   },
   {
     id: "people",

--- a/src/app/dashboard/wedding-day/seating/_components/TableCard.tsx
+++ b/src/app/dashboard/wedding-day/seating/_components/TableCard.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useDroppable } from "@dnd-kit/core";
-import { Circle, RectangleVertical, Square, Trash2, Edit3 } from "lucide-react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Circle, GripVertical, RectangleVertical, Square, Trash2, Edit3 } from "lucide-react";
 import type { ReactNode } from "react";
 
 type Shape = "ROUND" | "RECT" | "SQUARE";
@@ -25,18 +27,38 @@ export function TableCard({
   onEdit?: () => void;
   onDelete?: () => void;
 }) {
-  const { setNodeRef, isOver } = useDroppable({
+  const {
+    setNodeRef: setSortableRef,
+    setActivatorNodeRef,
+    attributes,
+    listeners,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, data: { type: "table-sort", tableId: id } });
+  const { setNodeRef: setDroppableRef, isOver } = useDroppable({
     id: `table:${id}`,
     data: { type: "table", tableId: id, capacity },
   });
+
+  const setRefs = (node: HTMLElement | null) => {
+    setSortableRef(node);
+    setDroppableRef(node);
+  };
 
   const full = seatsUsed >= capacity;
   const ShapeIcon = shape === "ROUND" ? Circle : shape === "RECT" ? RectangleVertical : Square;
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setRefs}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
       className={`flex min-h-32 flex-col rounded-2xl border bg-zinc-900/60 p-3 transition ${
+        isDragging ? "opacity-40" : ""
+      } ${
         isOver
           ? full
             ? "border-rose-500 bg-rose-500/5"
@@ -45,7 +67,17 @@ export function TableCard({
       }`}
     >
       <header className="mb-2 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <button
+            type="button"
+            ref={setActivatorNodeRef}
+            {...attributes}
+            {...listeners}
+            aria-label="Reordenar mesa"
+            className="flex-none cursor-grab touch-none rounded p-0.5 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 active:cursor-grabbing"
+          >
+            <GripVertical className="h-4 w-4" />
+          </button>
           <ShapeIcon className="h-4 w-4 flex-none text-zinc-400" />
           <span className="truncate text-sm font-medium text-zinc-100">{name}</span>
         </div>

--- a/src/app/dashboard/wedding-day/seating/page.tsx
+++ b/src/app/dashboard/wedding-day/seating/page.tsx
@@ -11,7 +11,7 @@ export default async function SeatingPage() {
 
   const [tables, guests] = await Promise.all([
     prisma.seatingTable.findMany({
-      orderBy: { createdAt: "asc" },
+      orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
     }),
     prisma.guest.findMany({
       where: { rsvpStatus: "CONFIRMED" },

--- a/src/app/dashboard/wedding-day/seating/seating-client.tsx
+++ b/src/app/dashboard/wedding-day/seating/seating-client.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useTransition } from "react";
 import {
   DndContext,
+  type CollisionDetection,
   type DragEndEvent,
   type DragStartEvent,
   DragOverlay,
@@ -12,8 +13,10 @@ import {
   useSensor,
   useSensors,
   pointerWithin,
+  closestCenter,
 } from "@dnd-kit/core";
-import { Plus, Users, Info } from "lucide-react";
+import { SortableContext, arrayMove, rectSortingStrategy } from "@dnd-kit/sortable";
+import { GripVertical, Plus, Users, Info } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
@@ -21,6 +24,7 @@ import {
   assignGuestToTable,
   createSeatingTable,
   deleteSeatingTable,
+  reorderSeatingTables,
   updateSeatingTable,
 } from "@/app/actions/seatingTableActions";
 import { GuestChip, type GuestChipData } from "./_components/GuestChip";
@@ -33,6 +37,7 @@ type Table = {
   shape: string;
   x: number;
   y: number;
+  sortOrder: number;
   notes: string | null;
 };
 
@@ -46,6 +51,27 @@ function computeSeatsUsed(guests: GuestChipData[], tableId: string): number {
     .filter((g) => g.tableId === tableId)
     .reduce((sum, g) => sum + 1 + (g.plusOnesConfirmed ?? 0), 0);
 }
+
+// Guests droppam em mesas/pool; mesas reordenam entre si. Filtramos os candidatos
+// pelo tipo do item ativo para o `over` nunca ficar ambíguo (cada card é, ao mesmo
+// tempo, um item sortable e um droppable de convidado).
+const seatingCollision: CollisionDetection = (args) => {
+  const activeType = args.active.data.current?.type;
+  if (activeType === "table-sort") {
+    return closestCenter({
+      ...args,
+      droppableContainers: args.droppableContainers.filter(
+        (c) => c.data.current?.type === "table-sort",
+      ),
+    });
+  }
+  return pointerWithin({
+    ...args,
+    droppableContainers: args.droppableContainers.filter(
+      (c) => c.data.current?.type === "table" || c.data.current?.type === "pool",
+    ),
+  });
+};
 
 export default function SeatingClient({ initialTables, initialGuests }: Props) {
   const router = useRouter();
@@ -64,6 +90,7 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
     setGuests(initialGuests);
   }
   const [activeGuest, setActiveGuest] = useState<GuestChipData | null>(null);
+  const [activeTable, setActiveTable] = useState<Table | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [editing, setEditing] = useState<Table | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<Table | null>(null);
@@ -87,11 +114,42 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
       const guestId = idStr.slice("guest:".length);
       const guest = guests.find((g) => g.id === guestId);
       if (guest) setActiveGuest(guest);
+      return;
     }
+    const table = tables.find((t) => t.id === idStr);
+    if (table) setActiveTable(table);
+  }
+
+  function handleReorder(e: DragEndEvent) {
+    const activeId = String(e.active.id);
+    const overId = e.over ? String(e.over.id) : null;
+    if (!overId || overId === activeId) return;
+    const oldIndex = tables.findIndex((t) => t.id === activeId);
+    const newIndex = tables.findIndex((t) => t.id === overId);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const previous = tables;
+    const reordered = arrayMove(tables, oldIndex, newIndex);
+    setTables(reordered);
+
+    startTransition(async () => {
+      const res = await reorderSeatingTables(reordered.map((t) => t.id));
+      if (!res.success) {
+        toast.error("Falha", res.error);
+        setTables(previous);
+      } else {
+        router.refresh();
+      }
+    });
   }
 
   function handleDragEnd(e: DragEndEvent) {
     setActiveGuest(null);
+    setActiveTable(null);
+    if (e.active.data.current?.type === "table-sort") {
+      handleReorder(e);
+      return;
+    }
     const activeId = String(e.active.id);
     if (!activeId.startsWith("guest:")) return;
     const guestId = activeId.slice("guest:".length);
@@ -183,7 +241,7 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={pointerWithin}
+      collisionDetection={seatingCollision}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
     >
@@ -219,34 +277,36 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
               <Info className="h-3.5 w-3.5" />
               {tables.length === 0
                 ? "Crie a primeira mesa para começar."
-                : "Solte um convidado em cima de uma mesa para alocar."}
+                : "Solte um convidado numa mesa para alocar; arraste pela alça para reordenar."}
             </div>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              {tables.map((t) => {
-                const tableGuests = guests.filter((g) => g.tableId === t.id);
-                const seatsUsed = computeSeatsUsed(guests, t.id);
-                return (
-                  <TableCard
-                    key={t.id}
-                    id={t.id}
-                    name={t.name}
-                    capacity={t.capacity}
-                    shape={t.shape as "ROUND" | "RECT" | "SQUARE"}
-                    seatsUsed={seatsUsed}
-                    onEdit={() => setEditing(t)}
-                    onDelete={() => setConfirmDelete(t)}
-                  >
-                    {tableGuests.length === 0 ? (
-                      <p className="rounded-lg border border-dashed border-zinc-700 px-2 py-3 text-center text-[11px] text-zinc-500">
-                        Solte convidados aqui
-                      </p>
-                    ) : (
-                      tableGuests.map((g) => <GuestChip key={g.id} guest={g} compact />)
-                    )}
-                  </TableCard>
-                );
-              })}
-            </div>
+            <SortableContext items={tables.map((t) => t.id)} strategy={rectSortingStrategy}>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                {tables.map((t) => {
+                  const tableGuests = guests.filter((g) => g.tableId === t.id);
+                  const seatsUsed = computeSeatsUsed(guests, t.id);
+                  return (
+                    <TableCard
+                      key={t.id}
+                      id={t.id}
+                      name={t.name}
+                      capacity={t.capacity}
+                      shape={t.shape as "ROUND" | "RECT" | "SQUARE"}
+                      seatsUsed={seatsUsed}
+                      onEdit={() => setEditing(t)}
+                      onDelete={() => setConfirmDelete(t)}
+                    >
+                      {tableGuests.length === 0 ? (
+                        <p className="rounded-lg border border-dashed border-zinc-700 px-2 py-3 text-center text-[11px] text-zinc-500">
+                          Solte convidados aqui
+                        </p>
+                      ) : (
+                        tableGuests.map((g) => <GuestChip key={g.id} guest={g} compact />)
+                      )}
+                    </TableCard>
+                  );
+                })}
+              </div>
+            </SortableContext>
           </section>
         </div>
 
@@ -290,6 +350,14 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
           <div className="rounded-lg border border-rose-500 bg-zinc-900 px-2.5 py-1.5 text-xs text-zinc-100 shadow-lg">
             {activeGuest.name}
             {activeGuest.plusOnesConfirmed > 0 ? ` +${activeGuest.plusOnesConfirmed}` : ""}
+          </div>
+        ) : activeTable ? (
+          <div className="flex items-center gap-2 rounded-2xl border border-rose-500 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 shadow-2xl">
+            <GripVertical className="h-4 w-4 text-zinc-500" />
+            <span className="font-medium">{activeTable.name}</span>
+            <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-[10px] text-zinc-400">
+              {computeSeatsUsed(guests, activeTable.id)}/{activeTable.capacity}
+            </span>
           </div>
         ) : null}
       </DragOverlay>

--- a/src/app/dashboard/wedding-day/wedding-day-client.tsx
+++ b/src/app/dashboard/wedding-day/wedding-day-client.tsx
@@ -4,8 +4,10 @@ import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import {
   AlertTriangle,
+  Armchair,
   CalendarHeart,
   CheckCircle2,
+  ChevronRight,
   CloudRain,
   Loader2,
   Phone,
@@ -150,6 +152,22 @@ export default function WeddingDayClient({
         <Stat label="Chegaram" value={`${checkedIn}/${totalSeats}`} accent={checkedIn > 0 ? "emerald" : "amber"} />
         <Stat label="Tarefas do dia" value={String(tasksToday.length)} accent="amber" />
       </div>
+
+      <Link
+        href="/dashboard/wedding-day/seating"
+        className="flex items-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4 transition-colors hover:border-rose-500/40 hover:bg-zinc-900/80"
+      >
+        <span className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-rose-500/15 text-rose-300">
+          <Armchair className="h-5 w-5" />
+        </span>
+        <div className="min-w-0">
+          <h3 className="font-semibold text-zinc-100">Mapa de assentos</h3>
+          <p className="text-sm text-zinc-400">
+            Organize as mesas e arraste os convidados confirmados para os lugares.
+          </p>
+        </div>
+        <ChevronRight className="ml-auto h-5 w-5 flex-none text-zinc-500" />
+      </Link>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <Card title="Cronograma do dia" icon={<CalendarHeart className="h-5 w-5" />}>

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -19,6 +19,7 @@ export type AuditAction =
   | "BULK_CREATE"
   | "ASSIGN_TABLE"
   | "UNASSIGN_TABLE"
+  | "REORDER"
   | "RSVP_GROUP_RESPOND"
   | "MARK_PIX_RECEIVED"
   | "BACKUP_EXPORT"

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,14 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.6.3",
+    date: "2026-05-27",
+    highlights: [
+      "🪑 'Mapa de assentos' voltou a ter porta de entrada na interface: item no menu lateral (grupo Casamento, abaixo de 'Dia D') e card de atalho no topo de 'Dia do casamento'. Antes só dava para chegar digitando a URL.",
+      "↕️ As mesas agora podem ser reordenadas: arraste cada mesa pela alça (ícone de cabo no cabeçalho) para mudar a ordem no grid — a nova ordem fica salva. Os convidados continuam sendo arrastados normalmente para dentro das mesas.",
+    ],
+  },
+  {
     version: "0.6.2",
     date: "2026-05-26",
     highlights: [

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -734,18 +734,21 @@ export const HELP_ARTICLES: HelpArticle[] = [
     id: "seating-chart",
     title: "Mapa visual de assentos",
     category: "wedding-day",
-    keywords: ["mesa", "assento", "lugar", "seating", "salão", "layout", "drag"],
+    keywords: ["mesa", "assento", "lugar", "seating", "salão", "layout", "drag", "reordenar"],
     icon: Users,
     summary:
-      "Arraste convidados confirmados para mesas com capacidade definida. Use no /dashboard/wedding-day/seating.",
+      "Arraste convidados confirmados para mesas com capacidade definida. Abra pelo menu 'Mapa de assentos' (grupo Casamento) ou pelo card no topo de 'Dia do casamento'.",
     steps: [
+      { title: "Abra o mapa", body: "Menu lateral → 'Mapa de assentos' (logo abaixo de 'Dia D'), ou card de atalho no topo da tela 'Dia do casamento'." },
       { title: "Crie mesas", body: "Botão 'Nova mesa' — defina nome, capacidade e formato (redonda/retangular/quadrada)." },
       { title: "Arraste convidados", body: "O pool lateral lista só quem está CONFIRMADO. Solte um chip em cima da mesa; a capacidade considera +1 confirmados." },
+      { title: "Reordene as mesas", body: "Arraste cada mesa pela alça (ícone de cabo no cabeçalho) para mudar a ordem no grid. A nova ordem fica salva." },
       { title: "Desaloque ou reorganize", body: "Solte de volta no pool para liberar o assento, ou em outra mesa para realocar." },
     ],
     tips: [
       "Capacidade leva em conta acompanhantes. Convidado com +2 ocupa 3 assentos.",
       "Mesa cheia recusa o drop e mostra toast.",
+      "Só a alça move a mesa — assim os chips de convidado dentro do card continuam clicáveis e arrastáveis.",
     ],
   },
   {

--- a/src/messages/en/common.json
+++ b/src/messages/en/common.json
@@ -90,6 +90,7 @@
     "guests": "Guests",
     "gifts": "Gifts",
     "weddingDay": "Wedding day",
+    "seating": "Seating map",
     "honeymoon": "Honeymoon",
     "trousseau": "Trousseau",
     "insights": "Insights",

--- a/src/messages/es/common.json
+++ b/src/messages/es/common.json
@@ -90,6 +90,7 @@
     "guests": "Invitados",
     "gifts": "Regalos",
     "weddingDay": "Día D",
+    "seating": "Mapa de asientos",
     "honeymoon": "Luna de miel",
     "trousseau": "Ajuar",
     "insights": "Insights",

--- a/src/messages/pt-BR/common.json
+++ b/src/messages/pt-BR/common.json
@@ -90,6 +90,7 @@
     "guests": "Convidados",
     "gifts": "Presentes",
     "weddingDay": "Dia D",
+    "seating": "Mapa de assentos",
     "honeymoon": "Lua de mel",
     "trousseau": "Enxoval",
     "insights": "Insights",


### PR DESCRIPTION
## Contexto

A tela de **mapa de assentos** (`/dashboard/wedding-day/seating`) existe e é funcional desde a **v0.3.0** (drag & drop de convidados, validação de capacidade com +1s, soft-delete, audit), mas ficou **órfã**: nenhum link na interface apontava para ela — só dava para chegar digitando a URL.

O changelog **v0.3.2** dizia que o item havia saído do menu top-level mas "continua acessível dentro de 'Dia D'" — porém esse link **nunca chegou a existir**. Esta PR corrige isso e ainda torna as mesas reordenáveis.

## O que muda

### 1. Dois pontos de acesso na UI
- **Menu lateral**: item "Mapa de assentos" (ícone `Armchair`) no grupo Casamento, abaixo de "Dia D". "Dia D" passou a `exact: true` para não destacar dois itens ao navegar para `/seating`.
- **Card de atalho** no topo da página `/dashboard/wedding-day`.
- Chave i18n `nav.seating` adicionada nos **3** catálogos (pt-BR/en/es).

### 2. Reordenação de mesas (grid com alça de arrasto)
- Novo campo `SeatingTable.sortOrder` + action `reorderSeatingTables` (transação, Zod, audit `REORDER`).
- `page.tsx` ordena por `[sortOrder, createdAt]` (mesas antigas com `sortOrder=0` caem no desempate por data).
- `TableCard` vira **sortable** (alça `GripVertical`) **e** continua **droppable** de convidados. Uma `collisionDetection` customizada filtra os candidatos pelo tipo do item ativo, então arrastar convidado e arrastar mesa não se confundem. Usa `@dnd-kit/sortable` (já era dependência).

### 3. Testes
- Novo `seatingTableActions.test.ts` (13 casos): capacidade com +1s do novo convidado e dos já alocados, exclusão do próprio ao reatribuir, desalocação, race no `count=0`, e a reordenação.

## Sincronização de docs
`docs/seating-chart.md`, artigo `seating-chart` no help center, changelog (**v0.6.3**) e README.

## Schema
Adiciona `SeatingTable.sortOrder Int @default(0)` — mudança **aditiva e segura**. Rodar \`npm run db:push\` ao subir o ambiente.

## Verificação
- ✅ `npm run lint` (0 erros)
- ✅ `npm run test:run` (527 testes)
- ✅ `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)