### PR TITLE
feat(users): edição de e-mail + diagnóstico de envios + aviso de RSVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ confirmou a presença.
 - 💍 **Painel do Dia D** (cronograma, plano B chuva, contatos críticos, check-in)
 - 🪑 **Mapa de assentos** — arraste convidados confirmados para as mesas e reordene as mesas pela alça; capacidade considera +1s
 - 📊 **Insights** financeiros (health score, heatmap, detector de creep)
-- 📨 **Notificações por email + WhatsApp** (Baileys) — no idioma do destinatário
+- 📨 **Notificações por email + WhatsApp** (Baileys) — no idioma do destinatário, com aviso aos noivos quando um convidado responde o RSVP e painel de diagnóstico de envios (Ajustes › Notificações)
 - 🌐 **Multi-idioma** (pt-BR, inglês, espanhol) — escolhido por usuário e respeitado em emails/WhatsApp/RSVP
 - 🔐 **2FA TOTP**, reset por email/WhatsApp, audit log
 - 📅 **iCalendar (.ics)** para sincronizar com Google/Apple Calendar

--- a/docs/notificacoes.md
+++ b/docs/notificacoes.md
@@ -29,14 +29,29 @@ banco. Veja [i18n.md](i18n.md) para o padrão completo.
 | `PAYMENT_OVERDUE` | Pagamento já passou da data | ✅ | ✅ |
 | `TASK_DUE` | Tarefa vence em até 2 dias | ✅ | ✅ |
 | `TASK_OVERDUE` | Tarefa já passou da data | ✅ | ✅ |
+| `GUEST_RSVP` | Convidado responde o RSVP (individual ou de grupo) | ✅ (gestores/noivos) | ✅ |
 | `SYSTEM_WHATSAPP_DOWN` | Conexão WhatsApp caiu por > ~1 min, ou exige novo QR | ✅ (admins) | — |
 | `SYSTEM_WHATSAPP_RECOVERED` | Conexão WhatsApp voltou após queda já avisada | ✅ (admins) | — |
 
+`GUEST_RSVP` vai para todos os usuários ativos com role `ADMIN`/`GROOM`/`BRIDE`/`PLANNER`
+(reusa o mesmo conjunto do cron de lembretes). É **best-effort** e **deduplicado por dia**
+por `refId` (o convidado/grupo só gera uma notificação por dia, mesmo reabrindo o link).
+O disparo é em `notifyRsvpResponse` ([src/lib/notifications/rsvp.ts](../src/lib/notifications/rsvp.ts)),
+chamado por `publicRsvpRespond` e `publicRsvpRespondForGroup`.
+
 Cada envio é registrado em `NotificationLog`:
-- `status` = `OK` | `ERROR`
+- `status` = `SENT` | `FAILED`
 - `errorMsg` em caso de falha
 - `kind` + `refType` + `refId` permitem **idempotência por dia** (um pagamento
   X nunca recebe duas notificações `PAYMENT_DUE` no mesmo dia).
+
+### Diagnóstico de envios (Ajustes › Notificações)
+
+Gestores (ADMIN/GROOM/BRIDE) veem em **Ajustes › Notificações** os últimos 50 envios
+(`NotificationLog`) com tipo, canal, destinatário, `status` (SENT/FAILED) e a mensagem de
+erro do SMTP. Use isso para diagnosticar, por exemplo, falhas recorrentes quando o admin
+ainda está com o e-mail placeholder `admin@admin.com` do seed — troque o e-mail em
+**Ajustes › Time** (qualquer usuário) ou em **Perfil** (o seu, com confirmação de senha).
 
 ## Configuração SMTP
 

