### PR TITLE
feat(dashboard): paginação client-side nas listas longas

### DIFF
--- a/docs/modulos.md
+++ b/docs/modulos.md
@@ -197,3 +197,18 @@ docs.
 | Tarefa atrasada | a cada 30 min | ✅ | ✅ | — |
 
 > ℹ️ Toda notificação é idempotente por dia (ver `NotificationLog`).
+
+## Paginação das listas
+
+As listas que podem crescer são paginadas no cliente (20 itens por página) via
+o componente reutilizável [`src/components/pagination.tsx`](../src/components/pagination.tsx)
+(`usePagination` + `<Pagination>`). A busca/filtro continua sendo feita em
+memória e a paginação recai sobre o resultado já filtrado — ao trocar o filtro,
+volta para a página 1. O controle mostra números de página + Anterior/Próxima e
+"Mostrando X–Y de Z", e some quando há uma página só.
+
+Listas paginadas: Convidados, Tarefas (visão Lista), Pagamentos (visão Lista),
+Presentes, Enxoval, Fornecedores, Receitas, Caixa e o histórico de envios em
+Ajustes › Notificações (busca até 200 registros). Visões não-lista (Kanban de
+tarefas, calendário de pagamentos) e listas curtas (Locais, Metas, Lua de Mel)
+não são paginadas.

--- a/src/app/dashboard/assets/assets-client.tsx
+++ b/src/app/dashboard/assets/assets-client.tsx
@@ -5,6 +5,7 @@ import { Loader2, Pencil, Plus, Search, Trash2 } from "lucide-react";
 import { createAsset, deleteAsset, updateAsset } from "@/app/actions/assetActions";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 import { formatCurrency, formatDateBR, toIsoDate } from "@/lib/format";
 import type { Asset } from "@/types";
 
@@ -63,6 +64,11 @@ export default function AssetsClient({ assets, goals }: Props) {
     return assets.filter((a) => a.title.toLowerCase().includes(term));
   }, [assets, search]);
 
