### PR TITLE
fix: correções de segurança e qualidade da auditoria completa

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,9 +331,13 @@ Todo body/form **deve** ser validado com Zod com limites explícitos:
   [src/i18n/request.ts](src/i18n/request.ts).
 - **Idiomas suportados:** `pt-BR` (default/fallback), `en`, `es`. Constante
   em [src/i18n/config.ts](src/i18n/config.ts).
-- **Sem prefixo de URL.** Locale resolvido na ordem: (1) `?lang=` em rotas
-  públicas (RSVP, login) → (2) cookie `NEXT_LOCALE` → (3) JWT `user.locale`
-  → (4) header `Accept-Language` → (5) default `pt-BR`.
+- **Sem prefixo de URL.** Ordem-alvo de resolução: (1) `?lang=` em rotas
+  públicas → (2) cookie `NEXT_LOCALE` → (3) JWT `user.locale` → (4) header
+  `Accept-Language` → (5) default `pt-BR`.
+  - **Divergência conhecida (estado atual):** o passo (1) `?lang=` é honrado
+    **apenas no fluxo de RSVP** — não é aplicado globalmente (login e demais
+    rotas públicas ignoram `?lang=` hoje). A resolução global efetiva começa
+    no cookie `NEXT_LOCALE`.
 - **Onde está a preferência:**
   - `User.locale` (`String @default("pt-BR")`) — propagado pelo JWT do
     Auth.js. Pode ser alterado em `/dashboard/profile`.
@@ -373,17 +377,21 @@ Todo body/form **deve** ser validado com Zod com limites explícitos:
   reemitir o JWT.
 - **Adicionar nova chave:** adicione nos **3** catálogos no mesmo PR. Não
   deixe `en`/`es` com placeholders — traduza ou peça revisão.
-- **Status atual da cobertura:**
-  - 100%: login, forgot-password, reset-password, RSVP individual e
-    grupo, sidebar/mobile-nav, onboarding wizard, profile, templates de
-    notificação (9 kinds × 3 idiomas), Server Actions críticas (auth,
-    passwordReset, onboarding, profile).
-  - **Pendente** (rotam pt-BR via shim de `formatCurrency`/`formatDate`,
-    sem tradução de UI nesta entrega): páginas internas do dashboard
-    (`vendors`, `venues`, `tasks`, `payments`, `income`, `assets`,
-    `goals`, `guests`, `gifts`, `wedding-day`, `honeymoon`, `trousseau`,
-    `insights`, `reports`, `settings`) e demais Server Actions. Conteúdo
-    detalhado do help center continua em pt-BR até traduções de
+- **Status atual da cobertura (estado real, não meta):**
+  - Traduzido (usa next-intl): login, forgot-password, reset-password, RSVP
+    individual e grupo, sidebar/mobile-nav, profile, templates de notificação
+    (9 kinds × 3 idiomas) e as Server Actions de auth/passwordReset.
+  - **Onboarding NÃO está 100%.** O wizard ainda tem toasts e `placeholder`s
+    hardcoded (não migrados para catálogo).
+  - **Dashboard quase não traduzido.** Apenas ~4 das ~80 páginas/telas do
+    dashboard consomem next-intl; as demais têm strings de UI hardcoded em
+    pt-BR (rotam pt-BR via shim de `formatCurrency`/`formatDate`).
+  - **Server Actions majoritariamente hardcoded.** ~44 das ~48 Server Actions
+    ainda retornam erros em pt-BR hardcoded (`return { error: "..." }`); só as
+    críticas de auth foram migradas.
+  - **`formatCurrency` ignora `EventSettings.currency`** hoje — o símbolo/moeda
+    exibido não respeita a configuração do evento. Limitação conhecida.
+  - Conteúdo detalhado do help center continua em pt-BR até traduções de
     comunidade.
 
 ### 6.5 Logs

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm run dev
 ### 🪟 Windows (PowerShell)
 
 ```powershell
-git clone https://github.com/guiloklex_hub/wedding-management-system.git
+git clone https://github.com/guiloklex-hub/wedding-management-system.git
 cd wedding-management-system
 .\setup.ps1
 npm run dev

--- a/docs/api.md
+++ b/docs/api.md
@@ -183,6 +183,46 @@ Authorization: Bearer <CRON_SECRET>
 
 ---
 
+## Cron de limpeza de arquivos
+
+```
+GET /api/cron/cleanup-files
+Authorization: Bearer <CRON_SECRET>
+```
+
+**Requer:** Bearer token (`CRON_SECRET` do `.env`), comparado timing-safe.
+Tem rate limit por IP (5/min).
+
+**O que faz:**
+1. Remove definitivamente os `Attachment` com `deletedAt` há mais de 30 dias
+   (apaga o arquivo em disco e o registro).
+2. Varre o diretório de uploads e remove arquivos órfãos (sem `Attachment`
+   correspondente).
+
+> ⚠️ Sem este cron os anexos soft-deletados nunca são apagados do disco —
+> o diretório de uploads cresce indefinidamente. Agende-o (ex.: diário).
+> Veja [deploy.md](deploy.md).
+
+**Retorna:**
+
+```json
+{
+  "ok": true,
+  "summary": {
+    "softDeletedHardRemoved": 3,
+    "orphanFilesRemoved": 1,
+    "errors": 0
+  }
+}
+```
+
+**Erros:**
+- `401` se Bearer inválido ou ausente.
+- `429` se o rate limit por IP for excedido.
+- `500` se `CRON_SECRET` não estiver configurado ou falha geral no cleanup.
+
+---
+
 ## Upload e download de arquivos
 
 ```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -10,6 +10,7 @@ Guia para colocar o Wedding Finance Planner online de forma estável.
 - PM2 para manter o processo Node vivo.
 - Cron diário para backup.
 - Cron a cada 30 min para `/api/cron/reminders`.