--- a/docs/permissoes.md
+++ b/docs/permissoes.md
@@ -77,6 +77,17 @@ Estas roles **também** são bloqueadas das áreas financeiras (`canViewSensitiv
 
 Ajustes › Time › "Convidar membro". Defina a role na criação. Comportamento de finanças aplica imediatamente.
 
+## Gestão de e-mails
+
+- **Editar e-mail de qualquer usuário**: gestores (ADMIN/GROOM/BRIDE — `canManageUsers`) usam
+  **Ajustes › Time › editar membro**. O `updateUser` valida unicidade do e-mail (campo `@unique`).
+  É a forma de corrigir o `admin@admin.com` placeholder criado pelo seed e de cadastrar os
+  e-mails reais dos noivos para que recebam lembretes e RSVPs.
+- **Editar o próprio e-mail**: qualquer usuário em **Perfil** (`/dashboard/profile`), informando
+  a **senha atual** (`updateOwnEmail` em [src/app/actions/profileActions.ts](../src/app/actions/profileActions.ts)).
+- Trocar o e-mail **não** derruba a sessão atual (a sessão é keyed por `id`); o novo e-mail
+  passa a valer no **próximo login**. Ambas as ações gravam `AuditLog` (`action: "UPDATE"`).
+
 ## Anexos e contratos (v0.4.0)
 
 Funções específicas em `src/lib/permissions.ts`:

--- a/src/app/actions/guestActions.ts
+++ b/src/app/actions/guestActions.ts
@@ -7,6 +7,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { notifyRsvpResponse } from "@/lib/notifications/rsvp";
 import { getClientIp, rateLimit } from "@/lib/rate-limit";
 import {
   detectMagic,
@@ -340,6 +341,15 @@ export async function publicRsvpRespond(
       },
     });
     revalidatePath("/dashboard/guests");
+
+    void notifyRsvpResponse({
+      refType: "Guest",
+      refId: updated.id,
+      guestName: updated.name,
+      rsvpStatus: updated.rsvpStatus,
+      plusOnes: updated.plusOnesConfirmed,
+    });
+
     return { success: true, data: { name: updated.name, status: updated.rsvpStatus } };
   } catch (err) {
     console.error("[publicRsvpRespond]", err);

--- a/src/app/actions/guestGroupActions.ts
+++ b/src/app/actions/guestGroupActions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { notifyRsvpResponse } from "@/lib/notifications/rsvp";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -240,6 +241,13 @@ export async function publicRsvpRespondForGroup(input: {
     });
     revalidatePath("/dashboard/guests");
     revalidatePath("/dashboard/guests/groups");
+
+    void notifyRsvpResponse({
+      refType: "GuestGroup",
+      refId: group.id,
+      guestName: group.name,
+      rsvpStatus: "RESPONDED",
+    });
 
     return {
       success: true,

--- a/src/app/actions/profileActions.test.ts
+++ b/src/app/actions/profileActions.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import bcrypt from "bcryptjs";
+import { prismaMock } from "@/test-utils/prisma";
+
+const authMock = vi.fn();
+vi.mock("@/auth", () => ({ auth: () => authMock() }));
+
+import { updateOwnEmail } from "./profileActions";
+
+function fd(obj: Record<string, string>): FormData {
+  const f = new FormData();
+  for (const [k, v] of Object.entries(obj)) f.set(k, v);
+  return f;
+}
+
+let hash: string;
+
+beforeEach(async () => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  prismaMock.auditLog.create.mockResolvedValue({} as never);
+  authMock.mockReset();
+  authMock.mockResolvedValue({ user: { id: "me" } });
+  hash = await bcrypt.hash("secret", 10);
+  prismaMock.user.findUnique.mockImplementation(
+    ((args: { where: { id?: string; email?: string } }) => {
+      const w = args.where;
+      if (w.id === "me") return Promise.resolve({ id: "me", email: "old@x.com", password: hash });
+      if (w.email === "taken@x.com") return Promise.resolve({ id: "other" });
+      return Promise.resolve(null);
+    }) as never,
+  );
+  prismaMock.user.update.mockResolvedValue({} as never);
+});
+
+describe("updateOwnEmail", () => {
+  it("rejeita quando a senha atual está incorreta", async () => {
+    const r = await updateOwnEmail(undefined, fd({ currentPassword: "wrong", email: "new@x.com" }));
+    expect(r.success).toBe(false);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("rejeita quando o e-mail já pertence a outro usuário", async () => {
+    const r = await updateOwnEmail(
+      undefined,
+      fd({ currentPassword: "secret", email: "taken@x.com" }),
+    );
+    expect(r.success).toBe(false);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("troca o e-mail com sucesso (normalizado) e registra audit", async () => {
+    const r = await updateOwnEmail(undefined, fd({ currentPassword: "secret", email: "New@x.com" }));
+    expect(r.success).toBe(true);
+    const call = prismaMock.user.update.mock.calls[0][0] as { data: { email?: string } };
+    expect(call.data.email).toBe("new@x.com");
+    expect(prismaMock.auditLog.create).toHaveBeenCalled();
+  });
+});

--- a/src/app/actions/profileActions.ts
+++ b/src/app/actions/profileActions.ts
@@ -1,7 +1,9 @@
 "use server";
 
 import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import bcrypt from "bcryptjs";
 import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
@@ -44,6 +46,58 @@ export async function updateLocale(
     return { success: true, data: { locale: parsed.data.locale as Locale } };
   } catch (err) {
     console.error("[updateLocale]", err);
+    return { success: false, error: t("errorSaving") };
+  }
+}
+
+const EmailSchema = z.object({
+  currentPassword: z.string().min(1).max(128),
+  email: z.string().trim().toLowerCase().email().max(160),
+});
+
+export async function updateOwnEmail(
+  _state: ActionResult | undefined,
+  formData: FormData,
+): Promise<ActionResult> {
+  const t = await getTranslations("actions.profile");
+  const tc = await getTranslations("actions.common");
+
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) return { success: false, error: tc("unauthorized") };
+
+  const parsed = EmailSchema.safeParse(Object.fromEntries(formData.entries()));
+  if (!parsed.success) {
+    return { success: false, error: t("invalidEmail") };
+  }
+
+  try {
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) return { success: false, error: tc("unauthorized") };
+
+    const ok = await bcrypt.compare(parsed.data.currentPassword, user.password);
+    if (!ok) return { success: false, error: t("wrongPassword") };
+
+    if (parsed.data.email !== user.email) {
+      const owner = await prisma.user.findUnique({
+        where: { email: parsed.data.email },
+        select: { id: true },
+      });
+      if (owner && owner.id !== user.id) {
+        return { success: false, error: t("emailTaken") };
+      }
+    }
+
+    await prisma.user.update({ where: { id: userId }, data: { email: parsed.data.email } });
+    await audit("User", userId, "UPDATE", { changes: { email: parsed.data.email }, self: true });
+    revalidatePath("/dashboard");
+    revalidatePath("/dashboard/profile");
+    return { success: true };
+  } catch (err) {
+    if (typeof err === "object" && err !== null && (err as { code?: string }).code === "P2002") {
+      return { success: false, error: t("emailTaken") };
+    }
+    console.error("[updateOwnEmail]", err);
     return { success: false, error: t("errorSaving") };
   }
 }

--- a/src/app/actions/userActions.test.ts
+++ b/src/app/actions/userActions.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prismaMock } from "@/test-utils/prisma";
+
+const authMock = vi.fn();
+vi.mock("@/auth", () => ({ auth: () => authMock() }));
+
+import { updateUser } from "./userActions";
+
+function fd(obj: Record<string, string>): FormData {
+  const f = new FormData();
+  for (const [k, v] of Object.entries(obj)) f.set(k, v);
+  return f;
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  prismaMock.auditLog.create.mockResolvedValue({} as never);
+  authMock.mockReset();
+  authMock.mockResolvedValue({ user: { id: "me", email: "me@x.com", role: "ADMIN" } });
+  prismaMock.user.findUnique.mockImplementation(
+    ((args: { where: { id?: string; email?: string } }) => {
+      const w = args.where;
+      if (w.id === "me")
+        return Promise.resolve({
+          id: "me",
+          email: "me@x.com",
+          role: "ADMIN",
+          isActive: true,
+          archivedAt: null,
+        });
+      if (w.id === "t1")
+        return Promise.resolve({
+          id: "t1",
+          email: "old@x.com",
+          role: "GROOM",
+          isActive: true,
+          archivedAt: null,
+        });
+      if (w.email === "taken@x.com") return Promise.resolve({ id: "other" });
+      return Promise.resolve(null);
+    }) as never,
+  );
+  prismaMock.user.update.mockResolvedValue({} as never);
+});
+
+describe("updateUser — email", () => {
+  it("troca o email com sucesso (normalizado para minúsculas)", async () => {
+    const r = await updateUser(undefined, fd({ id: "t1", name: "Novo", email: "New@x.com" }));
+    expect(r.success).toBe(true);
+    const call = prismaMock.user.update.mock.calls[0][0] as { data: { email?: string } };
+    expect(call.data.email).toBe("new@x.com");
+  });
+
+  it("rejeita email já usado por outro usuário e não grava", async () => {
+    const r = await updateUser(undefined, fd({ id: "t1", email: "taken@x.com" }));
+    expect(r.success).toBe(false);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("não inclui email no update quando é o mesmo do usuário", async () => {
+    const r = await updateUser(undefined, fd({ id: "t1", email: "old@x.com", name: "Old" }));
+    expect(r.success).toBe(true);
+    const call = prismaMock.user.update.mock.calls[0][0] as { data: { email?: string } };
+    expect(call.data.email).toBeUndefined();
+  });
+});

--- a/src/app/actions/userActions.ts
+++ b/src/app/actions/userActions.ts
@@ -170,6 +170,7 @@ export async function createUser(
 const UpdateSchema = z.object({
   id: z.string().min(1).max(64),
   name: z.string().trim().min(1).max(120).optional(),
+  email: emailSchema().optional(),
   phone: PhoneSchema.optional(),
   role: RoleSchema.optional(),
   isActive: z
@@ -194,12 +195,12 @@ export async function updateUser(
   if (!parsed.success) {
     return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
   }
-  const { id, name, phone, role, isActive } = parsed.data;
+  const { id, name, email, phone, role, isActive } = parsed.data;
 
   try {
     const target = await prisma.user.findUnique({
       where: { id },
-      select: { id: true, role: true, isActive: true, archivedAt: true },
+      select: { id: true, email: true, role: true, isActive: true, archivedAt: true },
     });
     if (!target || target.archivedAt) return { success: false, error: "Usuário não encontrado" };
 
@@ -219,8 +220,16 @@ export async function updateUser(
       }
     }
 
+    if (email && email !== target.email) {
+      const owner = await prisma.user.findUnique({ where: { email }, select: { id: true } });
+      if (owner && owner.id !== target.id) {
+        return { success: false, error: "Já existe um usuário com este email" };
+      }
+    }
+
     const data: Record<string, unknown> = {};
     if (typeof name === "string") data.name = name;
+    if (email && email !== target.email) data.email = email;
     if (phone !== undefined) data.phone = phone;
     if (role) data.role = role;
     if (typeof isActive === "boolean") data.isActive = isActive;
@@ -231,6 +240,9 @@ export async function updateUser(
     revalidatePath("/dashboard/settings");
     return { success: true };
   } catch (err) {
+    if (typeof err === "object" && err !== null && (err as { code?: string }).code === "P2002") {
+      return { success: false, error: "Já existe um usuário com este email" };
+    }
     console.error("[updateUser]", err);
     return { success: false, error: "Erro ao atualizar usuário" };
   }

--- a/src/app/dashboard/profile/profile-client.tsx
+++ b/src/app/dashboard/profile/profile-client.tsx
@@ -3,8 +3,8 @@
 import { useActionState, useEffect, useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { Globe, Lock, Loader2 } from "lucide-react";
-import { updateLocale } from "@/app/actions/profileActions";
+import { Globe, Lock, Loader2, Mail } from "lucide-react";
+import { updateLocale, updateOwnEmail } from "@/app/actions/profileActions";
 import { LOCALES, LOCALE_NATIVE_LABELS, type Locale } from "@/i18n/config";
 import { useToast } from "@/components/toast";
 
@@ -17,9 +17,11 @@ type Initial = {
 export default function ProfileClient({ initial }: { initial: Initial }) {
   const t = useTranslations("common");
   const tn = useTranslations("common.nav");
+  const ta = useTranslations("actions.profile");
   const toast = useToast();
   const [locale, setLocaleState] = useState<Locale>(initial.locale);
   const [state, formAction, pending] = useActionState(updateLocale, undefined);
+  const [emailState, emailAction, emailPending] = useActionState(updateOwnEmail, undefined);
 
   useEffect(() => {
     if (state?.success) {
@@ -30,6 +32,15 @@ export default function ProfileClient({ initial }: { initial: Initial }) {
     }
   }, [state, t, tn, toast]);
 
+  useEffect(() => {
+    if (emailState?.success) {
+      toast.success(ta("emailUpdated"));
+      window.location.reload();
+    } else if (emailState && !emailState.success) {
+      toast.error(t("common.errorGeneric"), emailState.error);
+    }
+  }, [emailState, t, ta, toast]);
+
   return (
     <div className="space-y-6">
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
@@ -37,6 +48,48 @@ export default function ProfileClient({ initial }: { initial: Initial }) {
         <p className="mt-1 text-sm text-zinc-400">{initial.name || "—"}</p>
         <h2 className="mt-4 text-lg font-semibold text-white">{t("labels.email")}</h2>
         <p className="mt-1 text-sm text-zinc-400">{initial.email}</p>
+      </section>
+
+      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
+        <div className="flex items-center gap-2">
+          <Mail className="h-5 w-5 text-rose-400" />
+          <h2 className="text-lg font-semibold text-white">{t("profile.changeEmailTitle")}</h2>
+        </div>
+        <p className="mt-1 text-sm text-zinc-400">{t("profile.reloginHint")}</p>
+        <form action={emailAction} className="mt-4 space-y-3">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">
+              {t("profile.currentPassword")}
+            </label>
+            <input
+              type="password"
+              name="currentPassword"
+              required
+              autoComplete="current-password"
+              className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">
+              {t("profile.newEmail")}
+            </label>
+            <input
+              type="email"
+              name="email"
+              required
+              defaultValue={initial.email}
+              className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={emailPending}
+            className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
+          >
+            {emailPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            {t("actions.save")}
+          </button>
+        </form>
       </section>
 
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { getEventConfig } from "@/lib/event-config";
 import { getSecuritySettings } from "@/lib/security-settings";
+import { canManageUsers } from "@/lib/permissions";
 import { toIsoDate } from "@/lib/format";
 import SettingsClient from "./settings-client";
 
@@ -48,6 +49,23 @@ export default async function SettingsPage() {
 
   const securitySettings = await getSecuritySettings();
 
+  const notificationLogs = canManageUsers(me?.role)
+    ? await prisma.notificationLog.findMany({
+        orderBy: { createdAt: "desc" },
+        take: 50,
+        select: {
+          id: true,
+          kind: true,
+          channel: true,
+          targetEmail: true,
+          targetPhone: true,
+          status: true,
+          errorMsg: true,
+          createdAt: true,
+        },
+      })
+    : [];
+
   return (
     <div className="space-y-6">
       <div>
@@ -70,6 +88,7 @@ export default async function SettingsPage() {
         me={me}
         members={members}
         securitySettings={securitySettings}
+        notificationLogs={notificationLogs}
       />
     </div>
   );

--- a/src/app/dashboard/settings/settings-client.tsx
+++ b/src/app/dashboard/settings/settings-client.tsx
@@ -8,6 +8,7 @@ import {
   Download,
   KeyRound,
   Loader2,
+  Mail,
   MoreVertical,
   Pencil,
   Power,
@@ -96,7 +97,18 @@ type Member = {
 
 const ROLE_OPTIONS: Role[] = [...ROLES];
 
-type Tab = "event" | "security" | "team" | "whatsapp" | "profile" | "backup";
+type NotificationLogEntry = {
+  id: string;
+  kind: string;
+  channel: string;
+  targetEmail: string | null;
+  targetPhone: string | null;
+  status: string;
+  errorMsg: string | null;
+  createdAt: Date;
+};
+
+type Tab = "event" | "security" | "team" | "whatsapp" | "profile" | "backup" | "notifications";
 
 export default function SettingsClient({
   initial,
@@ -104,12 +116,14 @@ export default function SettingsClient({
   me,
   members,
   securitySettings,
+  notificationLogs,
 }: {
   initial: Initial;
   pixSettings: PixSettings;
   me: Me;
   members: Member[];
   securitySettings: SecuritySettings;
+  notificationLogs: NotificationLogEntry[];
 }) {
   const toast = useToast();
   const [tab, setTab] = useState<Tab>("event");
@@ -128,6 +142,11 @@ export default function SettingsClient({
         <TabBtn current={tab} value="team" onClick={() => setTab("team")}>
           Time
         </TabBtn>
+        {manageUsers ? (
+          <TabBtn current={tab} value="notifications" onClick={() => setTab("notifications")}>
+            Notificações
+          </TabBtn>
+        ) : null}
         {isAdmin ? (
           <TabBtn current={tab} value="whatsapp" onClick={() => setTab("whatsapp")}>
             WhatsApp
@@ -159,7 +178,76 @@ export default function SettingsClient({
       {tab === "whatsapp" && isAdmin ? <WhatsAppTab toast={toast} /> : null}
       {tab === "profile" ? <ProfileTab me={me} toast={toast} /> : null}
       {tab === "backup" ? <BackupTab isAdmin={isAdmin} toast={toast} /> : null}
+      {tab === "notifications" && manageUsers ? (
+        <NotificationsTab logs={notificationLogs} />
+      ) : null}
     </div>
+  );
+}
+
+function NotificationsTab({ logs }: { logs: NotificationLogEntry[] }) {
+  return (
+    <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
+      <div className="flex items-center gap-2">
+        <Mail className="h-5 w-5 text-rose-400" />
+        <h2 className="text-lg font-semibold text-white">Envios recentes</h2>
+      </div>
+      <p className="mt-1 text-sm text-zinc-500">
+        Últimos 50 envios de e-mail/WhatsApp. Use esta lista para diagnosticar falhas de SMTP ou
+        destinatário inválido (ex.: o admin@admin.com padrão do seed).
+      </p>
+      {logs.length === 0 ? (
+        <p className="mt-4 rounded-xl border border-dashed border-zinc-800 px-4 py-8 text-center text-sm text-zinc-500">
+          Nenhum envio registrado ainda.
+        </p>
+      ) : (
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-zinc-800 text-left text-xs uppercase tracking-wide text-zinc-500">
+                <th className="py-2 pr-3 font-medium">Quando</th>
+                <th className="py-2 pr-3 font-medium">Tipo</th>
+                <th className="py-2 pr-3 font-medium">Canal</th>
+                <th className="py-2 pr-3 font-medium">Destinatário</th>
+                <th className="py-2 pr-3 font-medium">Status</th>
+                <th className="py-2 font-medium">Erro</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((l) => {
+                const failed = l.status === "FAILED";
+                return (
+                  <tr key={l.id} className="border-b border-zinc-900 align-top">
+                    <td className="py-2 pr-3 whitespace-nowrap text-zinc-400">
+                      {formatDateTimeBR(l.createdAt)}
+                    </td>
+                    <td className="py-2 pr-3 text-zinc-300">{l.kind}</td>
+                    <td className="py-2 pr-3 text-zinc-400">{l.channel}</td>
+                    <td className="py-2 pr-3 text-zinc-400">
+                      {l.targetEmail ?? l.targetPhone ?? "—"}
+                    </td>
+                    <td className="py-2 pr-3">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                          failed
+                            ? "bg-rose-500/20 text-rose-300"
+                            : "bg-emerald-500/20 text-emerald-300"
+                        }`}
+                      >
+                        {l.status}
+                      </span>
+                    </td>
+                    <td className="py-2 text-xs text-rose-300/80 break-words">
+                      {l.errorMsg ?? ""}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -1115,6 +1203,7 @@ function EditUserModal({
     <Modal onClose={onClose} title={`Editar ${member.name ?? member.email}`}>
       <form action={handle} className="space-y-3">
         <Field name="name" label="Nome" required defaultValue={member.name ?? ""} />
+        <Field name="email" label="E-mail" type="email" required defaultValue={member.email} />
         <Field
           name="phone"
           label="Telefone (WhatsApp, opcional)"

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,15 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.6.4",
+    date: "2026-05-27",
+    highlights: [
+      "✉️ Agora dá para trocar o e-mail de qualquer usuário em Ajustes › Time (corrige o admin@admin.com padrão e cadastra os e-mails reais dos noivos) e o seu próprio e-mail em Perfil, confirmando a senha atual.",
+      "📋 Nova aba Ajustes › Notificações: lista os últimos 50 envios de e-mail/WhatsApp com status (enviado/falhou) e a mensagem de erro — fim do mistério de 'o e-mail não chega'.",
+      "💌 Quando um convidado responde o RSVP (individual ou em grupo), os noivos/gestores recebem um aviso por e-mail/WhatsApp (deduplicado por dia).",
+    ],
+  },
+  {
     version: "0.6.3",
     date: "2026-05-27",
     highlights: [

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -237,6 +237,14 @@ export const HELP_ARTICLES: HelpArticle[] = [
         body: "Uma senha provisória é gerada e enviada por email (e WhatsApp, se configurado) ao novo usuário.",
       },
       { title: "Primeiro login do convidado", body: "Ele(a) será forçado(a) a trocar a senha imediatamente." },
+      {
+        title: "Trocar o e-mail de um usuário",
+        body: "Em Ajustes › Time, edite o membro e altere o campo 'E-mail'. É assim que você corrige o admin@admin.com padrão e cadastra os e-mails reais dos noivos. Cada um também pode trocar o próprio e-mail em Perfil (pedindo a senha atual).",
+      },
+    ],
+    tips: [
+      "O e-mail é o login. Ao trocá-lo, use o novo no próximo login — a sessão aberta continua valendo.",
+      "Sem um e-mail real cadastrado, lembretes e avisos de RSVP falham no envio (veja Ajustes › Notificações).",
     ],
     warnings: ["O cadastro público está desativado — só admins criam contas."],
   },
@@ -499,6 +507,10 @@ export const HELP_ARTICLES: HelpArticle[] = [
         body: "Defina SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM. Reinicie o servidor após mudar .env.",
       },
       { title: "Teste", body: "Crie uma tarefa com deadline em alguns minutos e rode o cron manualmente para validar." },
+      {
+        title: "Diagnostique falhas em Ajustes › Notificações",
+        body: "Os últimos 50 envios aparecem ali com status SENT/FAILED e a mensagem de erro do SMTP. Erros repetidos para admin@admin.com indicam que o e-mail placeholder do seed ainda não foi trocado (faça isso em Ajustes › Time ou no Perfil).",
+      },
     ],
     warnings: [
       "Gmail só aceita **App Password** (16 caracteres). Senha normal **não** funciona desde 2022.",

--- a/src/lib/notifications/rsvp.test.ts
+++ b/src/lib/notifications/rsvp.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prismaMock } from "@/test-utils/prisma";
+
+const notifyMock = vi.fn();
+vi.mock("./index", () => ({ notify: (...args: unknown[]) => notifyMock(...args) }));
+
+import { notifyRsvpResponse } from "./rsvp";
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  notifyMock.mockReset();
+  notifyMock.mockResolvedValue({});
+});
+
+describe("notifyRsvpResponse", () => {
+  it("não notifica quando já houve envio hoje (dedupe diário)", async () => {
+    prismaMock.notificationLog.count.mockResolvedValue(1 as never);
+    await notifyRsvpResponse({
+      refType: "Guest",
+      refId: "g1",
+      guestName: "Ana",
+      rsvpStatus: "CONFIRMED",
+    });
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("notifica cada gestor/noivo ativo com o kind e refId corretos", async () => {
+    prismaMock.notificationLog.count.mockResolvedValue(0 as never);
+    prismaMock.user.findMany.mockResolvedValue([
+      { id: "u1", name: "Noivo", email: "noivo@x.com", locale: "pt-BR" },
+      { id: "u2", name: "Noiva", email: "noiva@x.com", locale: "en" },
+    ] as never);
+
+    await notifyRsvpResponse({
+      refType: "Guest",
+      refId: "g1",
+      guestName: "Ana",
+      rsvpStatus: "CONFIRMED",
+      plusOnes: 1,
+    });
+
+    expect(notifyMock).toHaveBeenCalledTimes(2);
+    const [, input, opts] = notifyMock.mock.calls[0];
+    expect((input as { kind: string }).kind).toBe("GUEST_RSVP");
+    expect((input as { guestName: string }).guestName).toBe("Ana");
+    expect(opts).toEqual({ refType: "Guest", refId: "g1" });
+  });
+});

--- a/src/lib/notifications/rsvp.ts
+++ b/src/lib/notifications/rsvp.ts
@@ -1,0 +1,50 @@
+import { prisma } from "@/lib/prisma";
+import { coerceLocale } from "@/i18n/config";
+import { notify } from "./index";
+import { wasNotifiedToday } from "./log";
+
+const NOTIFY_ROLES = ["ADMIN", "GROOM", "BRIDE", "PLANNER"];
+
+type RsvpNotifyInput = {
+  refType: "Guest" | "GuestGroup";
+  refId: string;
+  guestName: string;
+  rsvpStatus: string;
+  plusOnes?: number;
+  groupName?: string | null;
+};
+
+/**
+ * Avisa gestores/noivos (ADMIN/GROOM/BRIDE/PLANNER ativos) quando um convidado responde
+ * o RSVP. Best-effort: nunca lança. Deduplica por (refId) por dia para não floodar quando
+ * o convidado reabre o link e responde de novo.
+ */
+export async function notifyRsvpResponse(input: RsvpNotifyInput): Promise<void> {
+  try {
+    if (await wasNotifiedToday("GUEST_RSVP", input.refType, input.refId)) return;
+
+    const recipients = await prisma.user.findMany({
+      where: { isActive: true, archivedAt: null, role: { in: NOTIFY_ROLES } },
+      select: { id: true, name: true, email: true, locale: true },
+    });
+
+    await Promise.all(
+      recipients.map((u) =>
+        notify(
+          { userId: u.id, email: u.email, locale: coerceLocale(u.locale) },
+          {
+            kind: "GUEST_RSVP",
+            userName: u.name ?? u.email,
+            guestName: input.guestName,
+            rsvpStatus: input.rsvpStatus,
+            plusOnes: input.plusOnes,
+            groupName: input.groupName ?? null,
+          },
+          { refType: input.refType, refId: input.refId },
+        ),
+      ),
+    );
+  } catch (err) {
+    console.error("[notifyRsvpResponse]", err);
+  }
+}

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -10,6 +10,7 @@ export type NotificationKind =
   | "PAYMENT_OVERDUE"
   | "TASK_DUE"
   | "TASK_OVERDUE"
+  | "GUEST_RSVP"
   | "SYSTEM_WHATSAPP_DOWN"
   | "SYSTEM_WHATSAPP_RECOVERED";
 
@@ -70,6 +71,14 @@ export type RenderInput =
       taskTitle: string;
       deadline: Date;
       daysOverdue: number;
+    } & WithLocale)
+  | ({
+      kind: "GUEST_RSVP";
+      userName: string;
+      guestName: string;
+      rsvpStatus: string;
+      plusOnes?: number;
+      groupName?: string | null;
     } & WithLocale)
   | ({
       kind: "SYSTEM_WHATSAPP_DOWN";
@@ -439,6 +448,51 @@ ${tk("waSubtitle", { days: input.daysOverdue })}
 
 ${escapeWaMarkdown(input.taskTitle)}
 ${tk("waDeadlineWas", { date })}`;
+      return { subject, html, text, waText };
+    }
+
+    case "GUEST_RSVP": {
+      const tk = (key: string, values?: Record<string, string | number | Date>) =>
+        t(`GUEST_RSVP.${key}`, values);
+      const guest = escapeHtml(input.guestName);
+      const statusLabel = tk(`status.${input.rsvpStatus}`);
+      const safeStatus = escapeHtml(statusLabel);
+      const subject = tk("subject", { guest: input.guestName });
+      const groupRow = input.groupName
+        ? `<tr><td style="padding:8px 0;color:#a1a1aa;">${escapeHtml(tk("groupLabel"))}</td><td style="padding:8px 0;text-align:right;">${escapeHtml(input.groupName)}</td></tr>`
+        : "";
+      const plusRow =
+        input.plusOnes && input.plusOnes > 0
+          ? `<tr><td style="padding:8px 0;color:#a1a1aa;">${escapeHtml(tk("plusOnesLabel"))}</td><td style="padding:8px 0;text-align:right;">${input.plusOnes}</td></tr>`
+          : "";
+      const html = wrapHtml(
+        subject,
+        `<p>${greetingHtml}</p>
+<p>${escapeHtml(tk("intro", { guest: input.guestName }))}</p>
+<table style="width:100%;border-collapse:collapse;margin-top:16px;">
+<tr><td style="padding:8px 0;color:#a1a1aa;">${escapeHtml(tk("guestLabel"))}</td><td style="padding:8px 0;text-align:right;">${guest}</td></tr>
+<tr><td style="padding:8px 0;color:#a1a1aa;">${escapeHtml(tk("statusLabel"))}</td><td style="padding:8px 0;text-align:right;font-weight:600;">${safeStatus}</td></tr>
+${groupRow}
+${plusRow}
+</table>`,
+        locale,
+        footer,
+        header,
+      );
+      const groupText = input.groupName ? `\n${tk("groupLabel")}: ${input.groupName}` : "";
+      const plusText =
+        input.plusOnes && input.plusOnes > 0 ? `\n${tk("plusOnesLabel")}: ${input.plusOnes}` : "";
+      const text = `${tk("intro", { guest: input.guestName })}
+
+${tk("guestLabel")}: ${input.guestName}
+${tk("statusLabel")}: ${statusLabel}${groupText}${plusText}`;
+      const waGroup = input.groupName ? `\n• ${tk("groupLabel")}: ${escapeWaMarkdown(input.groupName)}` : "";
+      const waText = `*${header}*
+
+${tk("intro", { guest: escapeWaMarkdown(input.guestName) })}
+
+• ${tk("guestLabel")}: ${escapeWaMarkdown(input.guestName)}
+• ${tk("statusLabel")}: ${statusLabel}${waGroup}`;
       return { subject, html, text, waText };
     }
 

--- a/src/messages/en/actions.json
+++ b/src/messages/en/actions.json
@@ -29,6 +29,10 @@
   "profile": {
     "invalidLocale": "Invalid language",
     "errorSaving": "Error saving profile",
-    "saved": "Profile updated"
+    "saved": "Profile updated",
+    "invalidEmail": "Invalid email",
+    "wrongPassword": "Current password is incorrect",
+    "emailTaken": "A user with this email already exists",
+    "emailUpdated": "Email updated. Use it on your next login."
   }
 }

--- a/src/messages/en/common.json
+++ b/src/messages/en/common.json
@@ -52,6 +52,12 @@
     "optional": "(optional)",
     "required": "required"
   },
+  "profile": {
+    "changeEmailTitle": "Change email",
+    "currentPassword": "Current password",
+    "newEmail": "New email",
+    "reloginHint": "After changing your email, use the new one on your next login."
+  },
   "status": {
     "pending": "Pending",
     "paid": "Paid",

--- a/src/messages/en/notifications.json
+++ b/src/messages/en/notifications.json
@@ -89,6 +89,21 @@
     "waSubtitle": "Overdue by {days, plural, one {# day} other {# days}}.",
     "waDeadlineWas": "Was due: {date}"
   },
+  "GUEST_RSVP": {
+    "subject": "New RSVP: {guest}",
+    "intro": "{guest} replied to the invitation.",
+    "guestLabel": "Guest",
+    "statusLabel": "Reply",
+    "groupLabel": "Group",
+    "plusOnesLabel": "Plus-ones",
+    "status": {
+      "CONFIRMED": "Attending",
+      "DECLINED": "Not attending",
+      "PENDING": "Pending",
+      "MAYBE": "Maybe",
+      "RESPONDED": "Responded"
+    }
+  },
   "SYSTEM_WHATSAPP_DOWN": {
     "subjectLoggedOut": "⚠ Action required: WhatsApp disconnected",
     "subjectWaitingQr": "⚠ Action required: WhatsApp requested a new QR code",

--- a/src/messages/es/actions.json
+++ b/src/messages/es/actions.json
@@ -29,6 +29,10 @@
   "profile": {
     "invalidLocale": "Idioma inválido",
     "errorSaving": "Error al guardar el perfil",
-    "saved": "Perfil actualizado"
+    "saved": "Perfil actualizado",
+    "invalidEmail": "Correo inválido",
+    "wrongPassword": "La contraseña actual es incorrecta",
+    "emailTaken": "Ya existe un usuario con este correo",
+    "emailUpdated": "Correo actualizado. Úsalo en tu próximo inicio de sesión."
   }
 }

--- a/src/messages/es/common.json
+++ b/src/messages/es/common.json
@@ -52,6 +52,12 @@
     "optional": "(opcional)",
     "required": "obligatorio"
   },
+  "profile": {
+    "changeEmailTitle": "Cambiar correo",
+    "currentPassword": "Contraseña actual",
+    "newEmail": "Nuevo correo",
+    "reloginHint": "Al cambiar el correo, úsalo en tu próximo inicio de sesión."
+  },
   "status": {
     "pending": "Pendiente",
     "paid": "Pagado",

--- a/src/messages/es/notifications.json
+++ b/src/messages/es/notifications.json
@@ -89,6 +89,21 @@
     "waSubtitle": "Atrasada por {days, plural, one {# día} other {# días}}.",
     "waDeadlineWas": "Plazo era: {date}"
   },
+  "GUEST_RSVP": {
+    "subject": "Nuevo RSVP: {guest}",
+    "intro": "{guest} respondió a la invitación.",
+    "guestLabel": "Invitado",
+    "statusLabel": "Respuesta",
+    "groupLabel": "Grupo",
+    "plusOnesLabel": "Acompañantes",
+    "status": {
+      "CONFIRMED": "Confirmó asistencia",
+      "DECLINED": "No asistirá",
+      "PENDING": "Pendiente",
+      "MAYBE": "Quizás",
+      "RESPONDED": "Respondió"
+    }
+  },
   "SYSTEM_WHATSAPP_DOWN": {
     "subjectLoggedOut": "⚠ Acción requerida: WhatsApp desconectado",
     "subjectWaitingQr": "⚠ Acción requerida: WhatsApp pidió un nuevo código QR",

--- a/src/messages/pt-BR/actions.json
+++ b/src/messages/pt-BR/actions.json
@@ -29,6 +29,10 @@
   "profile": {
     "invalidLocale": "Idioma inválido",
     "errorSaving": "Erro ao salvar perfil",
-    "saved": "Perfil atualizado"
+    "saved": "Perfil atualizado",
+    "invalidEmail": "E-mail inválido",
+    "wrongPassword": "Senha atual incorreta",
+    "emailTaken": "Já existe um usuário com este e-mail",
+    "emailUpdated": "E-mail atualizado. Use-o no próximo login."
   }
 }

--- a/src/messages/pt-BR/common.json
+++ b/src/messages/pt-BR/common.json
@@ -52,6 +52,12 @@
     "optional": "(opcional)",
     "required": "obrigatório"
   },
+  "profile": {
+    "changeEmailTitle": "Alterar e-mail",
+    "currentPassword": "Senha atual",
+    "newEmail": "Novo e-mail",
+    "reloginHint": "Ao trocar o e-mail, use o novo no próximo login."
+  },
   "status": {
     "pending": "Pendente",
     "paid": "Pago",

--- a/src/messages/pt-BR/notifications.json
+++ b/src/messages/pt-BR/notifications.json
@@ -89,6 +89,21 @@
     "waSubtitle": "Atrasada há {days, plural, one {# dia} other {# dias}}.",
     "waDeadlineWas": "Prazo era: {date}"
   },
+  "GUEST_RSVP": {
+    "subject": "Novo RSVP: {guest}",
+    "intro": "{guest} respondeu ao convite.",
+    "guestLabel": "Convidado",
+    "statusLabel": "Resposta",
+    "groupLabel": "Grupo",
+    "plusOnesLabel": "Acompanhantes",
+    "status": {
+      "CONFIRMED": "Confirmou presença",
+      "DECLINED": "Não vai",
+      "PENDING": "Pendente",
+      "MAYBE": "Talvez",
+      "RESPONDED": "Respondeu"
+    }
+  },
   "SYSTEM_WHATSAPP_DOWN": {
     "subjectLoggedOut": "⚠ Ação necessária: WhatsApp desconectado",
     "subjectWaitingQr": "⚠ Ação necessária: WhatsApp pediu novo QR Code",


### PR DESCRIPTION
## Contexto

Dois problemas reais relatados pelo usuário:

1. **SMTP falha a cada execução do cron.** O seed cria **apenas** `admin@admin.com` (placeholder inválido) e **não havia forma de trocar o e-mail pela UI** — o Perfil era read-only e a edição de usuário (Ajustes › Time) cobria só nome/telefone/role. O cron de lembretes (a cada 30 min) tentava entregar para `admin@admin.com` → falhava sempre, gravando `NotificationLog(status=FAILED)`.
2. **Noivos não recebem e-mail.** Parcialmente esperado: precisavam existir como usuários GROOM/BRIDE com e-mail real + SMTP configurado. Além disso, **RSVP de convidado nunca notificava ninguém**.

## O que muda

### 1. Editar e-mail de qualquer usuário (Ajustes › Time)
`updateUser` passa a aceitar `email` (validação de unicidade + tratamento de `P2002` + audit); campo adicionado no `EditUserModal`. É a forma de corrigir o `admin@admin.com` e cadastrar os e-mails reais dos noivos.

### 2. Trocar o próprio e-mail (Perfil)
Nova action `updateOwnEmail` (em `profileActions`) com **confirmação da senha atual**, unicidade e audit; formulário i18n no Perfil. Trocar o e-mail **não derruba a sessão** (keyed por `id`); o novo vale no próximo login.

### 3. Diagnóstico de envios (Ajustes › Notificações)
Nova aba (gestores) listando os últimos 50 `NotificationLog` com status **SENT/FAILED** e a mensagem de erro do SMTP — fim do mistério de "o e-mail não chega".

### 4. Aviso de RSVP aos noivos
Novo `NotificationKind` `GUEST_RSVP` (templates + 3 catálogos). `notifyRsvpResponse` (best-effort, **deduplicado por dia** via `wasNotifiedToday`) avisa ADMIN/GROOM/BRIDE/PLANNER quando um convidado responde — disparado em `publicRsvpRespond` (individual) e `publicRsvpRespondForGroup` (grupo).

## Testes
Novos: `userActions.test.ts` (troca de e-mail + unicidade), `profileActions.test.ts` (`updateOwnEmail`: senha errada / e-mail duplicado / sucesso), `rsvp.test.ts` (`notifyRsvpResponse`: dedupe + destinatários).

## Docs / i18n
`docs/notificacoes.md`, `docs/permissoes.md`, help center, changelog (**v0.6.4**), README e os **3** catálogos (`actions.profile`, `common.profile`, `notifications.GUEST_RSVP`).

## Verificação
- ✅ `npx tsc --noEmit`
- ✅ `npm run lint` (0 erros)
- ✅ `npm run test:run` (535 testes)
- ✅ `npm run build`

## Fora de escopo
- Configurar SMTP por UI (continua via `.env`); aqui só diagnóstico + documentação.
- Alterar o seed para pedir e-mail real (a correção é a edição via UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)