+  const { pageItems, page, totalPages, total: pageTotal, from, to, setPage } = usePagination(
+    filtered,
+    20,
+  );
+
   const total = useMemo(() => assets.reduce((s, a) => s + a.amount, 0), [assets]);
 
   function handleDelete() {
@@ -88,7 +94,10 @@ export default function AssetsClient({ assets, goals }: Props) {
             <input
               type="search"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
               placeholder="Buscar aporte..."
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-emerald-500/50"
             />
@@ -125,7 +134,7 @@ export default function AssetsClient({ assets, goals }: Props) {
                   </td>
                 </tr>
               ) : (
-                filtered.map((asset) => (
+                pageItems.map((asset) => (
                   <tr key={asset.id} className="border-b border-zinc-800/50 transition-colors hover:bg-zinc-800/30">
                     <td className="px-6 py-4 text-zinc-200">{formatDateBR(asset.date)}</td>
                     <td className="px-6 py-4">
@@ -163,6 +172,15 @@ export default function AssetsClient({ assets, goals }: Props) {
           </table>
         </div>
       </div>
+
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        total={pageTotal}
+        from={from}
+        to={to}
+        onPageChange={setPage}
+      />
 
       {(isCreateOpen || editing) && (
         <AssetFormModal

--- a/src/app/dashboard/gifts/gifts-client.tsx
+++ b/src/app/dashboard/gifts/gifts-client.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/app/actions/giftActions";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 import { formatCurrency, formatDateBR, toIsoDate } from "@/lib/format";
 
 type GiftRow = {
@@ -45,6 +46,8 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
     if (filter === "PENDING_THANK") return gifts.filter((g) => g.status !== "THANKED");
     return gifts;
   }, [gifts, filter]);
+
+  const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(filtered, 20);
 
   const totals = useMemo(() => {
     const cash = gifts.filter((g) => g.type === "CASH").reduce((s, g) => s + (g.amount ?? 0), 0);
@@ -111,7 +114,10 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
       <div className="flex items-center justify-between">
         <select
           value={filter}
-          onChange={(e) => setFilter(e.target.value as typeof filter)}
+          onChange={(e) => {
+            setFilter(e.target.value as typeof filter);
+            setPage(1);
+          }}
           className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
         >
           <option value="ALL">Todos</option>
@@ -132,7 +138,7 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
         </div>
       ) : (
         <ul className="space-y-2">
-          {filtered.map((g) => (
+          {pageItems.map((g) => (
             <li key={g.id} className="flex flex-col gap-2 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4 sm:flex-row sm:items-center">
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-zinc-800">
                 <GiftIcon className={`h-4 w-4 ${g.type === "CASH" ? "text-emerald-400" : "text-sky-400"}`} />
@@ -220,6 +226,15 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
           ))}
         </ul>
       )}
+
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        total={total}
+        from={from}
+        to={to}
+        onPageChange={setPage}
+      />
 
       {(open || editing) && (
         <GiftFormModal

--- a/src/app/dashboard/guests/guests-client.tsx
+++ b/src/app/dashboard/guests/guests-client.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/app/actions/guestActions";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 
 type Guest = {
   id: string;
@@ -85,6 +86,8 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
       return true;
     });
   }, [guests, search, filter]);
+
+  const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(filtered, 20);
 
   const stats = useMemo(() => {
     const total = guests.length;
@@ -214,14 +217,20 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
             <input
               type="search"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
               placeholder="Buscar..."
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
             />
           </div>
           <select
             value={filter}
-            onChange={(e) => setFilter(e.target.value as typeof filter)}
+            onChange={(e) => {
+              setFilter(e.target.value as typeof filter);
+              setPage(1);
+            }}
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
           >
             <option value="ALL">Todos</option>
@@ -284,7 +293,7 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
                   </td>
                 </tr>
               ) : (
-                filtered.map((g) => (
+                pageItems.map((g) => (
                   <tr key={g.id} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
                     <td className="px-4 py-3">
                       <div className="flex flex-wrap items-center gap-1 font-medium text-zinc-200">
@@ -373,6 +382,15 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
           </table>
         </div>
       </div>
+
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        total={total}
+        from={from}
+        to={to}
+        onPageChange={setPage}
+      />
 
       {(open || editing) && (
         <GuestFormModal

--- a/src/app/dashboard/income/income-client.tsx
+++ b/src/app/dashboard/income/income-client.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/app/actions/incomeActions";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 import { formatCurrency, formatDateBR, toIsoDate } from "@/lib/format";
 
 type IncomeRow = {
@@ -54,6 +55,8 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
     }
     return { expected, received, total: expected + received };
   }, [incomes]);
+
+  const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(incomes, 20);
 
   function handleCreate(formData: FormData) {
     setBusy(true);
@@ -144,7 +147,7 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
                   </td>
                 </tr>
               ) : (
-                incomes.map((row) => (
+                pageItems.map((row) => (
                   <tr key={row.id} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
                     <td className="px-6 py-4">
                       <div className="text-zinc-200">{row.title}</div>
@@ -208,6 +211,15 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
           </table>
         </div>
       </div>
+
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        total={total}
+        from={from}
+        to={to}
+        onPageChange={setPage}
+      />
 
       {(open || editing) && (
         <IncomeFormModal

--- a/src/app/dashboard/payments/payments-client.tsx
+++ b/src/app/dashboard/payments/payments-client.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/app/actions/paymentActions";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 import { formatCurrency, formatDateBR, toIsoDate } from "@/lib/format";
 import { computeAdjustedAmount } from "@/lib/payment-adjustment";
 import type { Payment, PaymentMethod, PaymentStatus, Vendor } from "@/types";
@@ -102,6 +103,8 @@ export default function PaymentsClient({ payments, vendors }: Props) {
     });
   }, [payments, search, statusFilter]);
 
+  const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(filtered, 20);
+
   function handleMarkPaid(payment: PaymentWithVendor) {
     startTransition(async () => {
       const r = await markPaymentAsPaid(payment.id);
@@ -143,14 +146,20 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                 <input
                   type="search"
                   value={search}
-                  onChange={(e) => setSearch(e.target.value)}
+                  onChange={(e) => {
+                    setSearch(e.target.value);
+                    setPage(1);
+                  }}
                   placeholder="Buscar por fornecedor..."
                   className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
                 />
               </div>
               <select
                 value={statusFilter}
-                onChange={(e) => setStatusFilter(e.target.value as "ALL" | PaymentStatus)}
+                onChange={(e) => {
+                  setStatusFilter(e.target.value as "ALL" | PaymentStatus);
+                  setPage(1);
+                }}
                 className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
               >
                 <option value="ALL">Todos os status</option>
@@ -227,7 +236,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                       </td>
                     </tr>
                   ) : (
-                    filtered.map((payment) => (
+                    pageItems.map((payment) => (
                       <tr key={payment.id} className="border-b border-zinc-800/50 transition-colors hover:bg-zinc-800/30">
                         <td className="px-6 py-4 text-zinc-200">{formatDateBR(payment.dueDate)}</td>
                         <td className="px-6 py-4">{payment.vendor.name}</td>
@@ -306,7 +315,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                 {payments.length === 0 ? "Nenhum pagamento cadastrado." : "Nenhum resultado para o filtro."}
               </div>
             ) : (
-              filtered.map((payment) => (
+              pageItems.map((payment) => (
                 <div key={payment.id} className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4">
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
@@ -377,6 +386,15 @@ export default function PaymentsClient({ payments, vendors }: Props) {
               ))
             )}
           </div>
+
+          <Pagination
+            page={page}
+            totalPages={totalPages}
+            total={total}
+            from={from}
+            to={to}
+            onPageChange={setPage}
+          />
         </>
       ) : (
         <PaymentsCalendar

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -52,7 +52,7 @@ export default async function SettingsPage() {
   const notificationLogs = canManageUsers(me?.role)
     ? await prisma.notificationLog.findMany({
         orderBy: { createdAt: "desc" },
-        take: 50,
+        take: 200,
         select: {
           id: true,
           kind: true,

--- a/src/app/dashboard/settings/settings-client.tsx
+++ b/src/app/dashboard/settings/settings-client.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/app/actions/userActions";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 import { formatDateBR, formatDateTimeBR } from "@/lib/format";
 import { ROLES, ROLE_LABEL, ROLE_DESCRIPTION, type Role, canManageUsers } from "@/lib/permissions";
 import type { SecuritySettings } from "@/lib/security-settings";
@@ -186,6 +187,7 @@ export default function SettingsClient({
 }
 
 function NotificationsTab({ logs }: { logs: NotificationLogEntry[] }) {
+  const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(logs, 20);
   return (
     <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
       <div className="flex items-center gap-2">
@@ -193,7 +195,7 @@ function NotificationsTab({ logs }: { logs: NotificationLogEntry[] }) {
         <h2 className="text-lg font-semibold text-white">Envios recentes</h2>
       </div>
       <p className="mt-1 text-sm text-zinc-500">
-        Últimos 50 envios de e-mail/WhatsApp. Use esta lista para diagnosticar falhas de SMTP ou
+        Últimos envios de e-mail/WhatsApp. Use esta lista para diagnosticar falhas de SMTP ou
         destinatário inválido (ex.: o admin@admin.com padrão do seed).
       </p>
       {logs.length === 0 ? (
@@ -214,7 +216,7 @@ function NotificationsTab({ logs }: { logs: NotificationLogEntry[] }) {
               </tr>
             </thead>
             <tbody>
-              {logs.map((l) => {
+              {pageItems.map((l) => {
                 const failed = l.status === "FAILED";
                 return (
                   <tr key={l.id} className="border-b border-zinc-900 align-top">
@@ -245,6 +247,16 @@ function NotificationsTab({ logs }: { logs: NotificationLogEntry[] }) {
               })}
             </tbody>
           </table>
+          <div className="mt-3">
+            <Pagination
+              page={page}
+              totalPages={totalPages}
+              total={total}
+              from={from}
+              to={to}
+              onPageChange={setPage}
+            />
+          </div>
         </div>
       )}
     </section>

--- a/src/app/dashboard/tasks/tasks-client.tsx
+++ b/src/app/dashboard/tasks/tasks-client.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/app/actions/taskActions";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 import { formatDateBR, toIsoDate } from "@/lib/format";
 
 type TaskRow = {
@@ -89,6 +90,8 @@ export default function TasksClient({
       return true;
     });
   }, [tasks, filter]);
+
+  const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(filtered, 20);
 
   function handleCreate(formData: FormData) {
     setBusy(true);
@@ -160,7 +163,10 @@ export default function TasksClient({
         <div className="flex flex-wrap items-center gap-2">
           <select
             value={filter}
-            onChange={(e) => setFilter(e.target.value as typeof filter)}
+            onChange={(e) => {
+              setFilter(e.target.value as typeof filter);
+              setPage(1);
+            }}
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
           >
             <option value="all">Todas</option>
@@ -215,12 +221,22 @@ export default function TasksClient({
       </div>
 
       {view === "list" ? (
-        <ListView
-          tasks={filtered}
-          onStatus={handleStatus}
-          onEdit={setEditing}
-          onDelete={setDeleting}
-        />
+        <>
+          <ListView
+            tasks={pageItems}
+            onStatus={handleStatus}
+            onEdit={setEditing}
+            onDelete={setDeleting}
+          />
+          <Pagination
+            page={page}
+            totalPages={totalPages}
+            total={total}
+            from={from}
+            to={to}
+            onPageChange={setPage}
+          />
+        </>
       ) : (
         <KanbanView
           tasks={filtered}

--- a/src/app/dashboard/trousseau/trousseau-client.tsx
+++ b/src/app/dashboard/trousseau/trousseau-client.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/app/actions/trousseauActions";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 import { formatCurrency } from "@/lib/format";
 
 type Item = {
@@ -69,6 +70,8 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
     if (filter === "ALL") return items;
     return items.filter((i) => i.status === filter);
   }, [items, filter]);
+
+  const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(filtered, 20);
 
   const totals = useMemo(() => {
     const estTotal = items.reduce((s, i) => s + (i.estimatedPrice ?? 0), 0);
@@ -137,7 +140,10 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
       <div className="flex flex-wrap items-center justify-between gap-2">
         <select
           value={filter}
-          onChange={(e) => setFilter(e.target.value as typeof filter)}
+          onChange={(e) => {
+            setFilter(e.target.value as typeof filter);
+            setPage(1);
+          }}
           className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
         >
           <option value="ALL">Todos</option>
@@ -160,7 +166,7 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
         </p>
       ) : (
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          {filtered.map((it) => {
+          {pageItems.map((it) => {
             const prio = PRIORITY_LABEL[it.priority] ?? PRIORITY_LABEL.NICE_TO_HAVE;
             return (
               <article
@@ -255,6 +261,15 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
           })}
         </div>
       )}
+
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        total={total}
+        from={from}
+        to={to}
+        onPageChange={setPage}
+      />
 
       {(open || editing) && (
         <ItemModal

--- a/src/app/dashboard/vendors/vendors-client.tsx
+++ b/src/app/dashboard/vendors/vendors-client.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/app/actions/vendorActions";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 import { formatCurrency } from "@/lib/format";
 import type { CategoryDef } from "@/lib/categories";
 import type { Vendor, BudgetItem, VendorStatus } from "@/types";
@@ -103,6 +104,8 @@ export default function VendorsClient({ vendors, categories }: Props) {
     });
   }, [vendors, search, statusFilter]);
 
+  const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(filtered, 20);
+
   function handleStatusChange(vendor: VendorRow, newStatus: VendorStatus) {
     const item = vendor.budgetItems[0];
     const hasActual = !!item?.actualValue;
@@ -152,14 +155,20 @@ export default function VendorsClient({ vendors, categories }: Props) {
             <input
               type="search"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
               placeholder="Buscar fornecedor..."
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
             />
           </div>
           <select
             value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value as "ALL" | VendorStatus)}
+            onChange={(e) => {
+              setStatusFilter(e.target.value as "ALL" | VendorStatus);
+              setPage(1);
+            }}
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
           >
             <option value="ALL">Todos os status</option>
@@ -214,7 +223,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
                   </td>
                 </tr>
               ) : (
-                filtered.map((vendor) => {
+                pageItems.map((vendor) => {
                   const budget = vendor.budgetItems[0];
                   const value = budget?.actualValue ?? budget?.estimatedValue ?? 0;
                   const isReal = budget?.actualValue != null;
@@ -317,7 +326,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
             {vendors.length === 0 ? "Nenhum fornecedor cadastrado." : "Nenhum resultado para o filtro."}
           </div>
         ) : (
-          filtered.map((vendor) => {
+          pageItems.map((vendor) => {
             const budget = vendor.budgetItems[0];
             const value = budget?.actualValue ?? budget?.estimatedValue ?? 0;
             const isReal = budget?.actualValue != null;
@@ -398,6 +407,15 @@ export default function VendorsClient({ vendors, categories }: Props) {
           })
         )}
       </div>
+
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        total={total}
+        from={from}
+        to={to}
+        onPageChange={setPage}
+      />
 
       {isCreateOpen && (
         <VendorFormModal

--- a/src/components/pagination.test.tsx
+++ b/src/components/pagination.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { usePagination } from "./pagination";
+
+const items = (n: number) => Array.from({ length: n }, (_, i) => i + 1);
+
+describe("usePagination", () => {
+  it("fatia a primeira página e calcula from/to/total", () => {
+    const { result } = renderHook(() => usePagination(items(45), 20));
+    expect(result.current.total).toBe(45);
+    expect(result.current.totalPages).toBe(3);
+    expect(result.current.page).toBe(1);
+    expect(result.current.from).toBe(1);
+    expect(result.current.to).toBe(20);
+    expect(result.current.pageItems).toEqual(items(20));
+  });
+
+  it("avança de página e fatia o intervalo correto", () => {
+    const { result } = renderHook(() => usePagination(items(45), 20));
+    act(() => result.current.setPage(3));
+    expect(result.current.page).toBe(3);
+    expect(result.current.from).toBe(41);
+    expect(result.current.to).toBe(45);
+    expect(result.current.pageItems).toEqual([41, 42, 43, 44, 45]);
+  });
+
+  it("faz clamp da página para o range válido quando a lista encolhe", () => {
+    const { result, rerender } = renderHook(
+      ({ data }: { data: number[] }) => usePagination(data, 20),
+      { initialProps: { data: items(60) } },
+    );
+    act(() => result.current.setPage(3));
+    expect(result.current.page).toBe(3);
+
+    rerender({ data: items(10) });
+    expect(result.current.totalPages).toBe(1);
+    expect(result.current.page).toBe(1);
+    expect(result.current.pageItems).toEqual(items(10));
+  });
+
+  it("trata lista vazia com totalPages=1 e from=0", () => {
+    const { result } = renderHook(() => usePagination<number>([], 20));
+    expect(result.current.total).toBe(0);
+    expect(result.current.totalPages).toBe(1);
+    expect(result.current.from).toBe(0);
+    expect(result.current.to).toBe(0);
+    expect(result.current.pageItems).toEqual([]);
+  });
+});

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+export type PaginationState<T> = {
+  pageItems: T[];
+  page: number;
+  totalPages: number;
+  total: number;
+  from: number;
+  to: number;
+  setPage: (page: number) => void;
+};
+
+export function usePagination<T>(items: T[], pageSize = 20): PaginationState<T> {
+  const [rawPage, setRawPage] = useState(1);
+  const total = items.length;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const page = Math.min(Math.max(1, rawPage), totalPages);
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+  const pageItems = useMemo(() => items.slice(start, end), [items, start, end]);
+  return {
+    pageItems,
+    page,
+    totalPages,
+    total,
+    from: total === 0 ? 0 : start + 1,
+    to: Math.min(end, total),
+    setPage: setRawPage,
+  };
+}
+
+function buildPages(page: number, totalPages: number): (number | "ellipsis")[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  const pages: (number | "ellipsis")[] = [1];
+  const left = Math.max(2, page - 1);
+  const right = Math.min(totalPages - 1, page + 1);
+  if (left > 2) pages.push("ellipsis");
+  for (let p = left; p <= right; p++) pages.push(p);
+  if (right < totalPages - 1) pages.push("ellipsis");
+  pages.push(totalPages);
+  return pages;
+}
+
+export function Pagination({
+  page,
+  totalPages,
+  total,
+  from,
+  to,
+  onPageChange,
+}: {
+  page: number;
+  totalPages: number;
+  total: number;
+  from: number;
+  to: number;
+  onPageChange: (page: number) => void;
+}) {
+  const t = useTranslations("common.pagination");
+  if (totalPages <= 1) return null;
+
+  const pages = buildPages(page, totalPages);
+  const stepClass =
+    "inline-flex items-center gap-1 rounded-xl border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-sm text-zinc-300 transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-zinc-950";
+
+  return (
+    <nav
+      aria-label={t("navLabel")}
+      className="flex flex-col items-center justify-between gap-3 pt-1 sm:flex-row"
+    >
+      <p className="text-xs text-zinc-500">{t("showing", { from, to, total })}</p>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page <= 1}
+          aria-label={t("previous")}
+          className={stepClass}
+        >
+          <ChevronLeft className="h-4 w-4" />
+          <span className="hidden sm:inline">{t("previous")}</span>
+        </button>
+        {pages.map((p, idx) =>
+          p === "ellipsis" ? (
+            <span key={`ellipsis-${idx}`} className="px-1.5 text-sm text-zinc-600">
+              …
+            </span>
+          ) : (
+            <button
+              key={p}
+              type="button"
+              onClick={() => onPageChange(p)}
+              aria-current={p === page ? "page" : undefined}
+              className={`min-w-[2.25rem] rounded-xl border px-2.5 py-1.5 text-sm transition-colors ${
+                p === page
+                  ? "border-rose-500/30 bg-rose-500/10 text-rose-300"
+                  : "border-zinc-800 bg-zinc-950 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+              }`}
+            >
+              {p}
+            </button>
+          ),
+        )}
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={page >= totalPages}
+          aria-label={t("next")}
+          className={stepClass}
+        >
+          <span className="hidden sm:inline">{t("next")}</span>
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,14 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.6.5",
+    date: "2026-05-27",
+    highlights: [
+      "📄 Listas longas agora são paginadas (20 itens por página) com controle numerado + Anterior/Próxima e o indicador 'Mostrando X–Y de Z'. Vale para Convidados, Tarefas (visão Lista), Pagamentos (visão Lista), Presentes, Enxoval, Fornecedores, Receitas, Caixa e o histórico de envios em Ajustes › Notificações.",
+      "🔎 A busca e os filtros continuam instantâneos: a paginação recai sobre o resultado já filtrado e volta para a primeira página sempre que você muda o filtro.",
+    ],
+  },
+  {
     version: "0.6.4",
     date: "2026-05-27",
     highlights: [

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -984,6 +984,11 @@ export const HELP_FAQ: FaqItem[] = [
       "Tecnicamente sim (acessando por IP), mas o Auth.js v5 exige domínio e HTTPS para cookies seguros. Recomendamos um domínio + Cloudflare Tunnel ou Let's Encrypt.",
   },
   {
+    question: "Minhas listas estão grandes — dá para navegar por páginas?",
+    answer:
+      "Sim. Listas como Convidados, Tarefas, Pagamentos, Presentes, Enxoval, Fornecedores, Receitas e Caixa mostram 20 itens por página, com controle de páginas no rodapé (Anterior/Próxima + números) e o indicador 'Mostrando X–Y de Z'. A busca e os filtros continuam valendo: a paginação recai sobre o resultado filtrado e volta para a primeira página quando você muda o filtro.",
+  },
+  {
     question: "Os convidados precisam criar conta para responder o RSVP?",
     answer:
       "Não — cada convidado tem um link único `/rsvp/[token]` que funciona sem login. Você compartilha pelo WhatsApp ou outro canal.",

--- a/src/messages/en/common.json
+++ b/src/messages/en/common.json
@@ -84,6 +84,12 @@
     "daysAgo": "{count, plural, =0 {today} one {# day ago} other {# days ago}}",
     "daysOverdue": "{count, plural, one {# day overdue} other {# days overdue}}"
   },
+  "pagination": {
+    "showing": "Showing {from}–{to} of {total}",
+    "previous": "Previous",
+    "next": "Next",
+    "navLabel": "Pagination"
+  },
   "nav": {
     "dashboard": "Dashboard",
     "vendors": "Vendors",

--- a/src/messages/es/common.json
+++ b/src/messages/es/common.json
@@ -84,6 +84,12 @@
     "daysAgo": "{count, plural, =0 {hoy} one {hace # día} other {hace # días}}",
     "daysOverdue": "{count, plural, one {# día de atraso} other {# días de atraso}}"
   },
+  "pagination": {
+    "showing": "Mostrando {from}–{to} de {total}",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "navLabel": "Paginación"
+  },
   "nav": {
     "dashboard": "Panel",
     "vendors": "Proveedores",

--- a/src/messages/pt-BR/common.json
+++ b/src/messages/pt-BR/common.json
@@ -84,6 +84,12 @@
     "daysAgo": "{count, plural, =0 {hoje} one {há # dia} other {há # dias}}",
     "daysOverdue": "{count, plural, one {# dia em atraso} other {# dias em atraso}}"
   },
+  "pagination": {
+    "showing": "Mostrando {from}–{to} de {total}",
+    "previous": "Anterior",
+    "next": "Próxima",
+    "navLabel": "Paginação"
+  },
   "nav": {
     "dashboard": "Dashboard",
     "vendors": "Fornecedores",


### PR DESCRIPTION
## Contexto

Toda página de lista do dashboard buscava o dataset completo e renderizava **todos** os itens de uma vez. Listas grandes (convidados podem chegar a 300+, tarefas/presentes/pagamentos/enxoval 50–200) ficavam pesadas e difíceis de navegar.

Esta PR adiciona **paginação client-side** (20 itens/página) nas listas que crescem, **mantendo a busca/filtro instantâneo em memória** já existente — a paginação recai sobre o resultado já filtrado e volta para a página 1 ao trocar o filtro.

> Decisão de abordagem: client-side em vez de server-side (skip/take + filtros via URL). O filtro/busca atual é 100% client-side e o volume é pequeno (single-tenant, SQLite local); server-side quebraria a busca instantânea e exigiria refatorar o fetch de ~9 páginas sem ganho real.

## Mudanças

- **Novo componente reutilizável** [`src/components/pagination.tsx`](src/components/pagination.tsx):
  - Hook `usePagination(items, pageSize=20)` → `pageItems`, `page`, `totalPages`, `total`, `from`, `to`, `setPage` (clamp da página derivado no render, sem `useEffect`).
  - `<Pagination>` com numeração + elipse, Anterior/Próxima e "Mostrando X–Y de Z"; some quando há só uma página. Reaproveita o estilo `rose`/`zinc` do projeto.
- **Listas integradas:** Convidados, Tarefas (só visão Lista; Kanban intacto), Pagamentos (só visão Lista; calendário intacto), Presentes, Enxoval, Fornecedores (desktop+mobile), Receitas, Caixa.
- **Logs de notificação:** `take` 50→200 em `settings/page.tsx` + paginação na aba Ajustes › Notificações.
- **i18n:** bloco `common.pagination` nos 3 catálogos (pt-BR/en/es).
- **Docs:** changelog 0.6.5, seção em `docs/modulos.md` e FAQ na central de ajuda.

Fora de escopo (listas curtas / não-lista): Locais, Metas, Lua de Mel, lista de membros do time, Dia D, Insights.

## Verificação

- `npm run lint` — 0 erros (1 warning pré-existente em `vitest.setup.ts`).
- `npm run build` — passou; todas as rotas do dashboard compilaram.
- `npm run test:run` — **539 testes passando**, incluindo 4 novos para o hook em [`pagination.test.tsx`](src/components/pagination.test.tsx) (fatiamento, navegação, clamp ao encolher, lista vazia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)