+- Cron diário para `/api/cron/cleanup-files` (limpa anexos órfãos/soft-deletados).
 
 ## 1. Preparar o servidor
 
@@ -163,7 +164,21 @@ crontab -e
 0 3 * * * /usr/bin/cp /var/lib/wedding/dev.db /var/backups/wedding/wedding-$(date +\%F).db && find /var/backups/wedding -name "wedding-*.db" -mtime +30 -delete
 ```
 
-## 8. Conectar WhatsApp
+## 8. Cron de limpeza de arquivos
+
+Remove definitivamente anexos soft-deletados há mais de 30 dias e arquivos
+órfãos em disco (sem registro correspondente). Sem ele, o diretório de
+uploads cresce indefinidamente — risco de encher o disco.
+
+```bash
+crontab -e
+```
+
+```cron
+0 4 * * * curl -fsS -H "Authorization: Bearer SEU_CRON_SECRET" http://localhost:3005/api/cron/cleanup-files >> /var/log/wedding-cron.log 2>&1
+```
+
+## 9. Conectar WhatsApp
 
 Acesse <https://casamento.seudominio.com/dashboard/settings>, aba **WhatsApp**,
 escaneie o QR Code. A sessão fica em `.whatsapp-auth/` dentro do diretório
@@ -172,7 +187,7 @@ do projeto.
 > ⚠️ Esse diretório precisa ser persistido entre deploys. Se você costuma
 > `rm -rf` o projeto antes de fazer `git pull`, mova-o para fora antes.
 
-## 9. Atualização (deploy de nova versão)
+## 10. Atualização (deploy de nova versão)
 
 ```bash
 cd /var/www/wedding
@@ -184,7 +199,7 @@ pm2 reload wedding-management-system
 PM2 reinicia o processo Node com graceful reload — zero downtime na maioria
 dos casos.
 
-## 10. Monitoramento
+## 11. Monitoramento
 
 ```bash
 pm2 status                          # estado geral

--- a/src/app/actions/assetActions.ts
+++ b/src/app/actions/assetActions.ts
@@ -5,11 +5,12 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoFinance } from "@/lib/finance-access";
+import { money } from "@/lib/validation";
 import type { ActionResult } from "@/types";
 
 const AssetCreateSchema = z.object({
   title: z.string().trim().min(1, "Título é obrigatório").max(120),
-  amount: z.coerce.number().min(0.01, "Valor deve ser positivo"),
+  amount: money.min(0.01, "Valor deve ser positivo"),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data inválida"),
   goalId: z.string().optional().transform((v) => (v && v.length > 0 ? v : null)),
   notes: z

--- a/src/app/actions/contractActions.ts
+++ b/src/app/actions/contractActions.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/file-validation";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { canSignContract, canUploadContract } from "@/lib/permissions";
+import { money } from "@/lib/validation";
 import type { ActionResult } from "@/types";
 
 const ContractStatusSchema = z.enum([
@@ -34,7 +35,7 @@ const ContractBaseSchema = z.object({
   status: ContractStatusSchema.default("DRAFT"),
   signedAt: z.string().optional().transform((v) => (v && v.length > 0 ? new Date(v) : null)),
   expiresAt: z.string().optional().transform((v) => (v && v.length > 0 ? new Date(v) : null)),
-  totalValue: z.coerce.number().min(0).optional().transform((v) => (v != null && !Number.isNaN(v) ? v : null)),
+  totalValue: money.optional().transform((v) => (v != null && !Number.isNaN(v) ? v : null)),
   paymentTerms: z.string().trim().max(2000).optional().transform((v) => (v && v.length > 0 ? v : null)),
   cancellationPolicy: z.string().trim().max(2000).optional().transform((v) => (v && v.length > 0 ? v : null)),
   includedItems: z.string().trim().max(4000).optional().transform((v) => (v && v.length > 0 ? v : null)),

--- a/src/app/actions/giftActions.ts
+++ b/src/app/actions/giftActions.ts
@@ -3,7 +3,9 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { denyIfNoEdit } from "@/lib/finance-access";
+import { audit } from "@/lib/audit";
+import { denyIfNoEdit, denyIfNoFinance } from "@/lib/finance-access";
+import { money } from "@/lib/validation";
 import type { ActionResult } from "@/types";
 
 type TxClient = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
@@ -20,7 +22,7 @@ const GiftBaseSchema = z.object({
   guestId: z.string().optional().transform((v) => (v && v.length > 0 ? v : null)),
   giverName: optStr(160),
   type: z.enum(["CASH", "ITEM"]).default("CASH"),
-  amount: z.coerce.number().min(0).optional().transform((v) => (Number.isFinite(v) ? v : null)),
+  amount: money.optional().transform((v) => (Number.isFinite(v) ? v : null)),
   description: optStr(500),
   notes: optStr(500),
   isHoneymoonShare: z.preprocess(
@@ -143,7 +145,7 @@ export async function markGiftAsPixReceived(
   giftId: string,
   alsoCreateAsset = false,
 ): Promise<ActionResult> {
-  const denied = await denyIfNoEdit();
+  const denied = await denyIfNoFinance();
   if (denied) return denied;
   try {
     const gift = await prisma.gift.findFirst({
@@ -172,6 +174,11 @@ export async function markGiftAsPixReceived(
           },
         });
       }
+    });
+
+    await audit("Gift", giftId, "MARK_PIX_RECEIVED", {
+      amount: gift.amount,
+      alsoCreateAsset,
     });
 
     revalidatePath("/dashboard/gifts");

--- a/src/app/actions/goalActions.ts
+++ b/src/app/actions/goalActions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoFinance } from "@/lib/finance-access";
+import { money } from "@/lib/validation";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -17,7 +18,7 @@ const optStr = (max: number) =>
 
 const GoalBaseSchema = z.object({
   name: z.string().trim().min(1).max(120),
-  targetAmount: z.coerce.number().min(0.01),
+  targetAmount: money.min(0.01),
   targetDate: z
     .string()
     .optional()

--- a/src/app/actions/guestActions.ts
+++ b/src/app/actions/guestActions.ts
@@ -299,7 +299,7 @@ export async function bulkImportGuests(
 }
 
 const RsvpPublicSchema = z.object({
-  token: z.string().min(1),
+  token: z.string().trim().min(1).max(64),
   status: z.enum(["CONFIRMED", "DECLINED", "MAYBE"]),
   plusOnesConfirmed: z.coerce.number().int().min(0).max(10).default(0),
   dietary: optStr(200),

--- a/src/app/actions/guestGroupActions.ts
+++ b/src/app/actions/guestGroupActions.ts
@@ -1,11 +1,13 @@
 "use server";
 
+import { headers } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoEdit } from "@/lib/finance-access";
 import { notifyRsvpResponse } from "@/lib/notifications/rsvp";
+import { getClientIp, rateLimit } from "@/lib/rate-limit";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -171,6 +173,11 @@ export async function publicRsvpRespondForGroup(input: {
   }>;
   notes?: string | null;
 }): Promise<ActionResult<{ groupName: string; count: number }>> {
+  const ip = getClientIp(await headers());
+  const rl = rateLimit(`rsvp:${ip}`, 10, 60_000);
+  if (!rl.ok) {
+    return { success: false, error: "Muitas tentativas. Tente novamente em alguns minutos." };
+  }
   const normalized = {
     token: input.token,
     notes: input.notes ?? null,
@@ -188,9 +195,10 @@ export async function publicRsvpRespondForGroup(input: {
 
   try {
     const group = await prisma.guestGroup.findFirst({
-      where: { rsvpToken: parsed.data.token },
+      where: { rsvpToken: parsed.data.token, deletedAt: null },
       include: {
         guests: {
+          where: { deletedAt: null },
           select: { id: true, plusOnesAllowed: true },
         },
       },
@@ -218,7 +226,7 @@ export async function publicRsvpRespondForGroup(input: {
         const plusMax = plusAllowedById.get(r.guestId) ?? 0;
         const plus = r.status === "CONFIRMED" ? Math.min(r.plusOnesConfirmed, plusMax) : 0;
         return prisma.guest.updateMany({
-          where: { id: r.guestId, groupId: group.id },
+          where: { id: r.guestId, groupId: group.id, deletedAt: null },
           data: {
             rsvpStatus: r.status,
             rsvpRespondedAt: now,

--- a/src/app/actions/honeymoonActions.ts
+++ b/src/app/actions/honeymoonActions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { money } from "@/lib/validation";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -18,12 +19,14 @@ const HoneymoonSchema = z.object({
   destination: optStr(160),
   startDate: z.string().optional().transform((v) => (v && v.length > 0 ? new Date(v) : null)),
   endDate: z.string().optional().transform((v) => (v && v.length > 0 ? new Date(v) : null)),
-  budget: z.coerce.number().min(0).optional().transform((v) => (Number.isFinite(v) ? v : null)),
+  budget: money.optional().transform((v) => (Number.isFinite(v) ? v : null)),
   currency: z.enum(["BRL", "USD", "EUR"]).default("BRL"),
   notes: optStr(2000),
 });
 
 export async function ensureHoneymoon() {
+  const denied = await denyIfNoEdit();
+  if (denied) return null;
   return prisma.honeymoon.upsert({
     where: { id: "singleton" },
     update: {},
@@ -72,7 +75,7 @@ const ItemBaseSchema = z.object({
   vendor: optStr(120),
   startAt: z.string().optional().transform((v) => (v && v.length > 0 ? new Date(v) : null)),
   endAt: z.string().optional().transform((v) => (v && v.length > 0 ? new Date(v) : null)),
-  amount: z.coerce.number().min(0).optional().transform((v) => (Number.isFinite(v) ? v : null)),
+  amount: money.optional().transform((v) => (Number.isFinite(v) ? v : null)),
   currency: z.enum(["BRL", "USD", "EUR"]).default("BRL"),
   status: ItemStatusSchema.default("PLANNED"),
   confirmationNumber: optStr(80),

--- a/src/app/actions/incomeActions.ts
+++ b/src/app/actions/incomeActions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoFinance } from "@/lib/finance-access";
+import { money } from "@/lib/validation";
 import type { ActionResult } from "@/types";
 
 const SourceSchema = z.enum(["SALARY", "BONUS", "GIFT", "FREELANCE", "SALE", "RESTITUTION", "OTHER"]);
@@ -22,7 +23,7 @@ const optStr = (max: number) =>
 const IncomeBaseSchema = z.object({
   title: z.string().trim().min(1).max(160),
   source: SourceSchema.default("SALARY"),
-  amount: z.coerce.number().min(0.01),
+  amount: money.min(0.01),
   expectedDate: z
     .string()
     .optional()

--- a/src/app/actions/paymentActions.ts
+++ b/src/app/actions/paymentActions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoFinance } from "@/lib/finance-access";
+import { money } from "@/lib/validation";
 import { splitAmountCents } from "@/lib/installment-math";
 import type { ActionResult } from "@/types";
 
@@ -30,9 +31,7 @@ const optionalPercent = z.preprocess(
 );
 
 const PaymentBaseSchema = z.object({
-  amount: z.coerce
-    .number({ message: "Valor inválido" })
-    .min(0.01, "Valor deve ser maior que zero"),
+  amount: money.min(0.01, "Valor deve ser maior que zero"),
   dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data inválida"),
   status: z.enum(["PENDING", "PAID"]),
   method: PaymentMethodSchema,
@@ -80,9 +79,9 @@ const PaymentUpdateSchema = PaymentBaseSchema.extend({
 });
 
 const SplitPaymentSchema = z.object({
-  depositAmount: z.coerce.number().min(0.01),
+  depositAmount: money.min(0.01),
   depositMethod: PaymentMethodSchema,
-  finalAmount: z.coerce.number().min(0.01),
+  finalAmount: money.min(0.01),
   finalDueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   finalMethod: PaymentMethodSchema.default("PIX"),
   vendorId: z.string().min(1),

--- a/src/app/actions/trousseauActions.ts
+++ b/src/app/actions/trousseauActions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { money } from "@/lib/validation";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -23,8 +24,8 @@ const BaseSchema = z.object({
   room: RoomSchema.default("OTHER"),
   priority: PrioritySchema.default("NICE_TO_HAVE"),
   status: StatusSchema.default("TO_BUY"),
-  estimatedPrice: z.coerce.number().min(0).optional().transform((v) => (Number.isFinite(v) ? v : null)),
-  actualPrice: z.coerce.number().min(0).optional().transform((v) => (Number.isFinite(v) ? v : null)),
+  estimatedPrice: money.optional().transform((v) => (Number.isFinite(v) ? v : null)),
+  actualPrice: money.optional().transform((v) => (Number.isFinite(v) ? v : null)),
   store: optStr(120),
   link: optStr(500),
   notes: optStr(500),

--- a/src/app/actions/vendorActions.ts
+++ b/src/app/actions/vendorActions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { money } from "@/lib/validation";
 import type { ActionResult } from "@/types";
 
 const VendorCreateSchema = z.object({
@@ -24,7 +25,7 @@ const VendorCreateSchema = z.object({
     .max(2000)
     .optional()
     .transform((v) => (v && v.length > 0 ? v : undefined)),
-  estimatedValue: z.coerce.number().min(0, "Valor estimado deve ser positivo"),
+  estimatedValue: money,
 });
 
 const VendorUpdateSchema = z.object({
@@ -45,8 +46,8 @@ const VendorUpdateSchema = z.object({
     .max(2000)
     .optional()
     .transform((v) => (v && v.length > 0 ? v : undefined)),
-  estimatedValue: z.coerce.number().min(0).optional(),
-  actualValue: z.coerce.number().min(0).optional().nullable(),
+  estimatedValue: money.optional(),
+  actualValue: money.optional().nullable(),
 });
 
 export async function createVendor(

--- a/src/app/actions/venueActions.ts
+++ b/src/app/actions/venueActions.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { DEFAULT_VENUE_CHECKLIST } from "@/lib/venue-checklist";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { money } from "@/lib/validation";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -22,7 +23,7 @@ const VenueBaseSchema = z.object({
   mapsUrl: optStr(500),
   capacitySeated: z.coerce.number().int().min(0).optional().transform((v) => (Number.isFinite(v) ? v : null)),
   capacityStanding: z.coerce.number().int().min(0).optional().transform((v) => (Number.isFinite(v) ? v : null)),
-  baseRate: z.coerce.number().min(0).optional().transform((v) => (Number.isFinite(v) ? v : null)),
+  baseRate: money.optional().transform((v) => (Number.isFinite(v) ? v : null)),
   pricingNotes: optStr(2000),
   restrictions: optStr(2000),
   pros: optStr(2000),

--- a/src/app/dashboard/guests/groups/page.tsx
+++ b/src/app/dashboard/guests/groups/page.tsx
@@ -13,6 +13,7 @@ export default async function GuestGroupsPage() {
     prisma.guestGroup.findMany({
       include: {
         guests: {
+          where: { deletedAt: null },
           orderBy: { name: "asc" },
           select: { id: true, name: true, rsvpStatus: true },
         },

--- a/src/app/rsvp/group/[token]/page.tsx
+++ b/src/app/rsvp/group/[token]/page.tsx
@@ -21,10 +21,12 @@ export default async function PublicGroupRsvpPage({
   const group = await prisma.guestGroup.findFirst({
     where: {
       rsvpToken: token,
+      deletedAt: null,
       OR: [{ rsvpTokenExpiresAt: null }, { rsvpTokenExpiresAt: { gt: now } }],
     },
     include: {
       guests: {
+        where: { deletedAt: null },
         orderBy: { name: "asc" },
         select: {
           id: true,

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,17 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.6.6",
+    date: "2026-05-29",
+    highlights: [
+      "📅 Lembretes de vencimento voltaram a mostrar o dia certo: datas só-de-dia agora são exibidas em UTC, sem 'voltar um dia' por causa do fuso horário no e-mail/WhatsApp de cobrança.",
+      "🔒 RSVP em grupo mais seguro: a página pública agora tem limite de tentativas por IP (anti-abuso) e ignora convidados/grupos arquivados, evitando confirmação em nome de quem já saiu da lista.",
+      "💰 Valores monetários ganharam teto explícito na validação (até 1.000.000) em pagamentos, receitas e presentes — bloqueia digitação acidental de cifras gigantes.",
+      "🎁 Receber um presente em Pix agora exige permissão adequada e fica registrado na auditoria (quem deu baixa e quando), além de respeitar o dono dos dados.",
+      "⚡ Correção no modo WAL do SQLite: o banco volta a ativar o write-ahead log corretamente, reduzindo travamentos sob escrita concorrente.",
+    ],
+  },
+  {
     version: "0.6.5",
     date: "2026-05-27",
     highlights: [

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -587,6 +587,9 @@ export const HELP_ARTICLES: HelpArticle[] = [
         body: "Veja docs/instalacao-windows.md seção 'Cron de lembretes'.",
       },
     ],
+    tips: [
+      "O dia do vencimento no lembrete é exibido sempre como a data cadastrada (em UTC) — sem 'voltar um dia' por causa do fuso horário.",
+    ],
   },
 
   // ============ security ============
@@ -781,6 +784,10 @@ export const HELP_ARTICLES: HelpArticle[] = [
       "Cada convidado pode estar em apenas um grupo.",
       "Importou um CSV com a coluna 'Grupo' preenchida? Os grupos são criados automaticamente (e os existentes reaproveitados pelo nome) — basta abrir o grupo depois para preencher contato e copiar o link.",
     ],
+    warnings: [
+      "Convidados ou grupos arquivados não aparecem mais no RSVP de grupo — ninguém confirma em nome de quem já saiu da lista.",
+      "A página tem limite de tentativas por IP: links de grupo divulgados em excesso podem ser temporariamente barrados como proteção anti-abuso.",
+    ],
   },
   {
     id: "guest-import-wedy",
@@ -835,6 +842,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
     ],
     warnings: [
       "Pix estático não valida o valor — confira o extrato antes de marcar como recebido.",
+      "Dar baixa em um presente exige permissão adequada e fica registrado na auditoria (quem confirmou o recebimento e quando).",
     ],
   },
   {

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -279,6 +279,7 @@ ${input.loginUrl}`;
       const vendor = escapeHtml(input.vendorName);
       const value = formatCurrency(input.amount, moneyCurrency, locale);
       const date = formatDate(input.dueDate, locale, {
+        timeZone: "UTC",
         day: "2-digit",
         month: "2-digit",
         year: "numeric",
@@ -332,6 +333,7 @@ ${whenWa}
       const vendor = escapeHtml(input.vendorName);
       const value = formatCurrency(input.amount, moneyCurrency, locale);
       const date = formatDate(input.dueDate, locale, {
+        timeZone: "UTC",
         day: "2-digit",
         month: "2-digit",
         year: "numeric",
@@ -372,6 +374,7 @@ ${tk("waSubtitle", { days: input.daysOverdue })}
       const tk = (key: string, values?: Record<string, string | number | Date>) => t(`TASK_DUE.${key}`, values);
       const title = escapeHtml(input.taskTitle);
       const date = formatDate(input.deadline, locale, {
+        timeZone: "UTC",
         day: "2-digit",
         month: "2-digit",
         year: "numeric",
@@ -420,6 +423,7 @@ ${tk("waDeadline", { date })}`;
       const tk = (key: string, values?: Record<string, string | number | Date>) => t(`TASK_OVERDUE.${key}`, values);
       const title = escapeHtml(input.taskTitle);
       const date = formatDate(input.deadline, locale, {
+        timeZone: "UTC",
         day: "2-digit",
         month: "2-digit",
         year: "numeric",

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -148,8 +148,8 @@ if (!globalForPrisma.pragmaApplied) {
   globalForPrisma.pragmaApplied = true;
   void (async () => {
     try {
-      await prisma.$executeRawUnsafe("PRAGMA journal_mode = WAL");
-      await prisma.$executeRawUnsafe("PRAGMA busy_timeout = 5000");
+      await prisma.$queryRawUnsafe("PRAGMA journal_mode = WAL");
+      await prisma.$queryRawUnsafe("PRAGMA busy_timeout = 5000");
     } catch (err) {
       console.error("[prisma] failed to apply PRAGMA WAL/busy_timeout:", err);
     }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const money = z.coerce.number().min(0).max(1_000_000);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { mockDeep, mockReset } from "vitest-mock-extended";
 import type { PrismaClient } from "@prisma/client";
+import type { Locale } from "./src/i18n/config";
 
 vi.mock("@/lib/prisma", () => ({
   prisma: mockDeep<PrismaClient>(),
@@ -34,9 +35,8 @@ vi.mock("next/headers", () => ({
 }));
 
 vi.mock("next-intl/server", async () => {
-  const { LOCALES, DEFAULT_LOCALE } = await import("./src/i18n/config");
+  const { DEFAULT_LOCALE } = await import("./src/i18n/config");
 
-  type Locale = (typeof LOCALES)[number];
   const cache = new Map<Locale, Record<string, unknown>>();
 
   async function loadLocale(locale: Locale): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## Resumo

Aplica as correções da auditoria completa do sistema (workflow multi-agente com verificação adversarial). Sem mudanças de schema. Todos os gates verdes: `lint` (0 warnings), `test:run` (539 testes), `build` (limpo, sem os P2010 do PRAGMA).

## Mudanças por severidade

### 🔴 ALTA
- **Rate limit no RSVP em grupo** (`guestGroupActions.ts`): `publicRsvpRespondForGroup` não tinha rate limit e fazia até 200 `updateMany` + notificações por requisição. Espelha o RSVP individual (`getClientIp` + `rateLimit` por IP).

### 🟠 MÉDIA
- **Soft-delete respeitado no RSVP de grupo**: `deletedAt: null` no `findFirst`, no `include.guests` e no `updateMany` (action + page pública + painel). Evita expor/escrever em convidados e grupos arquivados.
- **Off-by-one de data nos lembretes**: `timeZone: "UTC"` nos `formatDate` de campos date-only (`PAYMENT_DUE/OVERDUE`, `TASK_DUE/OVERDUE`) — antes exibia o dia anterior em pt-BR.
- **Caps monetários (§5.10)**: novo helper `money` (`src/lib/validation.ts`) aplicado em payment/goal/income/asset/vendor/contract/venue/trousseau/gift/honeymoon.
- **PIX de presente**: `markGiftAsPixReceived` passa a usar `denyIfNoFinance` (cria `Asset`) e grava `audit(MARK_PIX_RECEIVED)`.
- **Docs**: cron `/api/cron/cleanup-files` documentado (deploy.md + api.md); URL de clone do README corrigida; AGENTS §6.7 ajustado para refletir a cobertura i18n real.

### 🟡 BAIXA / qualidade
- `PRAGMA journal_mode=WAL` e `busy_timeout` via `$queryRawUnsafe` (PRAGMA retorna linha → `$executeRawUnsafe` lançava P2010 ~16x por build e o WAL nunca era aplicado).
- Guard de auth em `ensureHoneymoon`; token de RSVP `.trim().min(1).max(64)`; warning de lint do `LOCALES` em `vitest.setup.ts`.
- Changelog `0.6.6` + 3 artigos do help center.

## Decisões que valem revisão
1. A mensagem de erro do rate limit no RSVP de grupo é string literal pt-BR (espelha a action irmã, que ainda não é i18n).
2. Em `paymentActions.amount`, a mensagem custom *"Valor inválido"* (tipo) caiu para a default do Zod ao adotar o helper (min/UX positivos preservados).
3. `payments/page.tsx` — `include: { vendor: true }` deixado sem filtro de propósito (relação pai to-one; esconder fornecedor arquivado perderia contexto, não é vazamento em single-tenant).

## Fora de escopo (deferido)
Migração i18n de toda a UI do dashboard (~80 páginas / 44 actions) e propagação de `EventSettings.currency` (~73 call-sites) — explicitamente *pending* no AGENTS §6.7 e território do §13. A §6.7 foi atualizada descrevendo essas limitações.

## Testes
- `npm run lint` ✅ exit 0, 0 warnings
- `npm run test:run` ✅ 61 arquivos / 539 testes
- `npm run build` ✅ exit 0, sem P2010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
