### PR TITLE
feat(i18n): traduzir UI do dashboard e Server Actions (pt-BR/en/es)

### DIFF
--- a/src/app/actions/assetActions.ts
+++ b/src/app/actions/assetActions.ts
@@ -2,16 +2,18 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoFinance } from "@/lib/finance-access";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const AssetCreateSchema = z.object({
-  title: z.string().trim().min(1, "Título é obrigatório").max(120),
-  amount: money.min(0.01, "Valor deve ser positivo"),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data inválida"),
+  title: z.string().trim().min(1).max(120),
+  amount: money.min(0.01),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   goalId: z.string().optional().transform((v) => (v && v.length > 0 ? v : null)),
   notes: z
     .string()
@@ -29,12 +31,13 @@ export async function createAsset(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.asset");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = AssetCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   try {
@@ -53,7 +56,7 @@ export async function createAsset(
     return { success: true };
   } catch (err) {
     console.error("[createAsset]", err);
-    return { success: false, error: "Erro ao criar aporte" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -61,12 +64,13 @@ export async function updateAsset(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.asset");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = AssetUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   try {
@@ -80,7 +84,7 @@ export async function updateAsset(
         notes: parsed.data.notes ?? null,
       },
     });
-    if (result.count === 0) return { success: false, error: "Aporte não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
 
     await audit("Asset", parsed.data.id, "UPDATE");
     revalidatePath("/dashboard");
@@ -88,11 +92,12 @@ export async function updateAsset(
     return { success: true };
   } catch (err) {
     console.error("[updateAsset]", err);
-    return { success: false, error: "Erro ao atualizar aporte" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
 export async function deleteAsset(assetId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.asset");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   try {
@@ -100,7 +105,7 @@ export async function deleteAsset(assetId: string): Promise<ActionResult> {
       where: { id: assetId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Aporte não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
 
     await audit("Asset", assetId, "DELETE");
     revalidatePath("/dashboard");
@@ -108,6 +113,6 @@ export async function deleteAsset(assetId: string): Promise<ActionResult> {
     return { success: true };
   } catch (err) {
     console.error("[deleteAsset]", err);
-    return { success: false, error: "Erro ao excluir aporte" };
+    return { success: false, error: t("errorDelete") };
   }
 }

--- a/src/app/actions/attachmentActions.ts
+++ b/src/app/actions/attachmentActions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { removeUpload, saveUpload } from "@/lib/storage";
@@ -45,17 +46,19 @@ export async function uploadAttachment(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.attachment");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
-  if (!session?.user) return { success: false, error: "Não autorizado" };
+  if (!session?.user) return { success: false, error: tc("unauthorized") };
   const role = (session.user as { role?: string }).role;
   const userId = (session.user as { id?: string }).id;
 
   const ip = getClientIp(await headers());
   if (!rateLimit(`upload:${userId ?? "anon"}`, 10, 60_000).ok) {
-    return { success: false, error: "Muitos uploads em sequência. Tente novamente em 1 minuto." };
+    return { success: false, error: t("rateLimitUser") };
   }
   if (!rateLimit(`upload:ip:${ip}`, 30, 60_000).ok) {
-    return { success: false, error: "Limite de uploads excedido." };
+    return { success: false, error: t("rateLimitIp") };
   }
 
   const file = formData.get("file");
@@ -65,19 +68,19 @@ export async function uploadAttachment(
     kind: formData.get("kind") ?? "OTHER",
   });
   if (!parsed.success) {
-    return { success: false, error: "Destino inválido" };
+    return { success: false, error: t("invalidTarget") };
   }
   const { ownerType, ownerId, kind } = parsed.data;
 
   if (!(file instanceof File) || file.size === 0) {
-    return { success: false, error: "Arquivo obrigatório" };
+    return { success: false, error: t("fileRequired") };
   }
 
   if (!canUploadAttachmentKind(role, kind)) {
-    return { success: false, error: "Sem permissão para este tipo de anexo" };
+    return { success: false, error: t("noPermissionKind") };
   }
   if (!canEdit(role)) {
-    return { success: false, error: "Sem permissão para editar" };
+    return { success: false, error: t("noPermissionEdit") };
   }
 
   let vendorId: string | null = null;
@@ -86,16 +89,16 @@ export async function uploadAttachment(
 
   if (ownerType === "VENDOR") {
     const v = await prisma.vendor.findFirst({ where: { id: ownerId, deletedAt: null } });
-    if (!v) return { success: false, error: "Fornecedor não encontrado" };
+    if (!v) return { success: false, error: t("vendorNotFound") };
     vendorId = v.id;
   } else if (ownerType === "CONTRACT") {
     const c = await prisma.contract.findFirst({ where: { id: ownerId, deletedAt: null } });
-    if (!c) return { success: false, error: "Contrato não encontrado" };
+    if (!c) return { success: false, error: t("contractNotFound") };
     contractId = c.id;
     vendorId = c.vendorId;
   } else if (ownerType === "VENUE") {
     const v = await prisma.venue.findFirst({ where: { id: ownerId, deletedAt: null } });
-    if (!v) return { success: false, error: "Local não encontrado" };
+    if (!v) return { success: false, error: t("venueNotFound") };
     venueId = v.id;
   }
 
@@ -147,36 +150,38 @@ export async function uploadAttachment(
     console.error("[uploadAttachment]", err);
     return {
       success: false,
-      error: err instanceof Error ? err.message : "Erro ao enviar arquivo",
+      error: err instanceof Error ? err.message : t("errorUpload"),
     };
   }
 }
 
 export async function deleteAttachment(attachmentId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.attachment");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
-  if (!session?.user) return { success: false, error: "Não autorizado" };
+  if (!session?.user) return { success: false, error: tc("unauthorized") };
   const role = (session.user as { role?: string }).role;
   const userId = (session.user as { id?: string }).id;
 
   if (!canEdit(role)) {
-    return { success: false, error: "Sem permissão" };
+    return { success: false, error: t("noPermission") };
   }
 
   try {
     const existing = await prisma.attachment.findFirst({
       where: { id: attachmentId, deletedAt: null },
     });
-    if (!existing) return { success: false, error: "Anexo não encontrado" };
+    if (!existing) return { success: false, error: t("notFound") };
 
     if (existing.kind === "CONTRACT" && !canManageContract(role)) {
       return {
         success: false,
-        error: "Apenas administrador, noivo ou noiva podem remover contratos.",
+        error: t("onlyAdminCoupleRemoveContract"),
       };
     }
 
     if (!canViewAttachmentKind(role, existing.kind)) {
-      return { success: false, error: "Sem permissão para este anexo" };
+      return { success: false, error: t("noPermissionView") };
     }
 
     await prisma.attachment.update({
@@ -197,7 +202,7 @@ export async function deleteAttachment(attachmentId: string): Promise<ActionResu
     return { success: true };
   } catch (err) {
     console.error("[deleteAttachment]", err);
-    return { success: false, error: "Erro ao excluir anexo" };
+    return { success: false, error: t("errorDelete") };
   }
 }
 

--- a/src/app/actions/contractActions.ts
+++ b/src/app/actions/contractActions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { auth } from "@/auth";
@@ -18,6 +19,7 @@ import {
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { canSignContract, canUploadContract } from "@/lib/permissions";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const ContractStatusSchema = z.enum([
@@ -53,12 +55,13 @@ export async function createContract(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult<{ id: string }>> {
+  const t = await getTranslations("actions.contract");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = ContractCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const existingVersionCount = await prisma.contract.count({
@@ -85,7 +88,7 @@ export async function createContract(
     return { success: true, data: { id: created.id } };
   } catch (err) {
     console.error("[createContract]", err);
-    return { success: false, error: "Erro ao criar contrato" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -93,12 +96,13 @@ export async function updateContract(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.contract");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = ContractUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const result = await prisma.contract.updateMany({
@@ -117,16 +121,17 @@ export async function updateContract(
         version: parsed.data.version ?? undefined,
       },
     });
-    if (result.count === 0) return { success: false, error: "Contrato não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath(`/dashboard/vendors/${parsed.data.vendorId}`);
     return { success: true };
   } catch (err) {
     console.error("[updateContract]", err);
-    return { success: false, error: "Erro ao atualizar contrato" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
 export async function deleteContract(contractId: string, vendorId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.contract");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -134,12 +139,12 @@ export async function deleteContract(contractId: string, vendorId: string): Prom
       where: { id: contractId, vendorId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Contrato não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath(`/dashboard/vendors/${vendorId}`);
     return { success: true };
   } catch (err) {
     console.error("[deleteContract]", err);
-    return { success: false, error: "Erro ao excluir contrato" };
+    return { success: false, error: t("errorDelete") };
   }
 }
 
@@ -157,11 +162,13 @@ export async function signContract(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.contract");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
-  if (!session?.user) return { success: false, error: "Não autorizado" };
+  if (!session?.user) return { success: false, error: tc("unauthorized") };
   const role = (session.user as { role?: string }).role;
   const userId = (session.user as { id?: string }).id;
-  if (!canSignContract(role)) return { success: false, error: "Sem permissão para assinar" };
+  if (!canSignContract(role)) return { success: false, error: t("noPermissionSign") };
 
   const parsed = SignContractSchema.safeParse({
     contractId: formData.get("contractId"),
@@ -170,7 +177,7 @@ export async function signContract(
     signedAt: formData.get("signedAt") || undefined,
   });
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   const status = parsed.data.method === "DIGITAL" ? "SIGNED_DIGITAL" : "SIGNED_PHYSICAL";
@@ -185,7 +192,7 @@ export async function signContract(
       },
       data: { status, signedAt },
     });
-    if (result.count === 0) return { success: false, error: "Contrato não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
 
     await audit(
       "Contract",
@@ -198,7 +205,7 @@ export async function signContract(
     return { success: true };
   } catch (err) {
     console.error("[signContract]", err);
-    return { success: false, error: "Erro ao registrar assinatura" };
+    return { success: false, error: t("errorSign") };
   }
 }
 
@@ -211,20 +218,22 @@ export async function replaceContractFile(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.contract");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
-  if (!session?.user) return { success: false, error: "Não autorizado" };
+  if (!session?.user) return { success: false, error: tc("unauthorized") };
   const role = (session.user as { role?: string }).role;
   const userId = (session.user as { id?: string }).id;
   if (!canUploadContract(role)) {
-    return { success: false, error: "Sem permissão para enviar contrato" };
+    return { success: false, error: t("noPermissionUpload") };
   }
 
   const ip = getClientIp(await headers());
   if (!rateLimit(`upload:${userId ?? "anon"}`, 10, 60_000).ok) {
-    return { success: false, error: "Muitos uploads em sequência. Tente novamente em 1 minuto." };
+    return { success: false, error: t("rateLimitUser") };
   }
   if (!rateLimit(`upload:ip:${ip}`, 30, 60_000).ok) {
-    return { success: false, error: "Limite de uploads excedido." };
+    return { success: false, error: t("rateLimitIp") };
   }
 
   const file = formData.get("file");
@@ -233,16 +242,16 @@ export async function replaceContractFile(
     vendorId: formData.get("vendorId"),
   });
   if (!parsed.success) {
-    return { success: false, error: "Destino inválido" };
+    return { success: false, error: t("invalidTarget") };
   }
   if (!(file instanceof File) || file.size === 0) {
-    return { success: false, error: "Arquivo obrigatório" };
+    return { success: false, error: t("fileRequired") };
   }
 
   const contract = await prisma.contract.findFirst({
     where: { id: parsed.data.contractId, vendorId: parsed.data.vendorId, deletedAt: null },
   });
-  if (!contract) return { success: false, error: "Contrato não encontrado" };
+  if (!contract) return { success: false, error: t("notFound") };
 
   try {
     const bytes = Buffer.from(await file.arrayBuffer());
@@ -320,6 +329,6 @@ export async function replaceContractFile(
       return { success: false, error: err.message };
     }
     console.error("[replaceContractFile]", err);
-    return { success: false, error: "Erro ao enviar contrato" };
+    return { success: false, error: t("errorUpload") };
   }
 }

--- a/src/app/actions/giftActions.ts
+++ b/src/app/actions/giftActions.ts
@@ -2,10 +2,12 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoEdit, denyIfNoFinance } from "@/lib/finance-access";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 type TxClient = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
@@ -42,12 +44,13 @@ export async function createGift(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.gift");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = GiftCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     await prisma.gift.create({
@@ -66,7 +69,7 @@ export async function createGift(
     return { success: true };
   } catch (err) {
     console.error("[createGift]", err);
-    return { success: false, error: "Erro ao registrar presente" };
+    return { success: false, error: t("errorCreating") };
   }
 }
 
@@ -74,12 +77,13 @@ export async function updateGift(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.gift");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = GiftUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const result = await prisma.gift.updateMany({
@@ -95,16 +99,17 @@ export async function updateGift(
         receivedAt: parsed.data.receivedAt,
       },
     });
-    if (result.count === 0) return { success: false, error: "Presente não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath("/dashboard/gifts");
     return { success: true };
   } catch (err) {
     console.error("[updateGift]", err);
-    return { success: false, error: "Erro ao atualizar presente" };
+    return { success: false, error: t("errorUpdating") };
   }
 }
 
 export async function markGiftThanked(giftId: string, thanked: boolean): Promise<ActionResult> {
+  const t = await getTranslations("actions.gift");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -115,16 +120,17 @@ export async function markGiftThanked(giftId: string, thanked: boolean): Promise
         thankedAt: thanked ? new Date() : null,
       },
     });
-    if (result.count === 0) return { success: false, error: "Presente não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath("/dashboard/gifts");
     return { success: true };
   } catch (err) {
     console.error("[markGiftThanked]", err);
-    return { success: false, error: "Erro ao atualizar" };
+    return { success: false, error: t("errorUpdatingShort") };
   }
 }
 
 export async function deleteGift(giftId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.gift");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -132,12 +138,12 @@ export async function deleteGift(giftId: string): Promise<ActionResult> {
       where: { id: giftId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Presente não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath("/dashboard/gifts");
     return { success: true };
   } catch (err) {
     console.error("[deleteGift]", err);
-    return { success: false, error: "Erro ao excluir presente" };
+    return { success: false, error: t("errorDeleting") };
   }
 }
 
@@ -145,14 +151,15 @@ export async function markGiftAsPixReceived(
   giftId: string,
   alsoCreateAsset = false,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.gift");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   try {
     const gift = await prisma.gift.findFirst({
       where: { id: giftId, deletedAt: null },
     });
-    if (!gift) return { success: false, error: "Presente não encontrado" };
-    if (gift.pixPaidAt) return { success: false, error: "Pix já marcado como recebido" };
+    if (!gift) return { success: false, error: t("notFound") };
+    if (gift.pixPaidAt) return { success: false, error: t("pixAlreadyReceived") };
 
     const now = new Date();
     await prisma.$transaction(async (tx: TxClient) => {
@@ -167,10 +174,13 @@ export async function markGiftAsPixReceived(
       if (alsoCreateAsset && gift.amount && gift.amount > 0) {
         await tx.asset.create({
           data: {
-            title: `Pix de ${gift.giverName ?? "convidado"}${gift.isHoneymoonShare ? " (cota lua de mel)" : ""}`,
+            title: t("assetTitle", {
+              giver: gift.giverName ?? t("assetGuestFallback"),
+              honeymoon: gift.isHoneymoonShare ? t("assetHoneymoonSuffix") : "",
+            }),
             amount: gift.amount,
             date: now,
-            notes: `Gerado a partir do presente #${gift.id}`,
+            notes: t("assetNotes", { id: gift.id }),
           },
         });
       }
@@ -186,6 +196,6 @@ export async function markGiftAsPixReceived(
     return { success: true };
   } catch (err) {
     console.error("[markGiftAsPixReceived]", err);
-    return { success: false, error: "Erro ao marcar Pix recebido" };
+    return { success: false, error: t("errorMarkingPix") };
   }
 }

--- a/src/app/actions/goalActions.ts
+++ b/src/app/actions/goalActions.ts
@@ -2,10 +2,12 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoFinance } from "@/lib/finance-access";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -35,12 +37,13 @@ export async function createGoal(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.goal");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = GoalCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const created = await prisma.savingsGoal.create({
@@ -59,7 +62,7 @@ export async function createGoal(
     return { success: true };
   } catch (err) {
     console.error("[createGoal]", err);
-    return { success: false, error: "Erro ao criar meta" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -67,12 +70,13 @@ export async function updateGoal(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.goal");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = GoalUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const result = await prisma.savingsGoal.updateMany({
@@ -86,18 +90,19 @@ export async function updateGoal(
         isActive: parsed.data.isActive,
       },
     });
-    if (result.count === 0) return { success: false, error: "Meta não encontrada" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await audit("SavingsGoal", parsed.data.id, "UPDATE", { name: parsed.data.name });
     revalidatePath("/dashboard/goals");
     revalidatePath("/dashboard");
     return { success: true };
   } catch (err) {
     console.error("[updateGoal]", err);
-    return { success: false, error: "Erro ao atualizar meta" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
 export async function deleteGoal(goalId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.goal");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   try {
@@ -105,7 +110,7 @@ export async function deleteGoal(goalId: string): Promise<ActionResult> {
       where: { id: goalId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Meta não encontrada" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await prisma.asset.updateMany({
       where: { goalId, deletedAt: null },
       data: { goalId: null },
@@ -116,6 +121,6 @@ export async function deleteGoal(goalId: string): Promise<ActionResult> {
     return { success: true };
   } catch (err) {
     console.error("[deleteGoal]", err);
-    return { success: false, error: "Erro ao excluir meta" };
+    return { success: false, error: t("errorDelete") };
   }
 }

--- a/src/app/actions/guestActions.ts
+++ b/src/app/actions/guestActions.ts
@@ -3,9 +3,11 @@
 import { headers } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import { denyIfNoEdit } from "@/lib/finance-access";
 import { notifyRsvpResponse } from "@/lib/notifications/rsvp";
 import { getClientIp, rateLimit } from "@/lib/rate-limit";
@@ -61,12 +63,13 @@ export async function createGuest(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.guest");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = GuestCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const created = await prisma.guest.create({
@@ -92,7 +95,7 @@ export async function createGuest(
     return { success: true };
   } catch (err) {
     console.error("[createGuest]", err);
-    return { success: false, error: "Erro ao criar convidado" };
+    return { success: false, error: t("errorCreating") };
   }
 }
 
@@ -100,12 +103,13 @@ export async function updateGuest(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.guest");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = GuestUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const result = await prisma.guest.updateMany({
@@ -127,17 +131,18 @@ export async function updateGuest(
         notes: parsed.data.notes,
       },
     });
-    if (result.count === 0) return { success: false, error: "Convidado não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await audit("Guest", parsed.data.id, "UPDATE", { name: parsed.data.name });
     revalidatePath("/dashboard/guests");
     return { success: true };
   } catch (err) {
     console.error("[updateGuest]", err);
-    return { success: false, error: "Erro ao atualizar convidado" };
+    return { success: false, error: t("errorUpdating") };
   }
 }
 
 export async function deleteGuest(guestId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.guest");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -145,17 +150,18 @@ export async function deleteGuest(guestId: string): Promise<ActionResult> {
       where: { id: guestId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Convidado não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await audit("Guest", guestId, "DELETE");
     revalidatePath("/dashboard/guests");
     return { success: true };
   } catch (err) {
     console.error("[deleteGuest]", err);
-    return { success: false, error: "Erro ao excluir convidado" };
+    return { success: false, error: t("errorDeleting") };
   }
 }
 
 export async function toggleCheckin(guestId: string, present: boolean): Promise<ActionResult> {
+  const t = await getTranslations("actions.guest");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -163,14 +169,14 @@ export async function toggleCheckin(guestId: string, present: boolean): Promise<
       where: { id: guestId, deletedAt: null },
       data: { checkedInAt: present ? new Date() : null },
     });
-    if (result.count === 0) return { success: false, error: "Convidado não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await audit("Guest", guestId, "STATUS_CHANGE", { checkedIn: present });
     revalidatePath("/dashboard/guests");
     revalidatePath("/dashboard/wedding-day");
     return { success: true };
   } catch (err) {
     console.error("[toggleCheckin]", err);
-    return { success: false, error: "Erro ao registrar presença" };
+    return { success: false, error: t("errorCheckin") };
   }
 }
 
@@ -192,19 +198,20 @@ export async function bulkImportGuests(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult<{ created: number; skipped: number; groupsCreated: number }>> {
+  const t = await getTranslations("actions.guest");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = ImportSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   const lines = parsed.data.raw
     .split(/\r?\n/)
     .map((l) => l.trim())
     .filter(Boolean);
-  if (lines.length === 0) return { success: false, error: "Nenhuma linha encontrada" };
+  if (lines.length === 0) return { success: false, error: t("noLinesFound") };
 
   const sep =
     parsed.data.separator === "TAB"
@@ -294,7 +301,7 @@ export async function bulkImportGuests(
     return { success: true, data: { created: createdCount, skipped, groupsCreated } };
   } catch (err) {
     console.error("[bulkImportGuests]", err);
-    return { success: false, error: "Erro ao importar" };
+    return { success: false, error: t("errorImporting") };
   }
 }
 
@@ -310,23 +317,24 @@ export async function publicRsvpRespond(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult<{ name: string; status: string }>> {
+  const t = await getTranslations("actions.guest");
   const ip = getClientIp(await headers());
   const rl = rateLimit(`rsvp:${ip}`, 10, 60_000);
   if (!rl.ok) {
-    return { success: false, error: "Muitas tentativas. Tente novamente em alguns minutos." };
+    return { success: false, error: t("tooManyAttempts") };
   }
   const data = Object.fromEntries(formData.entries());
   const parsed = RsvpPublicSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const guest = await prisma.guest.findFirst({
       where: { rsvpToken: parsed.data.token, deletedAt: null },
     });
-    if (!guest) return { success: false, error: "Convite não encontrado" };
+    if (!guest) return { success: false, error: t("inviteNotFound") };
     if (guest.rsvpTokenExpiresAt && guest.rsvpTokenExpiresAt.getTime() < Date.now()) {
-      return { success: false, error: "Link expirado. Solicite um novo convite." };
+      return { success: false, error: t("linkExpired") };
     }
 
     const plus = Math.min(parsed.data.plusOnesConfirmed, guest.plusOnesAllowed);
@@ -353,7 +361,7 @@ export async function publicRsvpRespond(
     return { success: true, data: { name: updated.name, status: updated.rsvpStatus } };
   } catch (err) {
     console.error("[publicRsvpRespond]", err);
-    return { success: false, error: "Erro ao registrar resposta" };
+    return { success: false, error: t("errorRsvp") };
   }
 }
 
@@ -421,29 +429,31 @@ export async function previewGuestImport(
   _state: ActionResult<PreviewData> | undefined,
   formData: FormData,
 ): Promise<ActionResult<PreviewData>> {
+  const t = await getTranslations("actions.guest");
+  const tc = await getTranslations("actions.common");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   const session = await auth();
   const userId = (session?.user as { id?: string } | undefined)?.id;
-  if (!userId) return { success: false, error: "Não autorizado" };
+  if (!userId) return { success: false, error: tc("unauthorized") };
 
   const ip = getClientIp(await headers());
   if (!rateLimit(`guest-import:${userId}`, 5, 60_000).ok) {
-    return { success: false, error: "Muitos uploads em sequência. Aguarde 1 minuto." };
+    return { success: false, error: t("tooManyUploads") };
   }
   if (!rateLimit(`guest-import:ip:${ip}`, 15, 60_000).ok) {
-    return { success: false, error: "Limite de uploads excedido." };
+    return { success: false, error: t("uploadLimitExceeded") };
   }
 
   const file = formData.get("file");
   if (!(file instanceof File) || file.size === 0) {
-    return { success: false, error: "Arquivo obrigatório" };
+    return { success: false, error: t("fileRequired") };
   }
 
   const sourceParam = SourceParamSchema.safeParse(formData.get("source") ?? "AUTO");
   if (!sourceParam.success) {
-    return { success: false, error: "Origem desconhecida" };
+    return { success: false, error: t("unknownSource") };
   }
 
   try {
@@ -463,9 +473,7 @@ export async function previewGuestImport(
     } else if (detectedMagic === "xlsx") {
       sheet = await extractXlsxRecords(bytes);
     } else {
-      throw new FileValidationError(
-        "Formato não suportado. Use .xlsx (Wedy) ou .csv (exportação do próprio sistema).",
-      );
+      throw new FileValidationError(t("unsupportedFormat"));
     }
 
     let importer: Importer | null = null;
@@ -474,8 +482,7 @@ export async function previewGuestImport(
       if (!importer) {
         return {
           success: false,
-          error:
-            "Não foi possível identificar o formato. Suportados: Wedy (.xlsx) ou CSV exportado pelo próprio sistema.",
+          error: t("unrecognizedFormat"),
         };
       }
     } else {
@@ -484,12 +491,12 @@ export async function previewGuestImport(
 
     const rows = importer.parseRecords(sheet.records);
     if (rows.length === 0) {
-      return { success: false, error: "Nenhuma linha válida encontrada na planilha." };
+      return { success: false, error: t("noValidRows") };
     }
     if (rows.length > MAX_IMPORT_ROWS) {
       return {
         success: false,
-        error: `Limite de ${MAX_IMPORT_ROWS} linhas por importação.`,
+        error: t("rowLimit", { max: MAX_IMPORT_ROWS }),
       };
     }
 
@@ -580,7 +587,7 @@ export async function previewGuestImport(
       return { success: false, error: err.message };
     }
     console.error("[previewGuestImport]", err);
-    return { success: false, error: "Erro ao processar arquivo" };
+    return { success: false, error: t("errorProcessingFile") };
   }
 }
 
@@ -593,23 +600,25 @@ export async function commitGuestImport(input: {
   importToken: string;
   mode: CommitMode;
 }): Promise<ActionResult<CommitData>> {
+  const t = await getTranslations("actions.guest");
+  const tc = await getTranslations("actions.common");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   const session = await auth();
   const userId = (session?.user as { id?: string } | undefined)?.id;
-  if (!userId) return { success: false, error: "Não autorizado" };
+  if (!userId) return { success: false, error: tc("unauthorized") };
 
   const parsed = CommitSchema.safeParse(input);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   const entry = consumeImport(userId, parsed.data.importToken);
   if (!entry) {
     return {
       success: false,
-      error: "Sessão de importação expirou. Reenvie o arquivo.",
+      error: t("importSessionExpired"),
     };
   }
 
@@ -887,6 +896,6 @@ export async function commitGuestImport(input: {
     return { success: true, data: result };
   } catch (err) {
     console.error("[commitGuestImport]", err);
-    return { success: false, error: "Erro ao gravar importação" };
+    return { success: false, error: t("errorCommittingImport") };
   }
 }

--- a/src/app/actions/guestGroupActions.ts
+++ b/src/app/actions/guestGroupActions.ts
@@ -3,8 +3,10 @@
 import { headers } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import { denyIfNoEdit } from "@/lib/finance-access";
 import { notifyRsvpResponse } from "@/lib/notifications/rsvp";
 import { getClientIp, rateLimit } from "@/lib/rate-limit";
@@ -34,13 +36,14 @@ export async function createGuestGroup(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.guestGroup");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   const data = Object.fromEntries(formData.entries());
   const parsed = GroupCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const created = await prisma.guestGroup.create({ data: parsed.data });
@@ -50,7 +53,7 @@ export async function createGuestGroup(
     return { success: true };
   } catch (err) {
     console.error("[createGuestGroup]", err);
-    return { success: false, error: "Erro ao criar grupo" };
+    return { success: false, error: t("errorCreating") };
   }
 }
 
@@ -58,13 +61,14 @@ export async function updateGuestGroup(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.guestGroup");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   const data = Object.fromEntries(formData.entries());
   const parsed = GroupUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const { id, ...rest } = parsed.data;
@@ -72,22 +76,23 @@ export async function updateGuestGroup(
       where: { id },
       data: rest,
     });
-    if (result.count === 0) return { success: false, error: "Grupo não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await audit("GuestGroup", id, "UPDATE", { name: rest.name });
     revalidatePath("/dashboard/guests/groups");
     revalidatePath("/dashboard/guests");
     return { success: true };
   } catch (err) {
     console.error("[updateGuestGroup]", err);
-    return { success: false, error: "Erro ao atualizar grupo" };
+    return { success: false, error: t("errorUpdating") };
   }
 }
 
 export async function deleteGuestGroup(groupId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.guestGroup");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   if (typeof groupId !== "string" || groupId.length === 0 || groupId.length > 64) {
-    return { success: false, error: "ID inválido" };
+    return { success: false, error: t("invalidId") };
   }
   try {
     await prisma.$transaction([
@@ -100,7 +105,7 @@ export async function deleteGuestGroup(groupId: string): Promise<ActionResult> {
     return { success: true };
   } catch (err) {
     console.error("[deleteGuestGroup]", err);
-    return { success: false, error: "Erro ao excluir grupo" };
+    return { success: false, error: t("errorDeleting") };
   }
 }
 
@@ -113,12 +118,13 @@ export async function setGroupMembers(input: {
   groupId: string;
   guestIds: string[];
 }): Promise<ActionResult> {
+  const t = await getTranslations("actions.guestGroup");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   const parsed = GroupMembershipSchema.safeParse(input);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     await prisma.$transaction([
@@ -143,7 +149,7 @@ export async function setGroupMembers(input: {
     return { success: true };
   } catch (err) {
     console.error("[setGroupMembers]", err);
-    return { success: false, error: "Erro ao atualizar membros" };
+    return { success: false, error: t("errorUpdatingMembers") };
   }
 }
 
@@ -173,10 +179,11 @@ export async function publicRsvpRespondForGroup(input: {
   }>;
   notes?: string | null;
 }): Promise<ActionResult<{ groupName: string; count: number }>> {
+  const t = await getTranslations("actions.guestGroup");
   const ip = getClientIp(await headers());
   const rl = rateLimit(`rsvp:${ip}`, 10, 60_000);
   if (!rl.ok) {
-    return { success: false, error: "Muitas tentativas. Tente novamente em alguns minutos." };
+    return { success: false, error: t("tooManyAttempts") };
   }
   const normalized = {
     token: input.token,
@@ -190,7 +197,7 @@ export async function publicRsvpRespondForGroup(input: {
   };
   const parsed = GroupResponseSchema.safeParse(normalized);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   try {
@@ -203,9 +210,9 @@ export async function publicRsvpRespondForGroup(input: {
         },
       },
     });
-    if (!group) return { success: false, error: "Convite de grupo não encontrado" };
+    if (!group) return { success: false, error: t("groupInviteNotFound") };
     if (group.rsvpTokenExpiresAt && group.rsvpTokenExpiresAt.getTime() < Date.now()) {
-      return { success: false, error: "Link expirado. Solicite um novo convite." };
+      return { success: false, error: t("linkExpired") };
     }
 
     const groupGuestIds = new Set(group.guests.map((g: { id: string }) => g.id));
@@ -216,7 +223,7 @@ export async function publicRsvpRespondForGroup(input: {
     // Anti-IDOR: reject responses containing guestId outside this group
     for (const r of parsed.data.responses) {
       if (!groupGuestIds.has(r.guestId)) {
-        return { success: false, error: "Resposta inválida (convidado fora do grupo)" };
+        return { success: false, error: t("guestOutsideGroup") };
       }
     }
 
@@ -263,6 +270,6 @@ export async function publicRsvpRespondForGroup(input: {
     };
   } catch (err) {
     console.error("[publicRsvpRespondForGroup]", err);
-    return { success: false, error: "Erro ao registrar respostas" };
+    return { success: false, error: t("errorRsvp") };
   }
 }

--- a/src/app/actions/honeymoonActions.ts
+++ b/src/app/actions/honeymoonActions.ts
@@ -2,9 +2,11 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { denyIfNoEdit } from "@/lib/finance-access";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -40,10 +42,11 @@ export async function updateHoneymoon(
 ): Promise<ActionResult> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
+  const t = await getTranslations("actions.honeymoon");
   const data = Object.fromEntries(formData.entries());
   const parsed = HoneymoonSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     await ensureHoneymoon();
@@ -62,7 +65,7 @@ export async function updateHoneymoon(
     return { success: true };
   } catch (err) {
     console.error("[updateHoneymoon]", err);
-    return { success: false, error: "Erro ao salvar" };
+    return { success: false, error: t("errorSaving") };
   }
 }
 
@@ -90,9 +93,10 @@ export async function createHoneymoonItem(
 ): Promise<ActionResult> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
+  const t = await getTranslations("actions.honeymoon");
   const parsed = ItemCreateSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     await ensureHoneymoon();
@@ -115,7 +119,7 @@ export async function createHoneymoonItem(
     return { success: true };
   } catch (err) {
     console.error("[createHoneymoonItem]", err);
-    return { success: false, error: "Erro ao adicionar" };
+    return { success: false, error: t("errorAdding") };
   }
 }
 
@@ -125,9 +129,10 @@ export async function updateHoneymoonItem(
 ): Promise<ActionResult> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
+  const t = await getTranslations("actions.honeymoon");
   const parsed = ItemUpdateSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const result = await prisma.honeymoonItem.updateMany({
@@ -145,28 +150,29 @@ export async function updateHoneymoonItem(
         notes: parsed.data.notes,
       },
     });
-    if (result.count === 0) return { success: false, error: "Item não encontrado" };
+    if (result.count === 0) return { success: false, error: t("itemNotFound") };
     revalidatePath("/dashboard/honeymoon");
     return { success: true };
   } catch (err) {
     console.error("[updateHoneymoonItem]", err);
-    return { success: false, error: "Erro ao atualizar" };
+    return { success: false, error: t("errorUpdating") };
   }
 }
 
 export async function deleteHoneymoonItem(id: string): Promise<ActionResult> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
+  const t = await getTranslations("actions.honeymoon");
   try {
     const result = await prisma.honeymoonItem.updateMany({
       where: { id, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Item não encontrado" };
+    if (result.count === 0) return { success: false, error: t("itemNotFound") };
     revalidatePath("/dashboard/honeymoon");
     return { success: true };
   } catch (err) {
     console.error("[deleteHoneymoonItem]", err);
-    return { success: false, error: "Erro ao excluir" };
+    return { success: false, error: t("errorDeleting") };
   }
 }

--- a/src/app/actions/incomeActions.ts
+++ b/src/app/actions/incomeActions.ts
@@ -2,10 +2,12 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoFinance } from "@/lib/finance-access";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const SourceSchema = z.enum(["SALARY", "BONUS", "GIFT", "FREELANCE", "SALE", "RESTITUTION", "OTHER"]);
@@ -41,12 +43,13 @@ export async function createIncome(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.income");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = IncomeCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const now = new Date();
@@ -69,7 +72,7 @@ export async function createIncome(
     return { success: true };
   } catch (err) {
     console.error("[createIncome]", err);
-    return { success: false, error: "Erro ao criar receita" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -77,18 +80,19 @@ export async function updateIncome(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.income");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = IncomeUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const existing = await prisma.income.findFirst({
       where: { id: parsed.data.id, deletedAt: null },
     });
-    if (!existing) return { success: false, error: "Receita não encontrada" };
+    if (!existing) return { success: false, error: t("notFound") };
 
     const receivedAt =
       parsed.data.status === "RECEIVED" ? existing.receivedAt ?? new Date() : null;
@@ -113,11 +117,12 @@ export async function updateIncome(
     return { success: true };
   } catch (err) {
     console.error("[updateIncome]", err);
-    return { success: false, error: "Erro ao atualizar receita" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
 export async function markIncomeReceived(incomeId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.income");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   try {
@@ -125,18 +130,19 @@ export async function markIncomeReceived(incomeId: string): Promise<ActionResult
       where: { id: incomeId, deletedAt: null },
       data: { status: "RECEIVED", receivedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Receita não encontrada" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await audit("Income", incomeId, "STATUS_CHANGE", { status: "RECEIVED" });
     revalidatePath("/dashboard/income");
     revalidatePath("/dashboard");
     return { success: true };
   } catch (err) {
     console.error("[markIncomeReceived]", err);
-    return { success: false, error: "Erro ao marcar como recebida" };
+    return { success: false, error: t("errorMarkReceived") };
   }
 }
 
 export async function deleteIncome(incomeId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.income");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   try {
@@ -144,13 +150,13 @@ export async function deleteIncome(incomeId: string): Promise<ActionResult> {
       where: { id: incomeId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Receita não encontrada" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await audit("Income", incomeId, "DELETE");
     revalidatePath("/dashboard/income");
     revalidatePath("/dashboard");
     return { success: true };
   } catch (err) {
     console.error("[deleteIncome]", err);
-    return { success: false, error: "Erro ao excluir receita" };
+    return { success: false, error: t("errorDelete") };
   }
 }

--- a/src/app/actions/paymentActions.ts
+++ b/src/app/actions/paymentActions.ts
@@ -2,10 +2,12 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoFinance } from "@/lib/finance-access";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import { splitAmountCents } from "@/lib/installment-math";
 import type { ActionResult } from "@/types";
 
@@ -91,12 +93,13 @@ export async function createPayment(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.payment");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = PaymentCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   const dueDate = new Date(parsed.data.dueDate);
@@ -105,7 +108,7 @@ export async function createPayment(
     const vendor = await prisma.vendor.findFirst({
       where: { id: parsed.data.vendorId, deletedAt: null },
     });
-    if (!vendor) return { success: false, error: "Fornecedor não encontrado" };
+    if (!vendor) return { success: false, error: t("vendorNotFound") };
 
     const created = await prisma.payment.create({
       data: {
@@ -129,7 +132,7 @@ export async function createPayment(
     return { success: true };
   } catch (err) {
     console.error("[createPayment]", err);
-    return { success: false, error: "Erro ao criar pagamento" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -137,12 +140,13 @@ export async function updatePayment(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.payment");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = PaymentUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   const dueDate = new Date(parsed.data.dueDate);
@@ -151,7 +155,7 @@ export async function updatePayment(
     const existing = await prisma.payment.findFirst({
       where: { id: parsed.data.id, deletedAt: null },
     });
-    if (!existing) return { success: false, error: "Pagamento não encontrado" };
+    if (!existing) return { success: false, error: t("notFound") };
 
     const wasPaid = existing.status === "PAID";
     const nowPaid = parsed.data.status === "PAID";
@@ -179,11 +183,12 @@ export async function updatePayment(
     return { success: true };
   } catch (err) {
     console.error("[updatePayment]", err);
-    return { success: false, error: "Erro ao atualizar pagamento" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
 export async function markPaymentAsPaid(paymentId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.payment");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   try {
@@ -191,7 +196,7 @@ export async function markPaymentAsPaid(paymentId: string): Promise<ActionResult
       where: { id: paymentId, deletedAt: null, status: "PENDING" },
       data: { status: "PAID", paidAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Pagamento não encontrado ou já pago" };
+    if (result.count === 0) return { success: false, error: t("notFoundOrPaid") };
 
     await audit("Payment", paymentId, "MARK_PAID");
     revalidatePath("/dashboard");
@@ -199,11 +204,12 @@ export async function markPaymentAsPaid(paymentId: string): Promise<ActionResult
     return { success: true };
   } catch (err) {
     console.error("[markPaymentAsPaid]", err);
-    return { success: false, error: "Erro ao quitar pagamento" };
+    return { success: false, error: t("errorMarkPaid") };
   }
 }
 
 export async function undoPaymentPaid(paymentId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.payment");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   try {
@@ -211,7 +217,7 @@ export async function undoPaymentPaid(paymentId: string): Promise<ActionResult> 
       where: { id: paymentId, deletedAt: null, status: "PAID" },
       data: { status: "PENDING", paidAt: null },
     });
-    if (result.count === 0) return { success: false, error: "Não é possível estornar este pagamento" };
+    if (result.count === 0) return { success: false, error: t("cannotUndo") };
 
     await audit("Payment", paymentId, "UNDO_PAID");
     revalidatePath("/dashboard");
@@ -219,11 +225,12 @@ export async function undoPaymentPaid(paymentId: string): Promise<ActionResult> 
     return { success: true };
   } catch (err) {
     console.error("[undoPaymentPaid]", err);
-    return { success: false, error: "Erro ao estornar pagamento" };
+    return { success: false, error: t("errorUndo") };
   }
 }
 
 export async function deletePayment(paymentId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.payment");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   try {
@@ -231,7 +238,7 @@ export async function deletePayment(paymentId: string): Promise<ActionResult> {
       where: { id: paymentId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Pagamento não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
 
     await audit("Payment", paymentId, "DELETE");
     revalidatePath("/dashboard");
@@ -239,7 +246,7 @@ export async function deletePayment(paymentId: string): Promise<ActionResult> {
     return { success: true };
   } catch (err) {
     console.error("[deletePayment]", err);
-    return { success: false, error: "Erro ao excluir pagamento" };
+    return { success: false, error: t("errorDelete") };
   }
 }
 
@@ -247,12 +254,13 @@ export async function createSplitPayment(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.payment");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = SplitPaymentSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos para split" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   const finalDue = new Date(parsed.data.finalDueDate);
@@ -261,7 +269,7 @@ export async function createSplitPayment(
     const vendor = await prisma.vendor.findFirst({
       where: { id: parsed.data.vendorId, deletedAt: null },
     });
-    if (!vendor) return { success: false, error: "Fornecedor não encontrado" };
+    if (!vendor) return { success: false, error: t("vendorNotFound") };
 
     const now = new Date();
     const [deposit, balance] = await prisma.$transaction([
@@ -298,7 +306,7 @@ export async function createSplitPayment(
     return { success: true };
   } catch (err) {
     console.error("[createSplitPayment]", err);
-    return { success: false, error: "Erro ao criar pagamentos divididos" };
+    return { success: false, error: t("errorSplit") };
   }
 }
 
@@ -330,17 +338,18 @@ export async function generateInstallments(input: {
   interestPercentPerMonth?: number;
   notes?: string;
 }): Promise<ActionResult<{ count: number }>> {
+  const t = await getTranslations("actions.payment");
   const denied = await denyIfNoFinance();
   if (denied) return denied;
   const parsed = InstallmentsSchema.safeParse(input);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const vendor = await prisma.vendor.findFirst({
       where: { id: parsed.data.vendorId, deletedAt: null },
     });
-    if (!vendor) return { success: false, error: "Fornecedor não encontrado" };
+    if (!vendor) return { success: false, error: t("vendorNotFound") };
 
     const totalCents = Math.round(parsed.data.totalAmount * 100);
     const amountsCents = splitAmountCents(totalCents, parsed.data.installmentsCount);
@@ -380,6 +389,6 @@ export async function generateInstallments(input: {
     return { success: true, data: { count: created.length } };
   } catch (err) {
     console.error("[generateInstallments]", err);
-    return { success: false, error: "Erro ao gerar parcelas" };
+    return { success: false, error: t("errorInstallments") };
   }
 }

--- a/src/app/actions/seatingTableActions.ts
+++ b/src/app/actions/seatingTableActions.ts
@@ -2,9 +2,11 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const TableCreateSchema = z.object({
@@ -27,13 +29,14 @@ export async function createSeatingTable(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.seatingTable");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   const data = Object.fromEntries(formData.entries());
   const parsed = TableCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const created = await prisma.seatingTable.create({
@@ -49,7 +52,7 @@ export async function createSeatingTable(
     return { success: true };
   } catch (err) {
     console.error("[createSeatingTable]", err);
-    return { success: false, error: "Erro ao criar mesa" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -57,13 +60,14 @@ export async function updateSeatingTable(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.seatingTable");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   const data = Object.fromEntries(formData.entries());
   const parsed = TableUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const result = await prisma.seatingTable.updateMany({
@@ -75,22 +79,23 @@ export async function updateSeatingTable(
         notes: parsed.data.notes,
       },
     });
-    if (result.count === 0) return { success: false, error: "Mesa não encontrada" };
+    if (result.count === 0) return { success: false, error: t("tableNotFound") };
     await audit("SeatingTable", parsed.data.id, "UPDATE", { name: parsed.data.name });
     revalidatePath("/dashboard/wedding-day/seating");
     return { success: true };
   } catch (err) {
     console.error("[updateSeatingTable]", err);
-    return { success: false, error: "Erro ao atualizar mesa" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
 export async function deleteSeatingTable(tableId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.seatingTable");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   if (typeof tableId !== "string" || tableId.length === 0 || tableId.length > 64) {
-    return { success: false, error: "ID inválido" };
+    return { success: false, error: t("invalidId") };
   }
   try {
     await prisma.$transaction([
@@ -105,19 +110,20 @@ export async function deleteSeatingTable(tableId: string): Promise<ActionResult>
     return { success: true };
   } catch (err) {
     console.error("[deleteSeatingTable]", err);
-    return { success: false, error: "Erro ao excluir mesa" };
+    return { success: false, error: t("errorDelete") };
   }
 }
 
 const ReorderSchema = z.array(z.string().min(1).max(64)).min(1).max(200);
 
 export async function reorderSeatingTables(orderedIds: string[]): Promise<ActionResult> {
+  const t = await getTranslations("actions.seatingTable");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   const parsed = ReorderSchema.safeParse(orderedIds);
   if (!parsed.success) {
-    return { success: false, error: "Ordem inválida" };
+    return { success: false, error: t("invalidOrder") };
   }
   const ids = parsed.data;
   try {
@@ -134,7 +140,7 @@ export async function reorderSeatingTables(orderedIds: string[]): Promise<Action
     return { success: true };
   } catch (err) {
     console.error("[reorderSeatingTables]", err);
-    return { success: false, error: "Erro ao reordenar mesas" };
+    return { success: false, error: t("errorReorder") };
   }
 }
 
@@ -143,25 +149,26 @@ export async function updateTablePosition(
   x: number,
   y: number,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.seatingTable");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   if (typeof tableId !== "string" || tableId.length === 0 || tableId.length > 64) {
-    return { success: false, error: "ID inválido" };
+    return { success: false, error: t("invalidId") };
   }
   if (!Number.isFinite(x) || !Number.isFinite(y)) {
-    return { success: false, error: "Coordenadas inválidas" };
+    return { success: false, error: t("invalidCoords") };
   }
   try {
     const result = await prisma.seatingTable.updateMany({
       where: { id: tableId },
       data: { x, y },
     });
-    if (result.count === 0) return { success: false, error: "Mesa não encontrada" };
+    if (result.count === 0) return { success: false, error: t("tableNotFound") };
     return { success: true };
   } catch (err) {
     console.error("[updateTablePosition]", err);
-    return { success: false, error: "Erro ao mover mesa" };
+    return { success: false, error: t("errorMove") };
   }
 }
 
@@ -169,21 +176,22 @@ export async function assignGuestToTable(
   guestId: string,
   tableId: string | null,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.seatingTable");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
 
   if (typeof guestId !== "string" || guestId.length === 0 || guestId.length > 64) {
-    return { success: false, error: "ID de convidado inválido" };
+    return { success: false, error: t("invalidGuestId") };
   }
   if (tableId !== null && (typeof tableId !== "string" || tableId.length === 0 || tableId.length > 64)) {
-    return { success: false, error: "ID de mesa inválido" };
+    return { success: false, error: t("invalidTableId") };
   }
 
   try {
     const outcome = await prisma.$transaction(async (tx) => {
       if (tableId) {
         const table = await tx.seatingTable.findUnique({ where: { id: tableId } });
-        if (!table) return { ok: false as const, error: "Mesa não encontrada" };
+        if (!table) return { ok: false as const, error: t("tableNotFound") };
 
         const currentGuests = await tx.guest.findMany({
           where: { tableId, deletedAt: null, NOT: { id: guestId } },
@@ -199,14 +207,19 @@ export async function assignGuestToTable(
           select: { plusOnesConfirmed: true, deletedAt: true },
         });
         if (!newGuest || newGuest.deletedAt) {
-          return { ok: false as const, error: "Convidado não encontrado" };
+          return { ok: false as const, error: t("guestNotFound") };
         }
 
         const seatsNeeded = 1 + (newGuest.plusOnesConfirmed ?? 0);
         if (seatsUsed + seatsNeeded > table.capacity) {
           return {
             ok: false as const,
-            error: `Mesa "${table.name}" não tem assentos suficientes (capacidade ${table.capacity}, ocupados ${seatsUsed}, necessário ${seatsNeeded})`,
+            error: t("tableFull", {
+              name: table.name,
+              capacity: table.capacity,
+              used: seatsUsed,
+              needed: seatsNeeded,
+            }),
           };
         }
       }
@@ -216,7 +229,7 @@ export async function assignGuestToTable(
         data: { tableId },
       });
       if (result.count === 0) {
-        return { ok: false as const, error: "Convidado não encontrado" };
+        return { ok: false as const, error: t("guestNotFound") };
       }
       return { ok: true as const };
     });
@@ -233,6 +246,6 @@ export async function assignGuestToTable(
     return { success: true };
   } catch (err) {
     console.error("[assignGuestToTable]", err);
-    return { success: false, error: "Erro ao alocar convidado" };
+    return { success: false, error: t("errorAssign") };
   }
 }

--- a/src/app/actions/securityActions.ts
+++ b/src/app/actions/securityActions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
@@ -17,14 +18,16 @@ import type { ActionResult } from "@/types";
 export async function startTwoFactorSetup(): Promise<
   ActionResult<{ secret: string; qrCodeSvg: string; otpauthUrl: string }>
 > {
+  const t = await getTranslations("actions.security");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
-  if (!session?.user?.email) return { success: false, error: "Não autorizado" };
+  if (!session?.user?.email) return { success: false, error: tc("unauthorized") };
   try {
     const setup = await createTotpSetup(session.user.email, "Wedding Finance");
     return { success: true, data: setup };
   } catch (err) {
     console.error("[startTwoFactorSetup]", err);
-    return { success: false, error: "Erro ao gerar configuração 2FA" };
+    return { success: false, error: t("errorGenerating") };
   }
 }
 
@@ -37,16 +40,18 @@ export async function confirmTwoFactor(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult<{ backupCodes: string[] }>> {
+  const t = await getTranslations("actions.security");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
   const userId = (session?.user as { id?: string } | undefined)?.id;
-  if (!userId) return { success: false, error: "Não autorizado" };
+  if (!userId) return { success: false, error: tc("unauthorized") };
 
   const parsed = ConfirmSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: "Código inválido" };
+    return { success: false, error: t("invalidCode") };
   }
   if (!verifyTotpToken(parsed.data.token, parsed.data.secret)) {
-    return { success: false, error: "Código TOTP inválido" };
+    return { success: false, error: t("invalidTotp") };
   }
 
   try {
@@ -65,7 +70,7 @@ export async function confirmTwoFactor(
     return { success: true, data: { backupCodes } };
   } catch (err) {
     console.error("[confirmTwoFactor]", err);
-    return { success: false, error: "Erro ao ativar 2FA" };
+    return { success: false, error: t("errorEnabling") };
   }
 }
 
@@ -77,17 +82,19 @@ export async function disableTwoFactor(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.security");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
   const userId = (session?.user as { id?: string } | undefined)?.id;
-  if (!userId) return { success: false, error: "Não autorizado" };
+  if (!userId) return { success: false, error: tc("unauthorized") };
 
   const parsed = DisableSchema.safeParse(Object.fromEntries(formData.entries()));
-  if (!parsed.success) return { success: false, error: "Código obrigatório" };
+  if (!parsed.success) return { success: false, error: t("codeRequired") };
 
   try {
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user || !user.twoFactorEnabled || !user.twoFactorSecret) {
-      return { success: false, error: "2FA não está ativo" };
+      return { success: false, error: t("notActive") };
     }
 
     const isTotp = verifyTotpToken(parsed.data.token, user.twoFactorSecret);
@@ -98,7 +105,7 @@ export async function disableTwoFactor(
       isBackup = check.valid;
       remaining = check.remaining;
     }
-    if (!isTotp && !isBackup) return { success: false, error: "Código inválido" };
+    if (!isTotp && !isBackup) return { success: false, error: t("invalidCode") };
 
     await prisma.user.update({
       where: { id: userId },
@@ -113,7 +120,7 @@ export async function disableTwoFactor(
     return { success: true };
   } catch (err) {
     console.error("[disableTwoFactor]", err);
-    return { success: false, error: "Erro ao desativar 2FA" };
+    return { success: false, error: t("errorDisabling") };
   }
 }
 

--- a/src/app/actions/settingsActions.ts
+++ b/src/app/actions/settingsActions.ts
@@ -2,9 +2,11 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { updateEventConfig } from "@/lib/event-config";
 import { audit } from "@/lib/audit";
 import { denyIfNoManage } from "@/lib/finance-access";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -36,12 +38,13 @@ export async function updateSettings(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.settings");
   const denied = await denyIfNoManage();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = SettingsSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   try {
@@ -59,7 +62,7 @@ export async function updateSettings(
     return { success: true };
   } catch (err) {
     console.error("[updateSettings]", err);
-    return { success: false, error: "Erro ao salvar configurações" };
+    return { success: false, error: t("errorSaving") };
   }
 }
 
@@ -67,12 +70,13 @@ export async function updatePixSettings(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.settings");
   const denied = await denyIfNoManage();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = PixSettingsSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     await updateEventConfig({
@@ -87,6 +91,6 @@ export async function updatePixSettings(
     return { success: true };
   } catch (err) {
     console.error("[updatePixSettings]", err);
-    return { success: false, error: "Erro ao salvar configurações Pix" };
+    return { success: false, error: t("errorSavingPix") };
   }
 }

--- a/src/app/actions/taskActions.ts
+++ b/src/app/actions/taskActions.ts
@@ -2,11 +2,13 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { getEventConfig } from "@/lib/event-config";
 import { TASK_TEMPLATES, templateDeadline } from "@/lib/task-templates";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const TaskStatusSchema = z.enum(["TODO", "IN_PROGRESS", "DONE", "BLOCKED"]);
@@ -43,10 +45,11 @@ export async function createTask(
 ): Promise<ActionResult> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
+  const t = await getTranslations("actions.task");
   const data = Object.fromEntries(formData.entries());
   const parsed = TaskCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const created = await prisma.task.create({
@@ -67,7 +70,7 @@ export async function createTask(
     return { success: true, data: { id: created.id } } as ActionResult<{ id: string }>;
   } catch (err) {
     console.error("[createTask]", err);
-    return { success: false, error: "Erro ao criar tarefa" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -77,16 +80,17 @@ export async function updateTask(
 ): Promise<ActionResult> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
+  const t = await getTranslations("actions.task");
   const data = Object.fromEntries(formData.entries());
   const parsed = TaskUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const existing = await prisma.task.findFirst({
       where: { id: parsed.data.id, deletedAt: null },
     });
-    if (!existing) return { success: false, error: "Tarefa não encontrada" };
+    if (!existing) return { success: false, error: t("notFound") };
 
     const completedAt =
       parsed.data.status === "DONE" ? existing.completedAt ?? new Date() : null;
@@ -110,7 +114,7 @@ export async function updateTask(
     return { success: true };
   } catch (err) {
     console.error("[updateTask]", err);
-    return { success: false, error: "Erro ao atualizar tarefa" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
@@ -120,6 +124,7 @@ export async function setTaskStatus(
 ): Promise<ActionResult> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
+  const t = await getTranslations("actions.task");
   try {
     const result = await prisma.task.updateMany({
       where: { id: taskId, deletedAt: null },
@@ -128,43 +133,45 @@ export async function setTaskStatus(
         completedAt: status === "DONE" ? new Date() : null,
       },
     });
-    if (result.count === 0) return { success: false, error: "Tarefa não encontrada" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await audit("Task", taskId, "STATUS_CHANGE", { status });
     revalidatePath("/dashboard/tasks");
     return { success: true };
   } catch (err) {
     console.error("[setTaskStatus]", err);
-    return { success: false, error: "Erro ao atualizar status" };
+    return { success: false, error: t("errorStatus") };
   }
 }
 
 export async function deleteTask(taskId: string): Promise<ActionResult> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
+  const t = await getTranslations("actions.task");
   try {
     const result = await prisma.task.updateMany({
       where: { id: taskId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Tarefa não encontrada" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     await audit("Task", taskId, "DELETE");
     revalidatePath("/dashboard/tasks");
     return { success: true };
   } catch (err) {
     console.error("[deleteTask]", err);
-    return { success: false, error: "Erro ao excluir tarefa" };
+    return { success: false, error: t("errorDelete") };
   }
 }
 
 export async function loadTaskTemplates(skipExisting = true): Promise<ActionResult<{ created: number }>> {
   const denied = await denyIfNoEdit();
   if (denied) return denied;
+  const t = await getTranslations("actions.task");
   try {
     const cfg = await getEventConfig();
     if (!cfg.eventDate) {
       return {
         success: false,
-        error: "Configure a data do evento em Ajustes para usar os templates.",
+        error: t("eventDateRequired"),
       };
     }
     const eventDate = cfg.eventDate;
@@ -199,6 +206,6 @@ export async function loadTaskTemplates(skipExisting = true): Promise<ActionResu
     return { success: true, data: { created: result.count } };
   } catch (err) {
     console.error("[loadTaskTemplates]", err);
-    return { success: false, error: "Erro ao carregar template" };
+    return { success: false, error: t("errorTemplates") };
   }
 }

--- a/src/app/actions/trousseauActions.ts
+++ b/src/app/actions/trousseauActions.ts
@@ -2,9 +2,11 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { denyIfNoEdit } from "@/lib/finance-access";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -38,11 +40,12 @@ export async function createTrousseauItem(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.trousseau");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const parsed = CreateSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     await prisma.trousseauItem.create({
@@ -62,7 +65,7 @@ export async function createTrousseauItem(
     return { success: true };
   } catch (err) {
     console.error("[createTrousseauItem]", err);
-    return { success: false, error: "Erro ao adicionar" };
+    return { success: false, error: t("errorAdding") };
   }
 }
 
@@ -70,11 +73,12 @@ export async function updateTrousseauItem(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.trousseau");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const parsed = UpdateSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const result = await prisma.trousseauItem.updateMany({
@@ -91,12 +95,12 @@ export async function updateTrousseauItem(
         notes: parsed.data.notes,
       },
     });
-    if (result.count === 0) return { success: false, error: "Item não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath("/dashboard/trousseau");
     return { success: true };
   } catch (err) {
     console.error("[updateTrousseauItem]", err);
-    return { success: false, error: "Erro ao atualizar" };
+    return { success: false, error: t("errorUpdating") };
   }
 }
 
@@ -104,6 +108,7 @@ export async function setTrousseauStatus(
   id: string,
   status: "TO_BUY" | "BOUGHT" | "GIFTED",
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.trousseau");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -111,16 +116,17 @@ export async function setTrousseauStatus(
       where: { id, deletedAt: null },
       data: { status },
     });
-    if (result.count === 0) return { success: false, error: "Item não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath("/dashboard/trousseau");
     return { success: true };
   } catch (err) {
     console.error("[setTrousseauStatus]", err);
-    return { success: false, error: "Erro ao atualizar status" };
+    return { success: false, error: t("errorUpdatingStatus") };
   }
 }
 
 export async function deleteTrousseauItem(id: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.trousseau");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -128,11 +134,11 @@ export async function deleteTrousseauItem(id: string): Promise<ActionResult> {
       where: { id, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Item não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath("/dashboard/trousseau");
     return { success: true };
   } catch (err) {
     console.error("[deleteTrousseauItem]", err);
-    return { success: false, error: "Erro ao excluir" };
+    return { success: false, error: t("errorDeleting") };
   }
 }

--- a/src/app/actions/userActions.ts
+++ b/src/app/actions/userActions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
@@ -10,6 +11,7 @@ import { ROLES, canManageUsers, type Role } from "@/lib/permissions";
 import { getSecuritySettings, setSecuritySettings } from "@/lib/security-settings";
 import { notify } from "@/lib/notifications";
 import { coerceLocale } from "@/i18n/config";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 function buildLoginUrl(): string {
@@ -23,30 +25,29 @@ const PhoneSchema = z
   .trim()
   .transform((v) => (v.length === 0 ? null : v))
   .nullable()
-  .refine(
-    (v) => v === null || /^\+\d{10,15}$/.test(v),
-    "Telefone deve estar no formato +5511999999999",
-  );
+  .refine((v) => v === null || /^\+\d{10,15}$/.test(v));
 
 async function requireManager(): Promise<
   | { ok: true; me: { id: string; email: string; role: string } }
   | { ok: false; error: string }
 > {
+  const t = await getTranslations("actions.user");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
   const email = session?.user?.email;
   const id = (session?.user as { id?: string } | undefined)?.id;
   const role = (session?.user as { role?: string } | undefined)?.role;
-  if (!email || !id) return { ok: false, error: "Não autorizado" };
-  if (!canManageUsers(role)) return { ok: false, error: "Sem permissão" };
+  if (!email || !id) return { ok: false, error: tc("unauthorized") };
+  if (!canManageUsers(role)) return { ok: false, error: t("noPermission") };
 
   const fresh = await prisma.user.findUnique({
     where: { id },
     select: { id: true, email: true, role: true, isActive: true, archivedAt: true },
   });
   if (!fresh || !fresh.isActive || fresh.archivedAt) {
-    return { ok: false, error: "Sessão inválida" };
+    return { ok: false, error: t("invalidSession") };
   }
-  if (!canManageUsers(fresh.role)) return { ok: false, error: "Sem permissão" };
+  if (!canManageUsers(fresh.role)) return { ok: false, error: t("noPermission") };
   return { ok: true, me: { id: fresh.id, email: fresh.email, role: fresh.role } };
 }
 
@@ -54,15 +55,17 @@ async function requireSession(): Promise<
   | { ok: true; me: { id: string; email: string; role: string } }
   | { ok: false; error: string }
 > {
+  const t = await getTranslations("actions.user");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
   const id = (session?.user as { id?: string } | undefined)?.id;
-  if (!id) return { ok: false, error: "Não autorizado" };
+  if (!id) return { ok: false, error: tc("unauthorized") };
   const fresh = await prisma.user.findUnique({
     where: { id },
     select: { id: true, email: true, role: true, isActive: true, archivedAt: true },
   });
   if (!fresh || !fresh.isActive || fresh.archivedAt) {
-    return { ok: false, error: "Sessão inválida" };
+    return { ok: false, error: t("invalidSession") };
   }
   return { ok: true, me: { id: fresh.id, email: fresh.email, role: fresh.role } };
 }
@@ -83,23 +86,29 @@ function emailSchema() {
     .string()
     .trim()
     .toLowerCase()
-    .email("Email inválido")
+    .email()
     .max(160);
 }
 
-async function passwordSchema() {
+async function passwordPolicy() {
   const settings = await getSecuritySettings();
-  const min = settings.passwordMinLength;
-  return z
-    .string()
-    .min(min, `Senha deve ter ao menos ${min} caracteres`)
-    .max(128, "Senha muito longa");
+  return settings.passwordMinLength;
+}
+
+function validatePassword(
+  password: string,
+  min: number,
+  t: Awaited<ReturnType<typeof getTranslations>>,
+): string | null {
+  if (password.length < min) return t("passwordTooShort", { min });
+  if (password.length > 128) return t("passwordTooLong");
+  return null;
 }
 
 const RoleSchema = z.enum(ROLES);
 
 const CreateSchema = z.object({
-  name: z.string().trim().min(1, "Nome obrigatório").max(120),
+  name: z.string().trim().min(1).max(120),
   email: emailSchema(),
   phone: PhoneSchema.optional(),
   password: z.string().min(6).max(128),
@@ -110,22 +119,23 @@ export async function createUser(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult<{ id: string }>> {
+  const t = await getTranslations("actions.user");
   const guard = await requireManager();
   if (!guard.ok) return { success: false, error: guard.error };
 
   const parsed = CreateSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
-  const pwSchema = await passwordSchema();
-  const pwCheck = pwSchema.safeParse(parsed.data.password);
-  if (!pwCheck.success) {
-    return { success: false, error: pwCheck.error.issues[0]?.message ?? "Senha inválida" };
+  const min = await passwordPolicy();
+  const pwError = validatePassword(parsed.data.password, min, t);
+  if (pwError) {
+    return { success: false, error: pwError };
   }
 
   try {
     const existing = await prisma.user.findUnique({ where: { email: parsed.data.email } });
-    if (existing) return { success: false, error: "Já existe um usuário com este email" };
+    if (existing) return { success: false, error: t("emailTaken") };
 
     const hashed = await bcrypt.hash(parsed.data.password, 10);
     const created = await prisma.user.create({
@@ -163,7 +173,7 @@ export async function createUser(
     return { success: true, data: { id: created.id } };
   } catch (err) {
     console.error("[createUser]", err);
-    return { success: false, error: "Erro ao criar usuário" };
+    return { success: false, error: t("errorCreating") };
   }
 }
 
@@ -188,12 +198,13 @@ export async function updateUser(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.user");
   const guard = await requireManager();
   if (!guard.ok) return { success: false, error: guard.error };
 
   const parsed = UpdateSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   const { id, name, email, phone, role, isActive } = parsed.data;
 
@@ -202,28 +213,28 @@ export async function updateUser(
       where: { id },
       select: { id: true, email: true, role: true, isActive: true, archivedAt: true },
     });
-    if (!target || target.archivedAt) return { success: false, error: "Usuário não encontrado" };
+    if (!target || target.archivedAt) return { success: false, error: t("notFound") };
 
     if (id === guard.me.id) {
       if (role && role !== guard.me.role) {
-        return { success: false, error: "Você não pode alterar sua própria função" };
+        return { success: false, error: t("cannotChangeOwnRole") };
       }
       if (isActive === false) {
-        return { success: false, error: "Você não pode desativar a si mesmo" };
+        return { success: false, error: t("cannotDeactivateSelf") };
       }
     }
 
     if (target.role === "ADMIN" && (role && role !== "ADMIN" || isActive === false)) {
       const others = await countActiveAdmins(target.id);
       if (others < 1) {
-        return { success: false, error: "Mantenha pelo menos um administrador ativo" };
+        return { success: false, error: t("keepOneAdmin") };
       }
     }
 
     if (email && email !== target.email) {
       const owner = await prisma.user.findUnique({ where: { email }, select: { id: true } });
       if (owner && owner.id !== target.id) {
-        return { success: false, error: "Já existe um usuário com este email" };
+        return { success: false, error: t("emailTaken") };
       }
     }
 
@@ -241,10 +252,10 @@ export async function updateUser(
     return { success: true };
   } catch (err) {
     if (typeof err === "object" && err !== null && (err as { code?: string }).code === "P2002") {
-      return { success: false, error: "Já existe um usuário com este email" };
+      return { success: false, error: t("emailTaken") };
     }
     console.error("[updateUser]", err);
-    return { success: false, error: "Erro ao atualizar usuário" };
+    return { success: false, error: t("errorUpdating") };
   }
 }
 
@@ -257,22 +268,23 @@ export async function resetUserPassword(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.user");
   const guard = await requireManager();
   if (!guard.ok) return { success: false, error: guard.error };
 
   const parsed = ResetPasswordSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
-  const pwSchema = await passwordSchema();
-  const pwCheck = pwSchema.safeParse(parsed.data.newPassword);
-  if (!pwCheck.success) {
-    return { success: false, error: pwCheck.error.issues[0]?.message ?? "Senha inválida" };
+  const min = await passwordPolicy();
+  const pwError = validatePassword(parsed.data.newPassword, min, t);
+  if (pwError) {
+    return { success: false, error: pwError };
   }
 
   try {
     const target = await prisma.user.findUnique({ where: { id: parsed.data.id } });
-    if (!target) return { success: false, error: "Usuário não encontrado" };
+    if (!target) return { success: false, error: t("notFound") };
 
     const hashed = await bcrypt.hash(parsed.data.newPassword, 10);
     await prisma.user.update({
@@ -300,20 +312,21 @@ export async function resetUserPassword(
     return { success: true };
   } catch (err) {
     console.error("[resetUserPassword]", err);
-    return { success: false, error: "Erro ao redefinir senha" };
+    return { success: false, error: t("errorResettingPassword") };
   }
 }
 
 export async function resetUserTwoFactor(targetId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.user");
   const guard = await requireManager();
   if (!guard.ok) return { success: false, error: guard.error };
   if (!targetId || typeof targetId !== "string") {
-    return { success: false, error: "ID inválido" };
+    return { success: false, error: t("invalidId") };
   }
 
   try {
     const target = await prisma.user.findUnique({ where: { id: targetId } });
-    if (!target) return { success: false, error: "Usuário não encontrado" };
+    if (!target) return { success: false, error: t("notFound") };
 
     await prisma.user.update({
       where: { id: target.id },
@@ -329,26 +342,27 @@ export async function resetUserTwoFactor(targetId: string): Promise<ActionResult
     return { success: true };
   } catch (err) {
     console.error("[resetUserTwoFactor]", err);
-    return { success: false, error: "Erro ao redefinir 2FA" };
+    return { success: false, error: t("errorResetting2FA") };
   }
 }
 
 export async function archiveUser(targetId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.user");
   const guard = await requireManager();
   if (!guard.ok) return { success: false, error: guard.error };
 
   try {
     if (targetId === guard.me.id) {
-      return { success: false, error: "Você não pode arquivar a si mesmo" };
+      return { success: false, error: t("cannotArchiveSelf") };
     }
     const target = await prisma.user.findUnique({ where: { id: targetId } });
     if (!target || target.archivedAt) {
-      return { success: false, error: "Usuário não encontrado" };
+      return { success: false, error: t("notFound") };
     }
     if (target.role === "ADMIN") {
       const others = await countActiveAdmins(target.id);
       if (others < 1) {
-        return { success: false, error: "Mantenha pelo menos um administrador ativo" };
+        return { success: false, error: t("keepOneAdmin") };
       }
     }
     await prisma.user.update({
@@ -360,17 +374,18 @@ export async function archiveUser(targetId: string): Promise<ActionResult> {
     return { success: true };
   } catch (err) {
     console.error("[archiveUser]", err);
-    return { success: false, error: "Erro ao arquivar usuário" };
+    return { success: false, error: t("errorArchiving") };
   }
 }
 
 export async function restoreUser(targetId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.user");
   const guard = await requireManager();
   if (!guard.ok) return { success: false, error: guard.error };
 
   try {
     const target = await prisma.user.findUnique({ where: { id: targetId } });
-    if (!target) return { success: false, error: "Usuário não encontrado" };
+    if (!target) return { success: false, error: t("notFound") };
     await prisma.user.update({
       where: { id: target.id },
       data: { archivedAt: null, isActive: true },
@@ -380,7 +395,7 @@ export async function restoreUser(targetId: string): Promise<ActionResult> {
     return { success: true };
   } catch (err) {
     console.error("[restoreUser]", err);
-    return { success: false, error: "Erro ao restaurar usuário" };
+    return { success: false, error: t("errorRestoring") };
   }
 }
 
@@ -393,27 +408,28 @@ export async function changeOwnPassword(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.user");
   const guard = await requireSession();
   if (!guard.ok) return { success: false, error: guard.error };
 
   const parsed = ChangeOwnSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
-  const pwSchema = await passwordSchema();
-  const pwCheck = pwSchema.safeParse(parsed.data.newPassword);
-  if (!pwCheck.success) {
-    return { success: false, error: pwCheck.error.issues[0]?.message ?? "Senha inválida" };
+  const min = await passwordPolicy();
+  const pwError = validatePassword(parsed.data.newPassword, min, t);
+  if (pwError) {
+    return { success: false, error: pwError };
   }
   if (parsed.data.currentPassword === parsed.data.newPassword) {
-    return { success: false, error: "A nova senha deve ser diferente da atual" };
+    return { success: false, error: t("newPasswordMustDiffer") };
   }
 
   try {
     const user = await prisma.user.findUnique({ where: { id: guard.me.id } });
-    if (!user) return { success: false, error: "Usuário não encontrado" };
+    if (!user) return { success: false, error: t("notFound") };
     const ok = await bcrypt.compare(parsed.data.currentPassword, user.password);
-    if (!ok) return { success: false, error: "Senha atual incorreta" };
+    if (!ok) return { success: false, error: t("wrongCurrentPassword") };
 
     const hashed = await bcrypt.hash(parsed.data.newPassword, 10);
     await prisma.user.update({
@@ -430,24 +446,25 @@ export async function changeOwnPassword(
     return { success: true };
   } catch (err) {
     console.error("[changeOwnPassword]", err);
-    return { success: false, error: "Erro ao trocar senha" };
+    return { success: false, error: t("errorChangingPassword") };
   }
 }
 
 const UpdateOwnProfileSchema = z.object({
-  name: z.string().trim().min(1, "Nome obrigatório").max(120),
+  name: z.string().trim().min(1).max(120),
 });
 
 export async function updateOwnProfile(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.user");
   const guard = await requireSession();
   if (!guard.ok) return { success: false, error: guard.error };
 
   const parsed = UpdateOwnProfileSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   try {
@@ -460,7 +477,7 @@ export async function updateOwnProfile(
     return { success: true };
   } catch (err) {
     console.error("[updateOwnProfile]", err);
-    return { success: false, error: "Erro ao atualizar perfil" };
+    return { success: false, error: t("errorUpdatingProfile") };
   }
 }
 
@@ -485,15 +502,16 @@ export async function updateSecuritySettings(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.user");
   const guard = await requireManager();
   if (!guard.ok) return { success: false, error: guard.error };
   if (guard.me.role !== "ADMIN") {
-    return { success: false, error: "Apenas administradores podem alterar política de segurança" };
+    return { success: false, error: t("securityPolicyAdminOnly") };
   }
 
   const parsed = SecuritySettingsSchema.safeParse(Object.fromEntries(formData.entries()));
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   try {
@@ -510,6 +528,6 @@ export async function updateSecuritySettings(
     return { success: true };
   } catch (err) {
     console.error("[updateSecuritySettings]", err);
-    return { success: false, error: "Erro ao salvar política de segurança" };
+    return { success: false, error: t("errorSavingSecurityPolicy") };
   }
 }

--- a/src/app/actions/vendorActions.ts
+++ b/src/app/actions/vendorActions.ts
@@ -2,10 +2,12 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoEdit } from "@/lib/finance-access";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const VendorCreateSchema = z.object({
@@ -54,12 +56,13 @@ export async function createVendor(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult<{ id: string }>> {
+  const t = await getTranslations("actions.vendor");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = VendorCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   try {
@@ -91,7 +94,7 @@ export async function createVendor(
     return { success: true, data: { id: vendor.id } };
   } catch (err) {
     console.error("[createVendor]", err);
-    return { success: false, error: "Erro ao criar fornecedor" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -99,12 +102,13 @@ export async function updateVendor(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.vendor");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = VendorUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
 
   try {
@@ -146,7 +150,7 @@ export async function updateVendor(
     return { success: true };
   } catch (err) {
     console.error("[updateVendor]", err);
-    return { success: false, error: "Erro ao atualizar fornecedor" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
@@ -155,6 +159,7 @@ export async function updateVendorStatus(
   status: "NEGOTIATION" | "CONTRACTED" | "FINALIZED",
   actualValue?: number,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.vendor");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -174,11 +179,12 @@ export async function updateVendorStatus(
     return { success: true };
   } catch (err) {
     console.error("[updateVendorStatus]", err);
-    return { success: false, error: "Erro ao atualizar status" };
+    return { success: false, error: t("errorStatus") };
   }
 }
 
 export async function deleteVendor(vendorId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.vendor");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -202,6 +208,6 @@ export async function deleteVendor(vendorId: string): Promise<ActionResult> {
     return { success: true };
   } catch (err) {
     console.error("[deleteVendor]", err);
-    return { success: false, error: "Erro ao excluir fornecedor" };
+    return { success: false, error: t("errorDelete") };
   }
 }

--- a/src/app/actions/vendorContactActions.ts
+++ b/src/app/actions/vendorContactActions.ts
@@ -2,9 +2,11 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const PhoneSchema = z
@@ -49,12 +51,13 @@ export async function createVendorContact(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.vendorContact");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = ContactCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const created = await prisma.$transaction(async (tx) => {
@@ -77,7 +80,7 @@ export async function createVendorContact(
     return { success: true };
   } catch (err) {
     console.error("[createVendorContact]", err);
-    return { success: false, error: "Erro ao adicionar contato" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -85,12 +88,13 @@ export async function updateVendorContact(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.vendorContact");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = ContactUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     await prisma.$transaction(async (tx) => {
@@ -112,11 +116,12 @@ export async function updateVendorContact(
     return { success: true };
   } catch (err) {
     console.error("[updateVendorContact]", err);
-    return { success: false, error: "Erro ao atualizar contato" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
 export async function deleteVendorContact(contactId: string, vendorId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.vendorContact");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -124,11 +129,11 @@ export async function deleteVendorContact(contactId: string, vendorId: string): 
       where: { id: contactId, vendorId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Contato não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath(`/dashboard/vendors/${vendorId}`);
     return { success: true };
   } catch (err) {
     console.error("[deleteVendorContact]", err);
-    return { success: false, error: "Erro ao excluir contato" };
+    return { success: false, error: t("errorDelete") };
   }
 }

--- a/src/app/actions/vendorNoteActions.ts
+++ b/src/app/actions/vendorNoteActions.ts
@@ -2,8 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const NoteSchema = z.object({
@@ -16,12 +18,13 @@ export async function createVendorNote(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.vendorNote");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = NoteSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     await prisma.vendorNote.create({
@@ -35,11 +38,12 @@ export async function createVendorNote(
     return { success: true };
   } catch (err) {
     console.error("[createVendorNote]", err);
-    return { success: false, error: "Erro ao adicionar nota" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
 export async function deleteVendorNote(noteId: string, vendorId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.vendorNote");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -47,11 +51,11 @@ export async function deleteVendorNote(noteId: string, vendorId: string): Promis
       where: { id: noteId, vendorId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Nota não encontrada" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath(`/dashboard/vendors/${vendorId}`);
     return { success: true };
   } catch (err) {
     console.error("[deleteVendorNote]", err);
-    return { success: false, error: "Erro ao excluir nota" };
+    return { success: false, error: t("errorDelete") };
   }
 }

--- a/src/app/actions/venueActions.ts
+++ b/src/app/actions/venueActions.ts
@@ -2,11 +2,13 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { audit } from "@/lib/audit";
 import { DEFAULT_VENUE_CHECKLIST } from "@/lib/venue-checklist";
 import { denyIfNoEdit } from "@/lib/finance-access";
 import { money } from "@/lib/validation";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const optStr = (max: number) =>
@@ -44,12 +46,13 @@ export async function createVenue(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult<{ id: string }>> {
+  const t = await getTranslations("actions.venue");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = VenueCreateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const created = await prisma.$transaction(async (tx) => {
@@ -91,7 +94,7 @@ export async function createVenue(
     return { success: true, data: { id: created.id } };
   } catch (err) {
     console.error("[createVenue]", err);
-    return { success: false, error: "Erro ao criar local" };
+    return { success: false, error: t("errorCreate") };
   }
 }
 
@@ -99,12 +102,13 @@ export async function updateVenue(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.venue");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = VenueUpdateSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const result = await prisma.venue.updateMany({
@@ -127,17 +131,18 @@ export async function updateVenue(
         notes: parsed.data.notes,
       },
     });
-    if (result.count === 0) return { success: false, error: "Local não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath(`/dashboard/venues/${parsed.data.id}`);
     revalidatePath("/dashboard/venues");
     return { success: true };
   } catch (err) {
     console.error("[updateVenue]", err);
-    return { success: false, error: "Erro ao atualizar local" };
+    return { success: false, error: t("errorUpdate") };
   }
 }
 
 export async function deleteVenue(venueId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.venue");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -145,12 +150,12 @@ export async function deleteVenue(venueId: string): Promise<ActionResult> {
       where: { id: venueId, deletedAt: null },
       data: { deletedAt: new Date() },
     });
-    if (result.count === 0) return { success: false, error: "Local não encontrado" };
+    if (result.count === 0) return { success: false, error: t("notFound") };
     revalidatePath("/dashboard/venues");
     return { success: true };
   } catch (err) {
     console.error("[deleteVenue]", err);
-    return { success: false, error: "Erro ao excluir local" };
+    return { success: false, error: t("errorDelete") };
   }
 }
 
@@ -163,12 +168,13 @@ export async function addChecklistItem(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.venue");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = ChecklistAddSchema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     const lastItem = await prisma.venueChecklistItem.findFirst({
@@ -183,7 +189,7 @@ export async function addChecklistItem(
     return { success: true };
   } catch (err) {
     console.error("[addChecklistItem]", err);
-    return { success: false, error: "Erro ao adicionar item" };
+    return { success: false, error: t("errorAddItem") };
   }
 }
 
@@ -192,6 +198,7 @@ export async function toggleChecklistItem(
   checked: boolean,
   value?: string,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.venue");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
@@ -203,21 +210,22 @@ export async function toggleChecklistItem(
     return { success: true };
   } catch (err) {
     console.error("[toggleChecklistItem]", err);
-    return { success: false, error: "Erro ao atualizar item" };
+    return { success: false, error: t("errorUpdateItem") };
   }
 }
 
 export async function deleteChecklistItem(itemId: string): Promise<ActionResult> {
+  const t = await getTranslations("actions.venue");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   try {
     const item = await prisma.venueChecklistItem.findUnique({ where: { id: itemId } });
-    if (!item) return { success: false, error: "Item não encontrado" };
+    if (!item) return { success: false, error: t("itemNotFound") };
     await prisma.venueChecklistItem.delete({ where: { id: itemId } });
     revalidatePath(`/dashboard/venues/${item.venueId}`);
     return { success: true };
   } catch (err) {
     console.error("[deleteChecklistItem]", err);
-    return { success: false, error: "Erro ao excluir item" };
+    return { success: false, error: t("errorDeleteItem") };
   }
 }

--- a/src/app/actions/weddingDayActions.ts
+++ b/src/app/actions/weddingDayActions.ts
@@ -2,8 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { denyIfNoEdit } from "@/lib/finance-access";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 const Schema = z.object({
@@ -31,12 +33,13 @@ export async function updateWeddingDay(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.weddingDay");
   const denied = await denyIfNoEdit();
   if (denied) return denied;
   const data = Object.fromEntries(formData.entries());
   const parsed = Schema.safeParse(data);
   if (!parsed.success) {
-    return { success: false, error: parsed.error.issues[0]?.message ?? "Dados inválidos" };
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
   try {
     await prisma.eventSettings.update({
@@ -51,6 +54,6 @@ export async function updateWeddingDay(
     return { success: true };
   } catch (err) {
     console.error("[updateWeddingDay]", err);
-    return { success: false, error: "Erro ao salvar" };
+    return { success: false, error: t("errorSaving") };
   }
 }

--- a/src/app/actions/whatsappActions.ts
+++ b/src/app/actions/whatsappActions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { z } from "zod";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { audit } from "@/lib/audit";
 import {
@@ -10,6 +11,7 @@ import {
   getWhatsAppStatus,
   sendWhatsApp,
 } from "@/lib/notifications/whatsapp";
+import { zodErrorMessage } from "@/lib/zod-i18n";
 import type { ActionResult } from "@/types";
 
 export type WhatsAppStatusPayload = {
@@ -26,11 +28,13 @@ async function requireAdmin(): Promise<
   | { ok: true; userId: string }
   | { ok: false; error: string }
 > {
+  const t = await getTranslations("actions.whatsapp");
+  const tc = await getTranslations("actions.common");
   const session = await auth();
   const userId = (session?.user as { id?: string } | undefined)?.id;
   const role = (session?.user as { role?: string } | undefined)?.role;
-  if (!userId) return { ok: false, error: "Não autorizado" };
-  if (role !== "ADMIN") return { ok: false, error: "Apenas administradores" };
+  if (!userId) return { ok: false, error: tc("unauthorized") };
+  if (role !== "ADMIN") return { ok: false, error: t("adminOnly") };
   return { ok: true, userId };
 }
 
@@ -101,6 +105,7 @@ export async function sendWhatsAppTest(
   _state: ActionResult | undefined,
   formData: FormData,
 ): Promise<ActionResult> {
+  const t = await getTranslations("actions.whatsapp");
   const guard = await requireAdmin();
   if (!guard.ok) return { success: false, error: guard.error };
 
@@ -108,14 +113,11 @@ export async function sendWhatsAppTest(
   if (!parsed.success) {
     return {
       success: false,
-      error: parsed.error.issues[0]?.message ?? "Telefone inválido",
+      error: zodErrorMessage(parsed.error, await getTranslations("common")),
     };
   }
 
-  const result = await sendWhatsApp(
-    parsed.data.phone,
-    "*Wedding Finance*\n\nMensagem de teste enviada com sucesso. Sua integração com WhatsApp está funcionando. ✅",
-  );
+  const result = await sendWhatsApp(parsed.data.phone, t("testMessageBody"));
 
   if (!result.ok) return { success: false, error: result.error };
   return { success: true };

--- a/src/app/dashboard/_components/funnel-card.tsx
+++ b/src/app/dashboard/_components/funnel-card.tsx
@@ -1,26 +1,28 @@
 import { Users2 } from "lucide-react";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 
 type Funnel = { NEGOTIATION: number; CONTRACTED: number; FINALIZED: number };
 
-export function FunnelCard({ funnel }: { funnel: Funnel }) {
+export async function FunnelCard({ funnel }: { funnel: Funnel }) {
+  const t = await getTranslations("dashboard.home");
   const total = funnel.NEGOTIATION + funnel.CONTRACTED + funnel.FINALIZED;
   if (total === 0) {
     return (
       <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-zinc-200">Funil de Fornecedores</h2>
+          <h2 className="text-sm font-semibold text-zinc-200">{t("funnel.title")}</h2>
           <Users2 className="h-4 w-4 text-zinc-500" />
         </div>
-        <p className="text-sm text-zinc-500">Nenhum fornecedor cadastrado.</p>
+        <p className="text-sm text-zinc-500">{t("funnel.empty")}</p>
       </div>
     );
   }
   const pct = (n: number) => (total === 0 ? 0 : (n / total) * 100);
   const segments = [
-    { key: "NEGOTIATION", label: "Negociando", value: funnel.NEGOTIATION, color: "bg-amber-500" },
-    { key: "CONTRACTED", label: "Contratados", value: funnel.CONTRACTED, color: "bg-violet-500" },
-    { key: "FINALIZED", label: "Finalizados", value: funnel.FINALIZED, color: "bg-emerald-500" },
+    { key: "NEGOTIATION", label: t("funnel.negotiating"), value: funnel.NEGOTIATION, color: "bg-amber-500" },
+    { key: "CONTRACTED", label: t("funnel.contracted"), value: funnel.CONTRACTED, color: "bg-violet-500" },
+    { key: "FINALIZED", label: t("funnel.finalized"), value: funnel.FINALIZED, color: "bg-emerald-500" },
   ];
   return (
     <Link
@@ -28,7 +30,7 @@ export function FunnelCard({ funnel }: { funnel: Funnel }) {
       className="block rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm transition-colors hover:bg-zinc-800/50"
     >
       <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-zinc-200">Funil de Fornecedores</h2>
+        <h2 className="text-sm font-semibold text-zinc-200">{t("funnel.title")}</h2>
         <Users2 className="h-4 w-4 text-zinc-500" />
       </div>
       <div className="flex h-3 w-full overflow-hidden rounded-full bg-zinc-800">

--- a/src/app/dashboard/_components/gifts-mini.tsx
+++ b/src/app/dashboard/_components/gifts-mini.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import { Gift } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { formatCurrency } from "@/lib/format";
 
-export function GiftsMini({
+export async function GiftsMini({
   totalCount,
   cashCount,
   cashTotal,
@@ -15,14 +16,15 @@ export function GiftsMini({
   thankedCount: number;
   thankedPct: number;
 }) {
+  const t = await getTranslations("dashboard.home");
   if (totalCount === 0) {
     return (
       <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-zinc-200">Presentes recebidos</h2>
+          <h2 className="text-sm font-semibold text-zinc-200">{t("gifts.title")}</h2>
           <Gift className="h-4 w-4 text-zinc-500" />
         </div>
-        <p className="text-sm text-zinc-500">Nenhum presente registrado ainda.</p>
+        <p className="text-sm text-zinc-500">{t("gifts.empty")}</p>
       </div>
     );
   }
@@ -32,14 +34,14 @@ export function GiftsMini({
       className="block rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm transition-colors hover:bg-zinc-800/50"
     >
       <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-zinc-200">Presentes recebidos</h2>
+        <h2 className="text-sm font-semibold text-zinc-200">{t("gifts.title")}</h2>
         <Gift className="h-4 w-4 text-zinc-500" />
       </div>
       <div className="flex items-end justify-between gap-3">
         <div className="min-w-0 flex-1">
           <p className="text-3xl font-bold text-zinc-100">{totalCount}</p>
           <p className="mt-1 break-words text-xs text-zinc-500">
-            {cashCount} em dinheiro · {totalCount - cashCount} em itens
+            {t("gifts.breakdown", { cash: cashCount, items: totalCount - cashCount })}
           </p>
         </div>
         <div className="shrink-0 text-right">
@@ -47,9 +49,9 @@ export function GiftsMini({
             <p className="text-sm font-semibold text-emerald-300">{formatCurrency(cashTotal)}</p>
           ) : null}
           <p className="mt-1 text-xs text-zinc-400">
-            Agradecidos: <span className="font-semibold text-zinc-100">{Math.round(thankedPct * 100)}%</span>
+            {t("gifts.thankedLabel")} <span className="font-semibold text-zinc-100">{Math.round(thankedPct * 100)}%</span>
           </p>
-          <p className="text-[10px] text-zinc-500">{thankedCount} de {totalCount}</p>
+          <p className="text-[10px] text-zinc-500">{t("gifts.thankedCount", { thanked: thankedCount, total: totalCount })}</p>
         </div>
       </div>
     </Link>

--- a/src/app/dashboard/_components/install-prompt.tsx
+++ b/src/app/dashboard/_components/install-prompt.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Download, Sparkles, X, Share } from "lucide-react";
 
 interface BeforeInstallPromptEvent extends Event {
@@ -17,6 +18,7 @@ interface NavigatorStandalone {
 }
 
 export function InstallPrompt() {
+  const t = useTranslations("dashboard.home");
   const [show, setShow] = useState(false);
   const [platform, setPlatform] = useState<"android" | "ios" | "other">("other");
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
@@ -98,7 +100,7 @@ export function InstallPrompt() {
         type="button"
         onClick={handleDismiss}
         className="absolute right-4 top-4 rounded-lg p-1 text-zinc-400 hover:bg-white/5 hover:text-zinc-200 transition-colors"
-        aria-label="Ignorar"
+        aria-label={t("install.dismiss")}
       >
         <X className="h-4 w-4" />
       </button>
@@ -109,31 +111,27 @@ export function InstallPrompt() {
         </div>
         <div className="min-w-0 flex-1">
           <h3 className="text-base font-semibold text-rose-100 font-serif flex items-center gap-1.5">
-            Instale como aplicativo <Sparkles className="h-4 w-4 text-rose-400 animate-pulse" />
+            {t("install.title")} <Sparkles className="h-4 w-4 text-rose-400 animate-pulse" />
           </h3>
 
           {platform === "ios" ? (
             <div className="mt-2 text-xs text-zinc-300 space-y-2">
-              <p>
-                Adicione o Wedding Finance Planner diretamente na tela de início do seu iPhone para uma experiência em tela cheia idêntica a um app nativo:
-              </p>
+              <p>{t("install.iosBody")}</p>
               <div className="inline-flex items-center gap-1 rounded-lg bg-zinc-950 px-2.5 py-1 text-zinc-200 border border-zinc-800/80">
-                <span>Toque em</span>
+                <span>{t("install.iosTap")}</span>
                 <Share className="h-3.5 w-3.5 mx-0.5 text-sky-400 inline" />
-                <span>Compartilhar &rarr; <strong>Adicionar à Tela de Início</strong></span>
+                <span>{t("install.iosShare")} &rarr; <strong>{t("install.iosAddToHome")}</strong></span>
               </div>
             </div>
           ) : (
             <div className="mt-2 text-xs text-zinc-300">
-              <p>
-                Adicione o aplicativo Wedding Finance Planner à sua tela de início para acompanhar suas finanças e tarefas de forma ágil, com acesso rápido e notificações.
-              </p>
+              <p>{t("install.androidBody")}</p>
               <button
                 type="button"
                 onClick={handleInstallClick}
                 className="mt-3 inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-xs font-bold text-white hover:bg-rose-500 transition-colors active:scale-[0.98]"
               >
-                Instalar Aplicativo
+                {t("install.installButton")}
               </button>
             </div>
           )}

--- a/src/app/dashboard/_components/risk-alert-strip.tsx
+++ b/src/app/dashboard/_components/risk-alert-strip.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { AlertCircle, AlertTriangle, ShieldCheck } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import type { RiskAlert } from "@/lib/reports/types";
 
 const SEVERITY_STYLES = {
@@ -23,7 +24,7 @@ const SEVERITY_STYLES = {
   },
 } as const;
 
-export function RiskAlertStrip({
+export async function RiskAlertStrip({
   risks,
   canSeeFinance,
 }: {
@@ -33,11 +34,13 @@ export function RiskAlertStrip({
   const visible = risks.filter((r) => (r.finance ? canSeeFinance : true));
   if (visible.length === 0) return null;
 
+  const t = await getTranslations("dashboard.home");
+
   return (
     <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4 shadow-sm">
       <div className="mb-3 flex items-center gap-2">
         <AlertTriangle className="h-4 w-4 text-amber-400" />
-        <h2 className="text-sm font-semibold text-zinc-200">Sinais de atenção</h2>
+        <h2 className="text-sm font-semibold text-zinc-200">{t("risks.title")}</h2>
         <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-[10px] text-zinc-300">
           {visible.length}
         </span>

--- a/src/app/dashboard/_components/rsvp-mini.tsx
+++ b/src/app/dashboard/_components/rsvp-mini.tsx
@@ -1,22 +1,24 @@
 import Link from "next/link";
 import { UserCheck } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 
-export function RsvpMini({
+export async function RsvpMini({
   rsvp,
   guestsTotal,
 }: {
   rsvp: { invited: number; confirmed: number; declined: number; maybe: number; plusOnesConfirmed: number };
   guestsTotal: number;
 }) {
+  const t = await getTranslations("dashboard.home");
   const total = rsvp.invited + rsvp.confirmed + rsvp.declined + rsvp.maybe;
   if (total === 0) {
     return (
       <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-zinc-200">Confirmações (RSVP)</h2>
+          <h2 className="text-sm font-semibold text-zinc-200">{t("rsvp.title")}</h2>
           <UserCheck className="h-4 w-4 text-zinc-500" />
         </div>
-        <p className="text-sm text-zinc-500">Nenhum convidado cadastrado ainda.</p>
+        <p className="text-sm text-zinc-500">{t("rsvp.empty")}</p>
       </div>
     );
   }
@@ -27,28 +29,28 @@ export function RsvpMini({
       className="block rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm transition-colors hover:bg-zinc-800/50"
     >
       <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-zinc-200">Confirmações (RSVP)</h2>
+        <h2 className="text-sm font-semibold text-zinc-200">{t("rsvp.title")}</h2>
         <UserCheck className="h-4 w-4 text-zinc-500" />
       </div>
       <div className="flex items-end justify-between gap-3">
         <div className="min-w-0 flex-1">
           <p className="text-3xl font-bold text-zinc-100">{confirmedPct}%</p>
           <p className="mt-1 break-words text-xs text-zinc-500">
-            {rsvp.confirmed} de {total} responderam confirmando
+            {t("rsvp.respondedConfirming", { confirmed: rsvp.confirmed, total })}
           </p>
         </div>
         <div className="grid shrink-0 grid-cols-1 gap-1 text-right text-xs">
-          <span className="text-emerald-400">{rsvp.confirmed} confirmados</span>
-          <span className="text-amber-400">{rsvp.maybe} talvez</span>
-          <span className="text-rose-400">{rsvp.declined} recusas</span>
-          <span className="text-zinc-500">{rsvp.invited} pendentes</span>
+          <span className="text-emerald-400">{t("rsvp.confirmed", { count: rsvp.confirmed })}</span>
+          <span className="text-amber-400">{t("rsvp.maybe", { count: rsvp.maybe })}</span>
+          <span className="text-rose-400">{t("rsvp.declined", { count: rsvp.declined })}</span>
+          <span className="text-zinc-500">{t("rsvp.pending", { count: rsvp.invited })}</span>
         </div>
       </div>
       {rsvp.plusOnesConfirmed > 0 ? (
-        <p className="mt-3 text-xs text-zinc-500">+{rsvp.plusOnesConfirmed} acompanhantes confirmados</p>
+        <p className="mt-3 text-xs text-zinc-500">{t("rsvp.plusOnes", { count: rsvp.plusOnesConfirmed })}</p>
       ) : null}
       {guestsTotal !== total ? (
-        <p className="mt-1 text-[10px] text-zinc-600">{guestsTotal} convidados no total</p>
+        <p className="mt-1 text-[10px] text-zinc-600">{t("rsvp.totalGuests", { count: guestsTotal })}</p>
       ) : null}
     </Link>
   );

--- a/src/app/dashboard/_components/upcoming-tasks.tsx
+++ b/src/app/dashboard/_components/upcoming-tasks.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ListTodo, Clock } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { formatDateBR } from "@/lib/format";
 
 const PRIORITY_STYLES: Record<string, string> = {
@@ -9,22 +10,30 @@ const PRIORITY_STYLES: Record<string, string> = {
   LOW: "bg-zinc-800 text-zinc-400 border-zinc-700",
 };
 
-export function UpcomingTasks({
+const PRIORITY_KEYS: Record<string, string> = {
+  URGENT: "urgent",
+  HIGH: "high",
+  MEDIUM: "medium",
+  LOW: "low",
+};
+
+export async function UpcomingTasks({
   tasks,
   compact,
 }: {
   tasks: Array<{ id: string; title: string; priority: string; deadline: Date | null }>;
   compact?: boolean;
 }) {
+  const tr = await getTranslations("dashboard.home");
   return (
     <div className={`rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm${compact ? " flex flex-col lg:max-h-[380px]" : ""}`}>
       <div className="mb-3 flex shrink-0 items-center justify-between">
-        <h2 className="text-sm font-semibold text-zinc-200">Próximas Tarefas</h2>
+        <h2 className="text-sm font-semibold text-zinc-200">{tr("upcomingTasks.title")}</h2>
         <ListTodo className="h-4 w-4 text-zinc-500" />
       </div>
       <div className={`custom-scrollbar space-y-3 overflow-y-auto pr-2${compact ? " min-h-0 flex-1" : " max-h-[300px]"}`}>
         {tasks.length === 0 ? (
-          <p className="text-sm text-zinc-500">Nenhuma tarefa pendente.</p>
+          <p className="text-sm text-zinc-500">{tr("upcomingTasks.empty")}</p>
         ) : (
           tasks.map((t) => (
             <Link
@@ -40,13 +49,13 @@ export function UpcomingTasks({
                     {formatDateBR(t.deadline)}
                   </p>
                 ) : (
-                  <p className="mt-1 text-xs text-zinc-600">Sem prazo</p>
+                  <p className="mt-1 text-xs text-zinc-600">{tr("upcomingTasks.noDeadline")}</p>
                 )}
               </div>
               <span
                 className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${PRIORITY_STYLES[t.priority] ?? PRIORITY_STYLES.MEDIUM}`}
               >
-                {t.priority}
+                {tr(`upcomingTasks.priority.${PRIORITY_KEYS[t.priority] ?? "medium"}`)}
               </span>
             </Link>
           ))

--- a/src/app/dashboard/assets/assets-client.tsx
+++ b/src/app/dashboard/assets/assets-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, Pencil, Plus, Search, Trash2 } from "lucide-react";
 import { createAsset, deleteAsset, updateAsset } from "@/app/actions/assetActions";
 import { useToast } from "@/components/toast";
@@ -15,6 +16,8 @@ type AssetRow = Asset & { goal: GoalRef | null };
 type Props = { assets: AssetRow[]; goals: GoalRef[] };
 
 export default function AssetsClient({ assets, goals }: Props) {
+  const t = useTranslations("dashboard.assets");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [isCreateOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<AssetRow | null>(null);
@@ -30,10 +33,10 @@ export default function AssetsClient({ assets, goals }: Props) {
       try {
         const r = await createAsset(undefined, formData);
         if (r.success) {
-          toast.success("Aporte registrado");
+          toast.success(t("toast.created"));
           setCreateOpen(false);
         } else {
-          toast.error("Falha", r.error);
+          toast.error(t("toast.failTitle"), r.error);
         }
       } finally {
         setCreating(false);
@@ -47,10 +50,10 @@ export default function AssetsClient({ assets, goals }: Props) {
       try {
         const r = await updateAsset(undefined, formData);
         if (r.success) {
-          toast.success("Aporte atualizado");
+          toast.success(t("toast.updated"));
           setEditing(null);
         } else {
-          toast.error("Falha", r.error);
+          toast.error(t("toast.failTitle"), r.error);
         }
       } finally {
         setUpdating(false);
@@ -77,10 +80,10 @@ export default function AssetsClient({ assets, goals }: Props) {
     startTransition(async () => {
       const r = await deleteAsset(target.id);
       if (r.success) {
-        toast.success("Aporte excluído");
+        toast.success(t("toast.deleted"));
         setDeleting(null);
       } else {
-        toast.error("Falha", r.error);
+        toast.error(t("toast.failTitle"), r.error);
       }
     });
   }
@@ -98,12 +101,12 @@ export default function AssetsClient({ assets, goals }: Props) {
                 setSearch(e.target.value);
                 setPage(1);
               }}
-              placeholder="Buscar aporte..."
+              placeholder={t("list.searchPlaceholder")}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-emerald-500/50"
             />
           </div>
           <span className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-300">
-            Total: {formatCurrency(total)}
+            {t("list.total", { value: formatCurrency(total) })}
           </span>
         </div>
         <button
@@ -111,7 +114,7 @@ export default function AssetsClient({ assets, goals }: Props) {
           className="flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-lg transition-colors hover:bg-emerald-500"
         >
           <Plus className="h-4 w-4" />
-          <span>Novo Aporte</span>
+          <span>{t("list.new")}</span>
         </button>
       </div>
 
@@ -120,17 +123,17 @@ export default function AssetsClient({ assets, goals }: Props) {
           <table className="w-full text-left text-sm text-zinc-400">
             <thead className="border-b border-zinc-800 bg-zinc-900/80 text-xs uppercase text-zinc-500">
               <tr>
-                <th className="px-6 py-4 font-medium">Data</th>
-                <th className="px-6 py-4 font-medium">Origem</th>
-                <th className="px-6 py-4 font-medium">Valor</th>
-                <th className="px-6 py-4 text-right font-medium">Ações</th>
+                <th className="px-6 py-4 font-medium">{t("table.date")}</th>
+                <th className="px-6 py-4 font-medium">{t("table.source")}</th>
+                <th className="px-6 py-4 font-medium">{t("table.amount")}</th>
+                <th className="px-6 py-4 text-right font-medium">{t("table.actions")}</th>
               </tr>
             </thead>
             <tbody>
               {filtered.length === 0 ? (
                 <tr>
                   <td colSpan={4} className="px-6 py-8 text-center text-zinc-500">
-                    {assets.length === 0 ? "Nenhum aporte registrado." : "Nenhum resultado para o filtro."}
+                    {assets.length === 0 ? t("list.empty") : t("list.noResults")}
                   </td>
                 </tr>
               ) : (
@@ -151,7 +154,7 @@ export default function AssetsClient({ assets, goals }: Props) {
                           type="button"
                           onClick={() => setEditing(asset)}
                           className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
-                          aria-label="Editar"
+                          aria-label={tc("actions.edit")}
                         >
                           <Pencil className="h-4 w-4" />
                         </button>
@@ -159,7 +162,7 @@ export default function AssetsClient({ assets, goals }: Props) {
                           type="button"
                           onClick={() => setDeleting(asset)}
                           className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-rose-500/10 hover:text-rose-400"
-                          aria-label="Excluir"
+                          aria-label={tc("actions.delete")}
                         >
                           <Trash2 className="h-4 w-4" />
                         </button>
@@ -198,9 +201,9 @@ export default function AssetsClient({ assets, goals }: Props) {
 
       <ConfirmDialog
         open={!!deleting}
-        title="Excluir aporte?"
+        title={t("delete.title")}
         description={deleting ? `${deleting.title} · ${formatCurrency(deleting.amount)}` : undefined}
-        confirmLabel="Excluir"
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
@@ -224,17 +227,19 @@ function AssetFormModal({
   formAction: (formData: FormData) => void;
   onClose: () => void;
 }) {
+  const t = useTranslations("dashboard.assets");
+  const tc = useTranslations("common");
   const todayIso = toIsoDate(new Date());
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 shadow-2xl">
         <form action={formAction} className="space-y-4 p-6">
-          <h2 className="text-xl font-bold text-white">{mode === "create" ? "Novo aporte" : "Editar aporte"}</h2>
+          <h2 className="text-xl font-bold text-white">{mode === "create" ? t("form.titleCreate") : t("form.titleEdit")}</h2>
 
           {asset ? <input type="hidden" name="id" value={asset.id} /> : null}
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Título / Origem</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.titleLabel")}</label>
             <input
               type="text"
               name="title"
@@ -242,13 +247,13 @@ function AssetFormModal({
               defaultValue={asset?.title ?? ""}
               maxLength={120}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-emerald-500/50"
-              placeholder="Ex: Salário de Março"
+              placeholder={t("form.titlePlaceholder")}
             />
           </div>
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Valor (R$)</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.amountLabel")}</label>
               <input
                 type="number"
                 step="0.01"
@@ -259,7 +264,7 @@ function AssetFormModal({
               />
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Data</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.dateLabel")}</label>
               <input
                 type="date"
                 name="date"
@@ -271,13 +276,13 @@ function AssetFormModal({
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Vincular a uma meta (opcional)</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.goalLabel")}</label>
             <select
               name="goalId"
               defaultValue={asset?.goalId ?? ""}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-emerald-500/50"
             >
-              <option value="">— sem meta —</option>
+              <option value="">{t("form.goalNone")}</option>
               {goals.map((g) => (
                 <option key={g.id} value={g.id}>
                   {g.name}
@@ -287,7 +292,7 @@ function AssetFormModal({
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.notesLabel")}</label>
             <textarea
               name="notes"
               rows={2}
@@ -303,14 +308,14 @@ function AssetFormModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-emerald-600 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/assets/page.tsx
+++ b/src/app/dashboard/assets/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { requireFinanceAccess } from "@/lib/finance-access";
 import AssetsClient from "./assets-client";
@@ -6,6 +7,7 @@ export const dynamic = "force-dynamic";
 
 export default async function AssetsPage() {
   await requireFinanceAccess();
+  const t = await getTranslations("dashboard.assets");
 
   const [assets, goals] = await Promise.all([
     prisma.asset.findMany({
@@ -23,7 +25,7 @@ export default async function AssetsPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight text-white">Caixa (Dinheiro Guardado)</h1>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
       </div>
       <AssetsClient assets={assets} goals={goals} />
     </div>

--- a/src/app/dashboard/charts.tsx
+++ b/src/app/dashboard/charts.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { useTranslations } from "next-intl";
 import { formatCurrency } from "@/lib/format";
 
 export type ChartDatum = {
@@ -22,10 +23,11 @@ const FALLBACK_COLORS = [
 ];
 
 export default function DashboardCharts({ data }: { data: ChartDatum[] }) {
+  const t = useTranslations("dashboard.home");
   if (!data || data.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-zinc-500">
-        Sem dados suficientes para o gráfico
+        {t("charts.noData")}
       </div>
     );
   }

--- a/src/app/dashboard/gifts/[id]/pix/page.tsx
+++ b/src/app/dashboard/gifts/[id]/pix/page.tsx
@@ -1,6 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import QRCode from "qrcode";
+import { getTranslations } from "next-intl/server";
 import { ArrowLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
@@ -23,6 +24,7 @@ export default async function GiftPixPage({
   if (!canEdit(role)) redirect("/dashboard");
 
   const { id } = await params;
+  const t = await getTranslations("dashboard.gifts");
   const gift = await prisma.gift.findFirst({
     where: { id },
   });
@@ -30,9 +32,9 @@ export default async function GiftPixPage({
 
   const cfg = await getEventConfig();
   const missingFields: string[] = [];
-  if (!cfg.pixKey) missingFields.push("chave Pix");
-  if (!cfg.pixHolderName) missingFields.push("nome do recebedor");
-  if (!cfg.pixCity) missingFields.push("cidade");
+  if (!cfg.pixKey) missingFields.push(t("pix.field.key"));
+  if (!cfg.pixHolderName) missingFields.push(t("pix.field.holder"));
+  if (!cfg.pixCity) missingFields.push(t("pix.field.city"));
 
   const amount = typeof gift.amount === "number" && gift.amount > 0 ? gift.amount : undefined;
 
@@ -52,7 +54,7 @@ export default async function GiftPixPage({
       qrDataUrl = await QRCode.toDataURL(brCode, { width: 360, margin: 1 });
     } catch (err) {
       console.error("[gift pix]", err);
-      pixError = err instanceof Error ? err.message : "Erro ao gerar QR Code";
+      pixError = err instanceof Error ? err.message : t("pix.errorGenerating");
     }
   }
 
@@ -64,9 +66,9 @@ export default async function GiftPixPage({
           className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800"
         >
           <ArrowLeft className="h-3.5 w-3.5" />
-          Voltar
+          {t("pix.back")}
         </Link>
-        <h1 className="text-xl font-semibold text-zinc-100">QR Code Pix</h1>
+        <h1 className="text-xl font-semibold text-zinc-100">{t("pix.title")}</h1>
       </header>
 
       <PixPanel

--- a/src/app/dashboard/gifts/[id]/pix/pix-panel.tsx
+++ b/src/app/dashboard/gifts/[id]/pix/pix-panel.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { Copy, CheckCircle2, Settings, AlertTriangle } from "lucide-react";
 import { useToast } from "@/components/toast";
 import { markGiftAsPixReceived } from "@/app/actions/giftActions";
@@ -27,6 +28,7 @@ export default function PixPanel({
   missingFields: string[];
   pixError: string | null;
 }) {
+  const t = useTranslations("dashboard.gifts");
   const router = useRouter();
   const toast = useToast();
   const [busy, setBusy] = useState(false);
@@ -36,8 +38,8 @@ export default function PixPanel({
   function copy() {
     if (!brCode) return;
     navigator.clipboard.writeText(brCode).then(
-      () => toast.success("Código copiado"),
-      () => toast.error("Erro", "Não foi possível copiar"),
+      () => toast.success(t("pix.toast.copied")),
+      () => toast.error(t("pix.toast.error"), t("pix.toast.copyFailed")),
     );
   }
 
@@ -46,10 +48,10 @@ export default function PixPanel({
     const res = await markGiftAsPixReceived(giftId, createAsset);
     setBusy(false);
     if (!res.success) {
-      toast.error("Erro", res.error);
+      toast.error(t("pix.toast.error"), res.error);
       return;
     }
-    toast.success("Pix marcado como recebido");
+    toast.success(t("pix.toast.marked"));
     startTransition(() => router.refresh());
   }
 
@@ -58,17 +60,17 @@ export default function PixPanel({
       <div className="rounded-2xl border border-amber-500/30 bg-amber-500/5 p-5">
         <div className="mb-3 flex items-center gap-2 text-amber-200">
           <AlertTriangle className="h-4 w-4" />
-          <h2 className="text-sm font-semibold">Configuração Pix incompleta</h2>
+          <h2 className="text-sm font-semibold">{t("pix.incomplete.title")}</h2>
         </div>
         <p className="mb-3 text-sm text-zinc-300">
-          Para gerar o QR Code, configure: <strong>{missingFields.join(", ")}</strong>.
+          {t("pix.incomplete.intro")} <strong>{missingFields.join(", ")}</strong>.
         </p>
         <Link
           href="/dashboard/settings"
           className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500"
         >
           <Settings className="h-4 w-4" />
-          Ir para Ajustes
+          {t("pix.incomplete.goToSettings")}
         </Link>
       </div>
     );
@@ -77,7 +79,7 @@ export default function PixPanel({
   if (pixError) {
     return (
       <div className="rounded-2xl border border-rose-500/30 bg-rose-500/5 p-5 text-sm text-rose-200">
-        Erro ao gerar Pix: {pixError}
+        {t("pix.errorPrefix")} {pixError}
       </div>
     );
   }
@@ -88,7 +90,7 @@ export default function PixPanel({
         {qrDataUrl ? (
           <Image
             src={qrDataUrl}
-            alt="QR Code Pix"
+            alt={t("pix.qrAlt")}
             width={300}
             height={300}
             className="mx-auto rounded-lg bg-white p-2"
@@ -99,27 +101,27 @@ export default function PixPanel({
 
       <div className="space-y-3">
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-          <h2 className="text-sm font-semibold text-zinc-100">Resumo</h2>
+          <h2 className="text-sm font-semibold text-zinc-100">{t("pix.summary.title")}</h2>
           <dl className="mt-2 space-y-1 text-sm">
-            <Row label="Presente">{giverName ?? `#${giftId.slice(0, 6)}`}</Row>
-            <Row label="Valor">
-              {formattedAmount ?? <span className="text-zinc-500">sem valor (livre)</span>}
+            <Row label={t("pix.summary.gift")}>{giverName ?? `#${giftId.slice(0, 6)}`}</Row>
+            <Row label={t("pix.summary.value")}>
+              {formattedAmount ?? <span className="text-zinc-500">{t("pix.summary.freeValue")}</span>}
             </Row>
-            <Row label="Status Pix">
+            <Row label={t("pix.summary.status")}>
               {pixPaidAt ? (
                 <span className="inline-flex items-center gap-1 text-emerald-300">
-                  <CheckCircle2 className="h-3.5 w-3.5" /> Recebido em{" "}
+                  <CheckCircle2 className="h-3.5 w-3.5" /> {t("pix.summary.receivedOn")}{" "}
                   {new Intl.DateTimeFormat("pt-BR", { dateStyle: "short" }).format(new Date(pixPaidAt))}
                 </span>
               ) : (
-                <span className="text-amber-300">Aguardando confirmação</span>
+                <span className="text-amber-300">{t("pix.summary.awaiting")}</span>
               )}
             </Row>
           </dl>
         </div>
 
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-          <h2 className="mb-2 text-sm font-semibold text-zinc-100">Pix copia e cola</h2>
+          <h2 className="mb-2 text-sm font-semibold text-zinc-100">{t("pix.copyPaste.title")}</h2>
           <textarea
             readOnly
             value={brCode ?? ""}
@@ -131,16 +133,14 @@ export default function PixPanel({
             className="mt-2 inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-3 py-2 text-sm text-zinc-200 hover:bg-zinc-800"
           >
             <Copy className="h-3.5 w-3.5" />
-            Copiar código
+            {t("pix.copyPaste.copyButton")}
           </button>
         </div>
 
         {!pixPaidAt ? (
           <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-            <h2 className="mb-2 text-sm font-semibold text-zinc-100">Confirmar recebimento</h2>
-            <p className="mb-3 text-xs text-zinc-400">
-              Após verificar o pagamento na sua conta, marque como recebido.
-            </p>
+            <h2 className="mb-2 text-sm font-semibold text-zinc-100">{t("pix.confirm.title")}</h2>
+            <p className="mb-3 text-xs text-zinc-400">{t("pix.confirm.hint")}</p>
             <label className="mb-3 flex items-center gap-2 text-xs text-zinc-300">
               <input
                 type="checkbox"
@@ -148,7 +148,7 @@ export default function PixPanel({
                 onChange={(e) => setCreateAsset(e.target.checked)}
                 className="h-4 w-4 rounded border-zinc-700 bg-zinc-800"
               />
-              Adicionar valor ao caixa (Asset)
+              {t("pix.confirm.addToAsset")}
             </label>
             <button
               type="button"
@@ -157,7 +157,7 @@ export default function PixPanel({
               className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-60"
             >
               <CheckCircle2 className="h-4 w-4" />
-              {busy ? "Salvando..." : "Marcar como recebido"}
+              {busy ? t("pix.confirm.saving") : t("pix.confirm.markReceived")}
             </button>
           </div>
         ) : null}

--- a/src/app/dashboard/gifts/gifts-client.tsx
+++ b/src/app/dashboard/gifts/gifts-client.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { CheckCircle2, Gift as GiftIcon, Heart, Loader2, Pencil, Plus, QrCode, Trash2 } from "lucide-react";
 import {
   createGift,
@@ -33,6 +34,8 @@ type GiftRow = {
 type GuestRef = { id: string; name: string };
 
 export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guests: GuestRef[] }) {
+  const t = useTranslations("dashboard.gifts");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<GiftRow | null>(null);
@@ -62,9 +65,9 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
       try {
         const r = await createGift(undefined, formData);
         if (r.success) {
-          toast.success("Presente registrado");
+          toast.success(t("toast.created"));
           setOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -76,9 +79,9 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
       try {
         const r = await updateGift(undefined, formData);
         if (r.success) {
-          toast.success("Presente atualizado");
+          toast.success(t("toast.updated"));
           setEditing(null);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setUpdatingBusy(false);
       }
@@ -87,8 +90,8 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
   function handleThanked(g: GiftRow) {
     startTransition(async () => {
       const r = await markGiftThanked(g.id, g.status !== "THANKED");
-      if (r.success) toast.success(g.status === "THANKED" ? "Desmarcado" : "Marcado como agradecido");
-      else toast.error("Falha", r.error);
+      if (r.success) toast.success(g.status === "THANKED" ? t("toast.unthanked") : t("toast.thanked"));
+      else toast.error(t("toast.failed"), r.error);
     });
   }
   function handleDelete() {
@@ -97,18 +100,18 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
     startTransition(async () => {
       const r = await deleteGift(id);
       if (r.success) {
-        toast.success("Presente removido");
+        toast.success(t("toast.removed"));
         setDeleting(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.failed"), r.error);
     });
   }
 
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <StatCard label="Total em dinheiro" value={formatCurrency(totals.cash)} accent="emerald" />
-        <StatCard label="Itens recebidos" value={String(totals.items)} />
-        <StatCard label="Aguardando agradecer" value={String(totals.pending)} accent="amber" />
+        <StatCard label={t("stats.cashTotal")} value={formatCurrency(totals.cash)} accent="emerald" />
+        <StatCard label={t("stats.itemsReceived")} value={String(totals.items)} />
+        <StatCard label={t("stats.pendingThank")} value={String(totals.pending)} accent="amber" />
       </div>
 
       <div className="flex items-center justify-between">
@@ -120,21 +123,21 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
           }}
           className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
         >
-          <option value="ALL">Todos</option>
-          <option value="PENDING_THANK">Aguardando agradecer</option>
+          <option value="ALL">{t("filter.all")}</option>
+          <option value="PENDING_THANK">{t("filter.pendingThank")}</option>
         </select>
         <button
           type="button"
           onClick={() => setOpen(true)}
           className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500"
         >
-          <Plus className="h-4 w-4" /> Novo presente
+          <Plus className="h-4 w-4" /> {t("actions.new")}
         </button>
       </div>
 
       {filtered.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/30 p-8 text-center text-sm text-zinc-500">
-          Nenhum presente registrado.
+          {t("list.empty")}
         </div>
       ) : (
         <ul className="space-y-2">
@@ -146,14 +149,14 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="font-medium text-zinc-100">
-                    {g.guest?.name ?? g.giverName ?? "Anônimo"}
+                    {g.guest?.name ?? g.giverName ?? t("anonymous")}
                   </span>
                   <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-[10px] uppercase tracking-wider text-zinc-400">
-                    {g.type === "CASH" ? "Dinheiro" : "Item"}
+                    {g.type === "CASH" ? t("type.cash") : t("type.item")}
                   </span>
                   {g.status === "THANKED" ? (
                     <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] text-emerald-300">
-                      <CheckCircle2 className="h-3 w-3" /> Agradecido
+                      <CheckCircle2 className="h-3 w-3" /> {t("badge.thanked")}
                     </span>
                   ) : null}
                 </div>
@@ -169,12 +172,12 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
                     <div className="flex items-center gap-1">
                       {g.isHoneymoonShare ? (
                         <span className="inline-flex items-center gap-1 rounded-full bg-rose-500/10 px-1.5 py-0.5 text-[10px] text-rose-300">
-                          <Heart className="h-2.5 w-2.5" /> lua de mel
+                          <Heart className="h-2.5 w-2.5" /> {t("badge.honeymoon")}
                         </span>
                       ) : null}
                       {g.pixPaidAt ? (
                         <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-emerald-300">
-                          Pix recebido
+                          {t("badge.pixReceived")}
                         </span>
                       ) : null}
                     </div>
@@ -184,8 +187,8 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
                   {g.type === "CASH" ? (
                     <Link
                       href={`/dashboard/gifts/${g.id}/pix`}
-                      aria-label="Gerar QR Pix"
-                      title="Gerar QR Pix"
+                      aria-label={t("actions.generatePix")}
+                      title={t("actions.generatePix")}
                       className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
                     >
                       <QrCode className="h-4 w-4" />
@@ -199,15 +202,15 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
                         ? "bg-emerald-500/10 text-emerald-300"
                         : "bg-zinc-800/70 text-zinc-300 hover:bg-zinc-700"
                     }`}
-                    aria-label="Alternar agradecimento"
-                    title={g.status === "THANKED" ? "Desmarcar agradecido" : "Marcar como agradecido"}
+                    aria-label={t("actions.toggleThank")}
+                    title={g.status === "THANKED" ? t("actions.unmarkThanked") : t("actions.markThanked")}
                   >
                     <CheckCircle2 className="h-4 w-4" />
                   </button>
                   <button
                     type="button"
                     onClick={() => setEditing(g)}
-                    aria-label="Editar"
+                    aria-label={tc("actions.edit")}
                     className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
                   >
                     <Pencil className="h-4 w-4" />
@@ -215,7 +218,7 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
                   <button
                     type="button"
                     onClick={() => setDeleting(g)}
-                    aria-label="Excluir"
+                    aria-label={tc("actions.delete")}
                     className="rounded-lg p-1.5 text-zinc-400 hover:bg-rose-500/10 hover:text-rose-400"
                   >
                     <Trash2 className="h-4 w-4" />
@@ -252,8 +255,9 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
 
       <ConfirmDialog
         open={!!deleting}
-        title="Excluir presente?"
-        confirmLabel="Excluir"
+        title={t("delete.title")}
+        confirmLabel={tc("actions.delete")}
+        cancelLabel={tc("actions.cancel")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
@@ -295,29 +299,31 @@ function GiftFormModal({
   onClose: () => void;
   formAction: (formData: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.gifts");
+  const tc = useTranslations("common");
   const [type, setType] = useState(gift?.type ?? "CASH");
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
         <h2 className="text-lg font-semibold text-white">
-          {mode === "create" ? "Novo presente" : "Editar presente"}
+          {mode === "create" ? t("form.titleCreate") : t("form.titleEdit")}
         </h2>
         <form action={formAction} className="mt-4 space-y-3">
           {gift ? <input type="hidden" name="id" value={gift.id} /> : null}
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Tipo</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.type")}</label>
             <select
               name="type"
               value={type}
               onChange={(e) => setType(e.target.value)}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
-              <option value="CASH">Dinheiro</option>
-              <option value="ITEM">Item</option>
+              <option value="CASH">{t("type.cash")}</option>
+              <option value="ITEM">{t("type.item")}</option>
             </select>
           </div>
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Convidado (opcional)</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.guest")}</label>
             <select
               name="guestId"
               defaultValue={gift?.guestId ?? ""}
@@ -331,19 +337,19 @@ function GiftFormModal({
               ))}
             </select>
           </div>
-          <Field name="giverName" label="Nome de quem deu (se não tiver convidado)" defaultValue={gift?.giverName ?? ""} />
+          <Field name="giverName" label={t("form.giverName")} defaultValue={gift?.giverName ?? ""} />
           {type === "CASH" ? (
-            <Field name="amount" label="Valor (R$)" type="number" step="0.01" defaultValue={gift?.amount?.toString() ?? ""} />
+            <Field name="amount" label={t("form.amount")} type="number" step="0.01" defaultValue={gift?.amount?.toString() ?? ""} />
           ) : (
             <Field
               name="description"
-              label="Descrição"
+              label={t("form.description")}
               defaultValue={gift?.description ?? ""}
             />
           )}
           <Field
             name="receivedAt"
-            label="Recebido em"
+            label={t("form.receivedAt")}
             type="date"
             defaultValue={gift ? toIsoDate(new Date(gift.receivedAt)) : toIsoDate(new Date())}
           />
@@ -355,11 +361,11 @@ function GiftFormModal({
                 defaultChecked={gift?.isHoneymoonShare ?? false}
                 className="h-4 w-4 rounded border-zinc-700 bg-zinc-800"
               />
-              Cota da lua de mel (mostrar QR Pix dedicado)
+              {t("form.honeymoonShare")}
             </label>
           ) : null}
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.notes")}</label>
             <textarea
               name="notes"
               rows={2}
@@ -374,14 +380,14 @@ function GiftFormModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/gifts/page.tsx
+++ b/src/app/dashboard/gifts/page.tsx
@@ -1,9 +1,11 @@
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import GiftsClient from "./gifts-client";
 
 export const dynamic = "force-dynamic";
 
 export default async function GiftsPage() {
+  const t = await getTranslations("dashboard.gifts");
   const [gifts, guests] = await Promise.all([
     prisma.gift.findMany({
       where: { deletedAt: null },
@@ -20,10 +22,8 @@ export default async function GiftsPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Presentes recebidos</h1>
-        <p className="text-sm text-zinc-500">
-          Registre o que recebeu (dinheiro ou item), de quem, e marque quando o agradecimento já foi enviado.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
       <GiftsClient gifts={gifts} guests={guests} />
     </div>

--- a/src/app/dashboard/goals/goals-client.tsx
+++ b/src/app/dashboard/goals/goals-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, Pencil, Plus, Target, Trash2 } from "lucide-react";
 import { createGoal, deleteGoal, updateGoal } from "@/app/actions/goalActions";
 import { useToast } from "@/components/toast";
@@ -20,6 +21,8 @@ type GoalRow = {
 };
 
 export default function GoalsClient({ goals }: { goals: GoalRow[] }) {
+  const t = useTranslations("dashboard.goals");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<GoalRow | null>(null);
@@ -34,9 +37,9 @@ export default function GoalsClient({ goals }: { goals: GoalRow[] }) {
       try {
         const r = await createGoal(undefined, formData);
         if (r.success) {
-          toast.success("Meta criada");
+          toast.success(t("toast.created"));
           setOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -49,9 +52,9 @@ export default function GoalsClient({ goals }: { goals: GoalRow[] }) {
       try {
         const r = await updateGoal(undefined, formData);
         if (r.success) {
-          toast.success("Meta atualizada");
+          toast.success(t("toast.updated"));
           setEditing(null);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setUpdatingBusy(false);
       }
@@ -64,9 +67,9 @@ export default function GoalsClient({ goals }: { goals: GoalRow[] }) {
     startTransition(async () => {
       const r = await deleteGoal(id);
       if (r.success) {
-        toast.success("Meta removida");
+        toast.success(t("toast.removed"));
         setDeleting(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.failed"), r.error);
     });
   }
 
@@ -78,13 +81,13 @@ export default function GoalsClient({ goals }: { goals: GoalRow[] }) {
           onClick={() => setOpen(true)}
           className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500"
         >
-          <Plus className="h-4 w-4" /> Nova meta
+          <Plus className="h-4 w-4" /> {t("list.new")}
         </button>
       </div>
 
       {goals.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/30 p-8 text-center text-sm text-zinc-500">
-          Nenhuma meta. Crie uma para acompanhar o progresso da poupança até a data alvo.
+          {t("list.empty")}
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -129,19 +132,21 @@ export default function GoalsClient({ goals }: { goals: GoalRow[] }) {
                         <h3 className="text-lg font-semibold text-zinc-100 font-serif leading-snug truncate">{g.name}</h3>
                         {!g.isActive ? (
                           <span className="rounded-full bg-zinc-800/80 px-2 py-0.5 text-[10px] text-zinc-400">
-                            inativa
+                            {t("card.inactive")}
                           </span>
                         ) : null}
                       </div>
                       {g.targetDate ? (
-                        <p className="mt-0.5 text-xs text-zinc-400">Alvo: {formatDateBR(g.targetDate)}</p>
+                        <p className="mt-0.5 text-xs text-zinc-400">
+                          {t("card.target", { date: formatDateBR(g.targetDate) })}
+                        </p>
                       ) : null}
                     </div>
                     <div className="flex gap-1">
                       <button
                         type="button"
                         onClick={() => setEditing(g)}
-                        aria-label="Editar"
+                        aria-label={tc("actions.edit")}
                         className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-100 transition-colors"
                       >
                         <Pencil className="h-4 w-4" />
@@ -149,7 +154,7 @@ export default function GoalsClient({ goals }: { goals: GoalRow[] }) {
                       <button
                         type="button"
                         onClick={() => setDeleting(g)}
-                        aria-label="Excluir"
+                        aria-label={tc("actions.delete")}
                         className="rounded-lg p-1.5 text-zinc-400 hover:bg-rose-500/10 hover:text-rose-400 transition-colors"
                       >
                         <Trash2 className="h-4 w-4" />
@@ -174,13 +179,13 @@ export default function GoalsClient({ goals }: { goals: GoalRow[] }) {
                         />
                       </div>
                       <div className="mt-1 flex items-center justify-between text-[11px] text-zinc-400">
-                        <span>{pct.toFixed(1)}% atingido</span>
-                        <span>{g.assetCount} aporte(s)</span>
+                        <span>{t("card.pctReached", { pct: pct.toFixed(1) })}</span>
+                        <span>{t("card.contributions", { count: g.assetCount })}</span>
                       </div>
                     </div>
                     <div className="grid grid-cols-2 gap-2 text-xs">
-                      <Mini label="Falta">{formatCurrency(remaining)}</Mini>
-                      <Mini label="Por mês">
+                      <Mini label={t("card.remaining")}>{formatCurrency(remaining)}</Mini>
+                      <Mini label={t("card.perMonth")}>
                         {monthlyNeed ? formatCurrency(monthlyNeed) : "—"}
                       </Mini>
                     </div>
@@ -207,9 +212,9 @@ export default function GoalsClient({ goals }: { goals: GoalRow[] }) {
 
       <ConfirmDialog
         open={!!deleting}
-        title="Excluir meta?"
-        description="Os aportes vinculados continuam existindo, mas perdem a vinculação."
-        confirmLabel="Excluir"
+        title={t("delete.title")}
+        description={t("delete.description")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
@@ -240,19 +245,21 @@ function GoalFormModal({
   onClose: () => void;
   formAction: (formData: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.goals");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
         <h2 className="text-lg font-semibold text-white">
-          {mode === "create" ? "Nova meta" : "Editar meta"}
+          {mode === "create" ? t("form.createTitle") : t("form.editTitle")}
         </h2>
         <form action={formAction} className="mt-4 space-y-3">
           {goal ? <input type="hidden" name="id" value={goal.id} /> : null}
-          <Field name="name" label="Nome" required defaultValue={goal?.name ?? ""} />
+          <Field name="name" label={t("form.name")} required defaultValue={goal?.name ?? ""} />
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Field
               name="targetAmount"
-              label="Valor alvo (R$)"
+              label={t("form.targetAmount")}
               type="number"
               step="0.01"
               required
@@ -260,15 +267,15 @@ function GoalFormModal({
             />
             <Field
               name="targetDate"
-              label="Data alvo"
+              label={t("form.targetDate")}
               type="date"
               defaultValue={goal?.targetDate ? toIsoDate(new Date(goal.targetDate)) : ""}
             />
           </div>
           <Field
             name="imageUrl"
-            label="URL da Imagem de Inspiração (Opcional)"
-            placeholder="https://exemplo.com/imagem.jpg"
+            label={t("form.imageUrl")}
+            placeholder={t("form.imageUrlPlaceholder")}
             defaultValue={goal?.imageUrl ?? ""}
             type="url"
           />
@@ -279,10 +286,10 @@ function GoalFormModal({
               defaultChecked={goal?.isActive ?? true}
               className="accent-rose-500"
             />
-            Meta ativa
+            {t("form.isActive")}
           </label>
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.notes")}</label>
             <textarea
               name="notes"
               rows={2}
@@ -297,14 +304,14 @@ function GoalFormModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/goals/page.tsx
+++ b/src/app/dashboard/goals/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { requireFinanceAccess } from "@/lib/finance-access";
 import GoalsClient from "./goals-client";
@@ -6,6 +7,7 @@ export const dynamic = "force-dynamic";
 
 export default async function GoalsPage() {
   await requireFinanceAccess();
+  const t = await getTranslations("dashboard.goals");
 
   const goals = await prisma.savingsGoal.findMany({
     where: { deletedAt: null },
@@ -31,10 +33,8 @@ export default async function GoalsPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Metas de poupança</h1>
-        <p className="text-sm text-zinc-500">
-          Defina quanto guardar até quando. Os aportes (caixa) podem ser vinculados a uma meta.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
       <GoalsClient goals={decorated} />
     </div>

--- a/src/app/dashboard/guests/groups/groups-client.tsx
+++ b/src/app/dashboard/guests/groups/groups-client.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { ArrowLeft, Plus, Link2, Trash2, Edit3, Users, CheckCircle2, X } from "lucide-react";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
@@ -39,6 +40,8 @@ export default function GroupsClient({
   allGuests: GuestRef[];
 }) {
   const router = useRouter();
+  const t = useTranslations("dashboard.guests.groups");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [groups, setGroups] = useState(initialGroups);
   const [guests, setGuests] = useState(allGuests);
@@ -63,8 +66,8 @@ export default function GroupsClient({
   function copyLink(token: string) {
     const url = `${window.location.origin}/rsvp/group/${token}`;
     navigator.clipboard.writeText(url).then(
-      () => toast.success("Link copiado", url),
-      () => toast.error("Erro", "Não foi possível copiar"),
+      () => toast.success(t("toast.linkCopied"), url),
+      () => toast.error(tc("common.errorGeneric"), t("toast.copyFailed")),
     );
   }
 
@@ -73,10 +76,10 @@ export default function GroupsClient({
     const res = await createGuestGroup(undefined, formData);
     setBusy(false);
     if (!res.success) {
-      toast.error("Erro", res.error);
+      toast.error(tc("common.errorGeneric"), res.error);
       return;
     }
-    toast.success("Grupo criado");
+    toast.success(t("toast.created"));
     setShowCreate(false);
     startTransition(() => router.refresh());
   }
@@ -88,10 +91,10 @@ export default function GroupsClient({
     const res = await updateGuestGroup(undefined, formData);
     setBusy(false);
     if (!res.success) {
-      toast.error("Erro", res.error);
+      toast.error(tc("common.errorGeneric"), res.error);
       return;
     }
-    toast.success("Grupo atualizado");
+    toast.success(t("toast.updated"));
     setEditing(null);
     startTransition(() => router.refresh());
   }
@@ -102,10 +105,10 @@ export default function GroupsClient({
     const res = await deleteGuestGroup(confirmDelete.id);
     setBusy(false);
     if (!res.success) {
-      toast.error("Erro", res.error);
+      toast.error(tc("common.errorGeneric"), res.error);
       return;
     }
-    toast.success("Grupo excluído");
+    toast.success(t("toast.deleted"));
     setConfirmDelete(null);
     startTransition(() => router.refresh());
   }
@@ -116,10 +119,10 @@ export default function GroupsClient({
     const res = await setGroupMembers({ groupId: managingMembersOf.id, guestIds });
     setBusy(false);
     if (!res.success) {
-      toast.error("Erro", res.error);
+      toast.error(tc("common.errorGeneric"), res.error);
       return;
     }
-    toast.success("Membros atualizados");
+    toast.success(t("toast.membersUpdated"));
     setManagingMembersOf(null);
     startTransition(() => router.refresh());
   }
@@ -130,14 +133,12 @@ export default function GroupsClient({
         href="/dashboard/guests"
         className="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-300"
       >
-        <ArrowLeft className="h-4 w-4" /> Voltar para convidados
+        <ArrowLeft className="h-4 w-4" /> {t("backToGuests")}
       </Link>
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="text-xl font-semibold text-zinc-100 md:text-2xl">Grupos / Famílias</h1>
-          <p className="text-sm text-zinc-400">
-            Crie grupos para gerar um único link de RSVP por família.
-          </p>
+          <h1 className="text-xl font-semibold text-zinc-100 md:text-2xl">{t("title")}</h1>
+          <p className="text-sm text-zinc-400">{t("subtitle")}</p>
         </div>
         <button
           type="button"
@@ -145,14 +146,14 @@ export default function GroupsClient({
           className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500"
         >
           <Plus className="h-4 w-4" />
-          Novo grupo
+          {t("newGroup")}
         </button>
       </header>
 
       {groups.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-zinc-700 p-8 text-center">
           <Users className="mx-auto mb-3 h-8 w-8 text-zinc-500" />
-          <p className="text-sm text-zinc-400">Nenhum grupo cadastrado.</p>
+          <p className="text-sm text-zinc-400">{t("empty")}</p>
         </div>
       ) : (
         <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -169,22 +170,22 @@ export default function GroupsClient({
                   <div className="min-w-0">
                     <h2 className="truncate text-base font-semibold text-zinc-100">{g.name}</h2>
                     {g.contactName ? (
-                      <p className="text-xs text-zinc-500">Contato: {g.contactName}</p>
+                      <p className="text-xs text-zinc-500">{t("card.contact", { name: g.contactName })}</p>
                     ) : null}
                   </div>
                   <span className="rounded bg-zinc-800 px-2 py-0.5 text-[10px] text-zinc-400">
-                    {g.guests.length} pessoas
+                    {t("card.people", { count: g.guests.length })}
                   </span>
                 </header>
                 <div className="mb-3 grid grid-cols-3 gap-1 text-center text-[10px]">
                   <span className="rounded bg-emerald-500/10 px-1.5 py-1 text-emerald-300">
-                    {confirmed} sim
+                    {t("card.yes", { count: confirmed })}
                   </span>
                   <span className="rounded bg-amber-500/10 px-1.5 py-1 text-amber-300">
-                    {pending} pendente
+                    {t("card.pending", { count: pending })}
                   </span>
                   <span className="rounded bg-rose-500/10 px-1.5 py-1 text-rose-300">
-                    {declined} não
+                    {t("card.no", { count: declined })}
                   </span>
                 </div>
                 <div className="flex flex-wrap gap-1.5">
@@ -194,7 +195,7 @@ export default function GroupsClient({
                     className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
                   >
                     <Link2 className="h-3.5 w-3.5" />
-                    Copiar link
+                    {t("card.copyLink")}
                   </button>
                   <button
                     type="button"
@@ -202,7 +203,7 @@ export default function GroupsClient({
                     className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
                   >
                     <Users className="h-3.5 w-3.5" />
-                    Membros
+                    {t("card.members")}
                   </button>
                   <button
                     type="button"
@@ -210,7 +211,7 @@ export default function GroupsClient({
                     className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
                   >
                     <Edit3 className="h-3.5 w-3.5" />
-                    Editar
+                    {tc("actions.edit")}
                   </button>
                   <button
                     type="button"
@@ -218,7 +219,7 @@ export default function GroupsClient({
                     className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-rose-300 hover:bg-rose-500/10"
                   >
                     <Trash2 className="h-3.5 w-3.5" />
-                    Excluir
+                    {tc("actions.delete")}
                   </button>
                 </div>
               </li>
@@ -229,7 +230,7 @@ export default function GroupsClient({
 
       {showCreate ? (
         <GroupForm
-          title="Novo grupo"
+          title={t("form.createTitle")}
           busy={busy}
           onCancel={() => setShowCreate(false)}
           onSubmit={handleCreate}
@@ -238,7 +239,7 @@ export default function GroupsClient({
 
       {editing ? (
         <GroupForm
-          title="Editar grupo"
+          title={t("form.editTitle")}
           initial={editing}
           busy={busy}
           onCancel={() => setEditing(null)}
@@ -258,15 +259,15 @@ export default function GroupsClient({
 
       <ConfirmDialog
         open={confirmDelete !== null}
-        title="Excluir grupo?"
+        title={t("delete.title")}
         description={
           confirmDelete
-            ? `O grupo "${confirmDelete.name}" será removido. Os convidados não serão excluídos.`
+            ? t("delete.description", { name: confirmDelete.name })
             : ""
         }
         tone="danger"
         busy={busy}
-        confirmLabel="Excluir"
+        confirmLabel={tc("actions.delete")}
         onConfirm={handleDelete}
         onCancel={() => setConfirmDelete(null)}
       />
@@ -287,6 +288,8 @@ function GroupForm({
   onCancel: () => void;
   onSubmit: (fd: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.guests.groups");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-[80] flex items-start justify-center overflow-y-auto bg-black/60 p-4 backdrop-blur-sm sm:items-center">
       <form
@@ -294,31 +297,31 @@ function GroupForm({
         className="my-4 w-full max-w-md space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900 p-5 shadow-2xl"
       >
         <h2 className="text-base font-semibold text-zinc-100">{title}</h2>
-        <FieldInput name="name" label="Nome do grupo" defaultValue={initial?.name} required maxLength={120} />
+        <FieldInput name="name" label={t("form.name")} defaultValue={initial?.name} required maxLength={120} />
         <FieldInput
           name="contactName"
-          label="Contato (opcional)"
+          label={t("form.contactName")}
           defaultValue={initial?.contactName ?? ""}
           maxLength={120}
         />
         <div className="grid grid-cols-2 gap-3">
           <FieldInput
             name="contactEmail"
-            label="Email"
+            label={t("form.email")}
             defaultValue={initial?.contactEmail ?? ""}
             type="email"
             maxLength={160}
           />
           <FieldInput
             name="contactPhone"
-            label="Telefone"
+            label={t("form.phone")}
             defaultValue={initial?.contactPhone ?? ""}
             maxLength={40}
           />
         </div>
         <FieldTextarea
           name="notes"
-          label="Observações"
+          label={t("form.notes")}
           defaultValue={initial?.notes ?? ""}
           rows={2}
           maxLength={500}
@@ -330,14 +333,14 @@ function GroupForm({
             disabled={busy}
             className="rounded-lg px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
           >
-            Cancelar
+            {tc("actions.cancel")}
           </button>
           <button
             type="submit"
             disabled={busy}
             className="rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-60"
           >
-            {busy ? "Salvando..." : "Salvar"}
+            {busy ? t("form.saving") : tc("actions.save")}
           </button>
         </div>
       </form>
@@ -358,6 +361,8 @@ function MembersDialog({
   onCancel: () => void;
   onSave: (ids: string[]) => void;
 }) {
+  const t = useTranslations("dashboard.guests.groups");
+  const tc = useTranslations("common");
   const [selected, setSelected] = useState<Set<string>>(
     new Set(group.guests.map((g) => g.id)),
   );
@@ -384,15 +389,13 @@ function MembersDialog({
       <div className="flex max-h-[calc(100dvh-2rem)] w-full max-w-lg flex-col rounded-2xl border border-zinc-800 bg-zinc-900 shadow-2xl">
         <header className="flex items-center justify-between border-b border-zinc-800 p-4">
           <div>
-            <h2 className="text-base font-semibold text-zinc-100">Membros de {group.name}</h2>
-            <p className="text-xs text-zinc-500">
-              Selecione os convidados que pertencem a este grupo.
-            </p>
+            <h2 className="text-base font-semibold text-zinc-100">{t("members.title", { name: group.name })}</h2>
+            <p className="text-xs text-zinc-500">{t("members.subtitle")}</p>
           </div>
           <button
             type="button"
             onClick={onCancel}
-            aria-label="Fechar"
+            aria-label={tc("actions.close")}
             className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-800"
           >
             <X className="h-4 w-4" />
@@ -403,13 +406,13 @@ function MembersDialog({
             type="search"
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
-            placeholder="Buscar convidado..."
+            placeholder={t("members.searchPlaceholder")}
             className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 focus:border-rose-500 focus:outline-none"
           />
         </div>
         <ul className="flex-1 overflow-y-auto p-2">
           {visible.length === 0 ? (
-            <p className="p-4 text-center text-sm text-zinc-500">Nenhum convidado disponível.</p>
+            <p className="p-4 text-center text-sm text-zinc-500">{t("members.noneAvailable")}</p>
           ) : (
             visible.map((g) => {
               const isSelected = selected.has(g.id);
@@ -437,7 +440,7 @@ function MembersDialog({
           )}
         </ul>
         <footer className="flex items-center justify-between border-t border-zinc-800 p-3">
-          <span className="text-xs text-zinc-500">{selected.size} selecionado(s)</span>
+          <span className="text-xs text-zinc-500">{t("members.selectedCount", { count: selected.size })}</span>
           <div className="flex gap-2">
             <button
               type="button"
@@ -445,7 +448,7 @@ function MembersDialog({
               disabled={busy}
               className="rounded-lg px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="button"
@@ -453,7 +456,7 @@ function MembersDialog({
               disabled={busy}
               className="rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-60"
             >
-              {busy ? "Salvando..." : "Salvar"}
+              {busy ? t("form.saving") : tc("actions.save")}
             </button>
           </div>
         </footer>

--- a/src/app/dashboard/guests/guests-client.tsx
+++ b/src/app/dashboard/guests/guests-client.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import {
   CheckCircle2,
   Copy,
@@ -46,12 +47,12 @@ type Guest = {
   notes: string | null;
 };
 
-const RSVP_LABEL: Record<string, string> = {
-  NOT_INVITED: "Não convidado",
-  INVITED: "Convidado",
-  CONFIRMED: "Confirmado",
-  DECLINED: "Recusou",
-  MAYBE: "Talvez",
+const RSVP_KEY: Record<string, string> = {
+  NOT_INVITED: "rsvp.notInvited",
+  INVITED: "rsvp.invited",
+  CONFIRMED: "rsvp.confirmed",
+  DECLINED: "rsvp.declined",
+  MAYBE: "rsvp.maybe",
 };
 
 const RSVP_CHIP: Record<string, string> = {
@@ -63,6 +64,10 @@ const RSVP_CHIP: Record<string, string> = {
 };
 
 export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; baseUrl: string }) {
+  const t = useTranslations("dashboard.guests");
+  const tc = useTranslations("common");
+  const rsvpLabel = (status: string) =>
+    RSVP_KEY[status] ? t(RSVP_KEY[status]) : status;
   const toast = useToast();
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<Guest | null>(null);
@@ -109,9 +114,9 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
       try {
         const r = await createGuest(undefined, formData);
         if (r.success) {
-          toast.success("Convidado criado");
+          toast.success(t("toast.created"));
           setOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(tc("common.errorGeneric"), r.error);
       } finally {
         setBusy(false);
       }
@@ -123,9 +128,9 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
       try {
         const r = await updateGuest(undefined, formData);
         if (r.success) {
-          toast.success("Convidado atualizado");
+          toast.success(t("toast.updated"));
           setEditing(null);
-        } else toast.error("Falha", r.error);
+        } else toast.error(tc("common.errorGeneric"), r.error);
       } finally {
         setUpdatingBusy(false);
       }
@@ -137,41 +142,41 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
     startTransition(async () => {
       const r = await deleteGuest(id);
       if (r.success) {
-        toast.success("Convidado removido");
+        toast.success(t("toast.removed"));
         setDeleting(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(tc("common.errorGeneric"), r.error);
     });
   }
   function handleCheckin(guest: Guest) {
     startTransition(async () => {
       const r = await toggleCheckin(guest.id, !guest.checkedInAt);
-      if (r.success) toast.success(guest.checkedInAt ? "Check-in revertido" : "Presença registrada");
-      else toast.error("Falha", r.error);
+      if (r.success) toast.success(guest.checkedInAt ? t("toast.checkinReverted") : t("toast.checkinDone"));
+      else toast.error(tc("common.errorGeneric"), r.error);
     });
   }
   function copyRsvp(guest: Guest) {
     const url = `${baseUrl}/rsvp/${guest.rsvpToken}`;
     navigator.clipboard.writeText(url).then(
-      () => toast.success("Link copiado"),
-      () => toast.error("Falha ao copiar"),
+      () => toast.success(t("toast.linkCopied")),
+      () => toast.error(t("toast.copyFailed")),
     );
   }
 
   function exportCsv() {
     const header = [
-      "Nome",
-      "Telefone",
-      "Email",
-      "Lado",
-      "Grupo",
-      "Status",
-      "+1 confirmados",
-      "Mesa",
-      "Restrições",
-      "Cidade",
-      "Padrinho",
-      "VIP",
-      "Criança",
+      t("csv.name"),
+      t("csv.phone"),
+      t("csv.email"),
+      t("csv.side"),
+      t("csv.group"),
+      t("csv.status"),
+      t("csv.plusOnesConfirmed"),
+      t("csv.table"),
+      t("csv.dietary"),
+      t("csv.city"),
+      t("csv.padrinho"),
+      t("csv.vip"),
+      t("csv.child"),
     ].join(",");
     const rows = filtered.map((g) =>
       [
@@ -180,14 +185,14 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
         g.email ?? "",
         g.side ?? "",
         g.groupName ?? "",
-        RSVP_LABEL[g.rsvpStatus] ?? g.rsvpStatus,
+        rsvpLabel(g.rsvpStatus),
         g.plusOnesConfirmed,
         g.tableNumber ?? "",
         g.dietary ?? "",
         g.city ?? "",
-        g.isPadrinho ? "sim" : "",
-        g.isVIP ? "sim" : "",
-        g.isChild ? "sim" : "",
+        g.isPadrinho ? t("csv.yes") : "",
+        g.isVIP ? t("csv.yes") : "",
+        g.isChild ? t("csv.yes") : "",
       ]
         .map((v) => `"${String(v).replace(/"/g, '""')}"`)
         .join(","),
@@ -196,7 +201,7 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `convidados-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.download = `${t("csv.fileName")}-${new Date().toISOString().slice(0, 10)}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   }
@@ -204,10 +209,15 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <StatTile label="Lista" value={stats.total} sub="convidados" />
-        <StatTile label="Confirmados" value={stats.confirmed} sub={`${stats.seats} cabeças`} accent="emerald" />
-        <StatTile label="Pendentes" value={stats.pending} accent="amber" />
-        <StatTile label="Recusaram" value={stats.declined} accent="rose" />
+        <StatTile label={t("stats.list")} value={stats.total} sub={t("stats.guests")} />
+        <StatTile
+          label={t("stats.confirmed")}
+          value={stats.confirmed}
+          sub={t("stats.heads", { count: stats.seats })}
+          accent="emerald"
+        />
+        <StatTile label={t("stats.pending")} value={stats.pending} accent="amber" />
+        <StatTile label={t("stats.declined")} value={stats.declined} accent="rose" />
       </div>
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -221,7 +231,7 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
                 setSearch(e.target.value);
                 setPage(1);
               }}
-              placeholder="Buscar..."
+              placeholder={t("filters.searchPlaceholder")}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
             />
           </div>
@@ -233,12 +243,12 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
             }}
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
           >
-            <option value="ALL">Todos</option>
-            <option value="CONFIRMED">Confirmados</option>
-            <option value="PENDING">Pendentes</option>
-            <option value="PADRINHOS">Padrinhos</option>
-            <option value="CHILDREN">Crianças</option>
-            <option value="CHECKED_IN">Já chegaram</option>
+            <option value="ALL">{t("filters.all")}</option>
+            <option value="CONFIRMED">{t("filters.confirmed")}</option>
+            <option value="PENDING">{t("filters.pending")}</option>
+            <option value="PADRINHOS">{t("filters.padrinhos")}</option>
+            <option value="CHILDREN">{t("filters.children")}</option>
+            <option value="CHECKED_IN">{t("filters.checkedIn")}</option>
           </select>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -246,27 +256,27 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
             href="/dashboard/guests/groups"
             className="inline-flex items-center gap-1.5 rounded-xl bg-zinc-800 px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-700"
           >
-            <Users className="h-4 w-4" /> Grupos
+            <Users className="h-4 w-4" /> {t("actions.groups")}
           </Link>
           <button
             type="button"
             onClick={exportCsv}
             className="inline-flex items-center gap-1.5 rounded-xl bg-zinc-800 px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-700"
           >
-            <Download className="h-4 w-4" /> CSV
+            <Download className="h-4 w-4" /> {t("actions.csv")}
           </button>
           <Link
             href="/dashboard/guests/import"
             className="inline-flex items-center gap-1.5 rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm font-medium text-rose-200 hover:bg-rose-500/20"
           >
-            <Upload className="h-4 w-4" /> Importar lista
+            <Upload className="h-4 w-4" /> {t("actions.importList")}
           </Link>
           <button
             type="button"
             onClick={() => setOpen(true)}
             className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-lg hover:bg-rose-500"
           >
-            <Plus className="h-4 w-4" /> Novo convidado
+            <Plus className="h-4 w-4" /> {t("actions.newGuest")}
           </button>
         </div>
       </div>
@@ -276,20 +286,20 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
           <table className="w-full text-left text-sm text-zinc-400">
             <thead className="border-b border-zinc-800 bg-zinc-900/80 text-xs uppercase text-zinc-500">
               <tr>
-                <th className="px-4 py-3 font-medium">Nome</th>
-                <th className="px-4 py-3 font-medium">Grupo</th>
-                <th className="px-4 py-3 font-medium">RSVP</th>
-                <th className="px-4 py-3 font-medium">+1</th>
-                <th className="px-4 py-3 font-medium">Mesa</th>
-                <th className="px-4 py-3 font-medium">Presença</th>
-                <th className="px-4 py-3 text-right font-medium">Ações</th>
+                <th className="px-4 py-3 font-medium">{t("table.name")}</th>
+                <th className="px-4 py-3 font-medium">{t("table.group")}</th>
+                <th className="px-4 py-3 font-medium">{t("table.rsvp")}</th>
+                <th className="px-4 py-3 font-medium">{t("table.plusOne")}</th>
+                <th className="px-4 py-3 font-medium">{t("table.table")}</th>
+                <th className="px-4 py-3 font-medium">{t("table.attendance")}</th>
+                <th className="px-4 py-3 text-right font-medium">{t("table.actions")}</th>
               </tr>
             </thead>
             <tbody>
               {filtered.length === 0 ? (
                 <tr>
                   <td colSpan={7} className="px-4 py-8 text-center text-zinc-500">
-                    {guests.length === 0 ? "Lista vazia." : "Nenhum resultado."}
+                    {guests.length === 0 ? t("table.empty") : t("table.noResults")}
                   </td>
                 </tr>
               ) : (
@@ -298,9 +308,9 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
                     <td className="px-4 py-3">
                       <div className="flex flex-wrap items-center gap-1 font-medium text-zinc-200">
                         <span>{g.name}</span>
-                        {g.isPadrinho ? <Tag>P</Tag> : null}
-                        {g.isChild ? <Tag>Criança</Tag> : null}
-                        {g.isVIP ? <Tag>VIP</Tag> : null}
+                        {g.isPadrinho ? <Tag>{t("tags.padrinhoShort")}</Tag> : null}
+                        {g.isChild ? <Tag>{t("tags.child")}</Tag> : null}
+                        {g.isVIP ? <Tag>{t("tags.vip")}</Tag> : null}
                       </div>
                       <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-0.5 text-[11px] text-zinc-500">
                         {g.phone ? <span>{g.phone}</span> : null}
@@ -321,7 +331,7 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
                           RSVP_CHIP[g.rsvpStatus] ?? RSVP_CHIP.INVITED
                         }`}
                       >
-                        {RSVP_LABEL[g.rsvpStatus] ?? g.rsvpStatus}
+                        {rsvpLabel(g.rsvpStatus)}
                       </span>
                     </td>
                     <td className="px-4 py-3 text-xs">
@@ -340,10 +350,10 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
                       >
                         {g.checkedInAt ? (
                           <>
-                            <CheckCircle2 className="h-3 w-3" /> Chegou
+                            <CheckCircle2 className="h-3 w-3" /> {t("attendance.arrived")}
                           </>
                         ) : (
-                          "Marcar"
+                          t("attendance.mark")
                         )}
                       </button>
                     </td>
@@ -352,7 +362,7 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
                         <button
                           type="button"
                           onClick={() => copyRsvp(g)}
-                          aria-label="Copiar link RSVP"
+                          aria-label={t("rowActions.copyRsvp")}
                           className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
                         >
                           <Copy className="h-4 w-4" />
@@ -360,7 +370,7 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
                         <button
                           type="button"
                           onClick={() => setEditing(g)}
-                          aria-label="Editar"
+                          aria-label={tc("actions.edit")}
                           className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
                         >
                           <Pencil className="h-4 w-4" />
@@ -368,7 +378,7 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
                         <button
                           type="button"
                           onClick={() => setDeleting(g)}
-                          aria-label="Excluir"
+                          aria-label={tc("actions.delete")}
                           className="rounded-lg p-1.5 text-zinc-400 hover:bg-rose-500/10 hover:text-rose-400"
                         >
                           <Trash2 className="h-4 w-4" />
@@ -407,8 +417,8 @@ export default function GuestsClient({ guests, baseUrl }: { guests: Guest[]; bas
 
       <ConfirmDialog
         open={!!deleting}
-        title={deleting ? `Excluir ${deleting.name}?` : "Excluir?"}
-        confirmLabel="Excluir"
+        title={deleting ? t("delete.confirmTitle", { name: deleting.name }) : t("delete.confirmTitleGeneric")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
@@ -460,62 +470,64 @@ function GuestFormModal({
   onClose: () => void;
   formAction: (formData: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.guests");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-2xl rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
         <h2 className="text-lg font-semibold text-white">
-          {mode === "create" ? "Novo convidado" : `Editar ${guest?.name ?? ""}`}
+          {mode === "create" ? t("form.createTitle") : t("form.editTitle", { name: guest?.name ?? "" })}
         </h2>
         <form action={formAction} className="mt-4 grid gap-3 sm:grid-cols-2">
           {guest ? <input type="hidden" name="id" value={guest.id} /> : null}
-          <Field name="name" label="Nome" required defaultValue={guest?.name ?? ""} />
-          <Field name="phone" label="Telefone" defaultValue={guest?.phone ?? ""} />
-          <Field name="email" label="Email" type="email" defaultValue={guest?.email ?? ""} />
+          <Field name="name" label={t("form.name")} required defaultValue={guest?.name ?? ""} />
+          <Field name="phone" label={t("form.phone")} defaultValue={guest?.phone ?? ""} />
+          <Field name="email" label={t("form.email")} type="email" defaultValue={guest?.email ?? ""} />
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Lado</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.side")}</label>
             <select
               name="side"
               defaultValue={guest?.side ?? ""}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
               <option value="">—</option>
-              <option value="NOIVO">Noivo</option>
-              <option value="NOIVA">Noiva</option>
-              <option value="AMBOS">Ambos</option>
+              <option value="NOIVO">{t("side.groom")}</option>
+              <option value="NOIVA">{t("side.bride")}</option>
+              <option value="AMBOS">{t("side.both")}</option>
             </select>
           </div>
-          <Field name="groupName" label="Grupo (ex: família dele)" defaultValue={guest?.groupName ?? ""} />
-          <Field name="city" label="Cidade" defaultValue={guest?.city ?? ""} />
+          <Field name="groupName" label={t("form.groupName")} defaultValue={guest?.groupName ?? ""} />
+          <Field name="city" label={t("form.city")} defaultValue={guest?.city ?? ""} />
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Status RSVP</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.rsvpStatus")}</label>
             <select
               name="rsvpStatus"
               defaultValue={guest?.rsvpStatus ?? "INVITED"}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
-              <option value="NOT_INVITED">Não convidado</option>
-              <option value="INVITED">Convidado</option>
-              <option value="CONFIRMED">Confirmado</option>
-              <option value="DECLINED">Recusou</option>
-              <option value="MAYBE">Talvez</option>
+              <option value="NOT_INVITED">{t("rsvp.notInvited")}</option>
+              <option value="INVITED">{t("rsvp.invited")}</option>
+              <option value="CONFIRMED">{t("rsvp.confirmed")}</option>
+              <option value="DECLINED">{t("rsvp.declined")}</option>
+              <option value="MAYBE">{t("rsvp.maybe")}</option>
             </select>
           </div>
           <Field
             name="plusOnesAllowed"
-            label="Acompanhantes permitidos"
+            label={t("form.plusOnesAllowed")}
             type="number"
             defaultValue={guest?.plusOnesAllowed?.toString() ?? "0"}
           />
-          <Field name="tableNumber" label="Mesa / setor" defaultValue={guest?.tableNumber ?? ""} />
-          <Field name="dietary" label="Restrições alimentares" defaultValue={guest?.dietary ?? ""} />
+          <Field name="tableNumber" label={t("form.tableNumber")} defaultValue={guest?.tableNumber ?? ""} />
+          <Field name="dietary" label={t("form.dietary")} defaultValue={guest?.dietary ?? ""} />
           <div className="flex flex-col gap-2 sm:col-span-2">
             <label className="flex items-center gap-2 text-sm text-zinc-300">
               <input type="checkbox" name="isChild" defaultChecked={guest?.isChild} className="accent-rose-500" />
-              Criança
+              {t("form.isChild")}
             </label>
             <label className="flex items-center gap-2 text-sm text-zinc-300">
               <input type="checkbox" name="isVIP" defaultChecked={guest?.isVIP} className="accent-rose-500" />
-              VIP
+              {t("form.isVIP")}
             </label>
             <label className="flex items-center gap-2 text-sm text-zinc-300">
               <input
@@ -524,11 +536,11 @@ function GuestFormModal({
                 defaultChecked={guest?.isPadrinho}
                 className="accent-rose-500"
               />
-              Padrinho / madrinha
+              {t("form.isPadrinho")}
             </label>
           </div>
           <div className="sm:col-span-2">
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.notes")}</label>
             <textarea
               name="notes"
               rows={2}
@@ -543,14 +555,14 @@ function GuestFormModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/guests/import/_components/paste-modal.tsx
+++ b/src/app/dashboard/guests/import/_components/paste-modal.tsx
@@ -2,11 +2,14 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { ChevronDown, Loader2, X } from "lucide-react";
 import { useToast } from "@/components/toast";
 import { bulkImportGuests } from "@/app/actions/guestActions";
 
 export function PasteImportModal({ onClose }: { onClose: () => void }) {
+  const t = useTranslations("dashboard.guests.import.paste");
+  const tc = useTranslations("common");
   const toast = useToast();
   const router = useRouter();
   const [busy, setBusy] = useState(false);
@@ -20,16 +23,16 @@ export function PasteImportModal({ onClose }: { onClose: () => void }) {
         if (r.success && r.data) {
           const groupsMsg =
             r.data.groupsCreated > 0
-              ? `, ${r.data.groupsCreated} grupo(s) criado(s)`
+              ? t("toast.groupsSuffix", { count: r.data.groupsCreated })
               : "";
           toast.success(
-            `${r.data.created} importados`,
-            `${r.data.skipped} linhas puladas${groupsMsg}`,
+            t("toast.importedTitle", { count: r.data.created }),
+            `${t("toast.skippedLines", { count: r.data.skipped })}${groupsMsg}`,
           );
           onClose();
           router.refresh();
         } else if (!r.success) {
-          toast.error("Falha", r.error);
+          toast.error(tc("common.errorGeneric"), r.error);
         }
       } finally {
         setBusy(false);
@@ -41,46 +44,44 @@ export function PasteImportModal({ onClose }: { onClose: () => void }) {
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/60 p-4 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-2xl rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-white">Colar texto bruto</h2>
+          <h2 className="text-lg font-semibold text-white">{t("title")}</h2>
           <button
             type="button"
             onClick={onClose}
             className="rounded-lg p-1 text-zinc-300 hover:bg-zinc-800"
-            aria-label="Fechar"
+            aria-label={tc("actions.close")}
           >
             <X className="h-5 w-5" />
           </button>
         </div>
         <p className="mt-2 text-sm text-zinc-400">
-          Cole linhas no formato{" "}
-          <code className="rounded bg-zinc-800 px-1">Nome,Telefone,Email,Lado,Grupo</code>{" "}
-          (uma linha por convidado). Telefone, email, lado e grupo são opcionais. Lado aceita
-          NOIVO/NOIVA/AMBOS. Quando a coluna <strong>Grupo</strong> for preenchida, grupos novos
-          são criados automaticamente (e os existentes reaproveitados, comparando pelo nome) —
-          convidados da mesma família passam a compartilhar um único link de RSVP.
+          {t.rich("instructions", {
+            code: (chunks) => <code className="rounded bg-zinc-800 px-1">{chunks}</code>,
+            strong: (chunks) => <strong>{chunks}</strong>,
+          })}
         </p>
         <form action={handleSubmit} className="mt-4 space-y-3">
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Conteúdo</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("contentLabel")}</label>
             <textarea
               name="raw"
               required
               rows={10}
-              placeholder={`Maria Silva,+5511999990000,maria@example.com,NOIVA,Família\nJoão Souza\nAna,,ana@example.com,,Trabalho dele`}
+              placeholder={t("placeholder")}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
             />
           </div>
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Separador</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("separatorLabel")}</label>
             <select
               name="separator"
               defaultValue="AUTO"
               className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
-              <option value="AUTO">Detectar automaticamente</option>
-              <option value="COMMA">, (vírgula)</option>
-              <option value="SEMICOLON">; (ponto-vírgula)</option>
-              <option value="TAB">Tab</option>
+              <option value="AUTO">{t("sepAuto")}</option>
+              <option value="COMMA">{t("sepComma")}</option>
+              <option value="SEMICOLON">{t("sepSemicolon")}</option>
+              <option value="TAB">{t("sepTab")}</option>
             </select>
           </div>
           <div className="flex gap-2 pt-2">
@@ -89,7 +90,7 @@ export function PasteImportModal({ onClose }: { onClose: () => void }) {
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
@@ -101,7 +102,7 @@ export function PasteImportModal({ onClose }: { onClose: () => void }) {
               ) : (
                 <ChevronDown className="h-4 w-4 rotate-90" />
               )}
-              Importar
+              {t("submit")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/guests/import/_components/preview-table.tsx
+++ b/src/app/dashboard/guests/import/_components/preview-table.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { ClassifiedRow } from "@/app/actions/guestActions";
 
-const STATUS_LABEL: Record<ClassifiedRow["classification"], string> = {
-  new: "Novo",
-  duplicate_same: "Já existe (mesmo grupo)",
-  duplicate_diff: "Já existe, dados divergem",
+const STATUS_KEY: Record<ClassifiedRow["classification"], string> = {
+  new: "table.statusNew",
+  duplicate_same: "table.statusDuplicateSame",
+  duplicate_diff: "table.statusDuplicateDiff",
 };
 
 const STATUS_CHIP: Record<ClassifiedRow["classification"], string> = {
@@ -14,12 +15,12 @@ const STATUS_CHIP: Record<ClassifiedRow["classification"], string> = {
   duplicate_diff: "bg-amber-500/10 text-amber-300 border-amber-500/20",
 };
 
-const RSVP_LABEL: Record<string, string> = {
-  NOT_INVITED: "Não convidado",
-  INVITED: "Convidado",
-  CONFIRMED: "Confirmado",
-  DECLINED: "Recusou",
-  MAYBE: "Talvez",
+const RSVP_KEY: Record<string, string> = {
+  NOT_INVITED: "rsvp.notInvited",
+  INVITED: "rsvp.invited",
+  CONFIRMED: "rsvp.confirmed",
+  DECLINED: "rsvp.declined",
+  MAYBE: "rsvp.maybe",
 };
 
 export function PreviewTable({
@@ -29,12 +30,15 @@ export function PreviewTable({
   rows: ClassifiedRow[];
   filter: "all" | ClassifiedRow["classification"];
 }) {
+  const t = useTranslations("dashboard.guests.import");
+  const tg = useTranslations("dashboard.guests");
+  const rsvpLabel = (status: string) => (RSVP_KEY[status] ? tg(RSVP_KEY[status]) : status);
   const visible = filter === "all" ? rows : rows.filter((r) => r.classification === filter);
 
   if (visible.length === 0) {
     return (
       <p className="rounded-xl bg-zinc-950 px-3 py-6 text-center text-sm text-zinc-500">
-        Nenhuma linha para este filtro.
+        {t("table.noRowsForFilter")}
       </p>
     );
   }
@@ -44,15 +48,15 @@ export function PreviewTable({
       <table className="w-full text-left text-xs text-zinc-400">
         <thead className="border-b border-zinc-800 bg-zinc-900/80 text-[10px] uppercase text-zinc-500">
           <tr>
-            <th className="px-3 py-2 font-medium">Status</th>
-            <th className="px-3 py-2 font-medium">Nome</th>
-            <th className="px-3 py-2 font-medium">Grupo</th>
-            <th className="px-3 py-2 font-medium">RSVP</th>
-            <th className="px-3 py-2 font-medium">Telefone</th>
-            <th className="px-3 py-2 font-medium">Email</th>
-            <th className="px-3 py-2 font-medium">Tags</th>
-            <th className="px-3 py-2 font-medium">Criança</th>
-            <th className="px-3 py-2 font-medium">PIN</th>
+            <th className="px-3 py-2 font-medium">{t("table.status")}</th>
+            <th className="px-3 py-2 font-medium">{t("table.name")}</th>
+            <th className="px-3 py-2 font-medium">{t("table.group")}</th>
+            <th className="px-3 py-2 font-medium">{t("table.rsvp")}</th>
+            <th className="px-3 py-2 font-medium">{t("table.phone")}</th>
+            <th className="px-3 py-2 font-medium">{t("table.email")}</th>
+            <th className="px-3 py-2 font-medium">{t("table.tags")}</th>
+            <th className="px-3 py-2 font-medium">{t("table.child")}</th>
+            <th className="px-3 py-2 font-medium">{t("table.pin")}</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-zinc-800">
@@ -62,17 +66,17 @@ export function PreviewTable({
                 <span
                   className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] ${STATUS_CHIP[row.classification]}`}
                 >
-                  {STATUS_LABEL[row.classification]}
+                  {t(STATUS_KEY[row.classification])}
                 </span>
               </td>
               <td className="px-3 py-2 text-zinc-100">{row.name}</td>
               <td className="px-3 py-2">{row.groupName ?? "—"}</td>
               <td className="px-3 py-2">
-                {RSVP_LABEL[row.rsvpStatus] ?? row.rsvpStatus}
+                {rsvpLabel(row.rsvpStatus)}
                 {row.rsvpStatusRaw && row.rsvpStatus === "INVITED" && row.rsvpStatusRaw !== "Sem resposta" ? (
                   <span
                     className="ml-1 text-[10px] text-amber-400"
-                    title={`Status original "${row.rsvpStatusRaw}" não reconhecido; tratado como Convidado.`}
+                    title={t("table.rawStatusHint", { raw: row.rsvpStatusRaw })}
                   >
                     *
                   </span>
@@ -84,7 +88,11 @@ export function PreviewTable({
                 {row.tags.length > 0 ? row.tags.join(", ") : "—"}
               </td>
               <td className="px-3 py-2">
-                {row.isChild ? `Sim${row.age != null ? ` (${row.age})` : ""}` : "—"}
+                {row.isChild
+                  ? row.age != null
+                    ? t("table.childYesAge", { age: row.age })
+                    : t("table.childYes")
+                  : "—"}
               </td>
               <td className="px-3 py-2">{row.pin ?? "—"}</td>
             </tr>

--- a/src/app/dashboard/guests/import/import-client.tsx
+++ b/src/app/dashboard/guests/import/import-client.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-// i18n: tela ainda pendente de migração para next-intl (AGENTS.md §6.7).
-// Strings em pt-BR direto na JSX seguem o padrão do guests-client.tsx.
-
 import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   ArrowLeft,
   CheckCircle2,
@@ -26,34 +24,19 @@ import { IMPORTER_OPTIONS } from "@/lib/guest-importers";
 import { PreviewTable } from "./_components/preview-table";
 import { PasteImportModal } from "./_components/paste-modal";
 
-const MODE_OPTIONS: Array<{
-  id: CommitMode;
-  label: string;
-  description: string;
-}> = [
-  {
-    id: "CREATE_NEW_ONLY",
-    label: "Pular linhas que já existem no mesmo grupo",
-    description: "Mais seguro. Só cria os convidados novos; nada é alterado.",
-  },
-  {
-    id: "UPSERT_BY_NAME",
-    label: "Atualizar dados de quem já existe no mesmo grupo",
-    description:
-      "Sobrescreve telefone, e-mail, status e tags dos convidados que já existem. Cria os novos.",
-  },
-  {
-    id: "CREATE_ALL_DUPLICATES",
-    label: "Criar tudo, mesmo que já exista",
-    description:
-      "Use quando houver homônimos em famílias diferentes que não devem ser fundidos.",
-  },
+const MODE_OPTION_IDS: CommitMode[] = [
+  "CREATE_NEW_ONLY",
+  "UPSERT_BY_NAME",
+  "CREATE_ALL_DUPLICATES",
 ];
 
 type Step = "upload" | "preview" | "done";
 
 export function GuestImportClient() {
   const router = useRouter();
+  const t = useTranslations("dashboard.guests.import");
+  const tc = useTranslations("common");
+  const b = (chunks: React.ReactNode) => <strong className="text-zinc-100">{chunks}</strong>;
   const toast = useToast();
   const [step, setStep] = useState<Step>("upload");
   const [source, setSource] = useState<string>("AUTO");
@@ -71,7 +54,7 @@ export function GuestImportClient() {
   async function handleUpload(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!file) {
-      toast.error("Selecione um arquivo .xlsx");
+      toast.error(t("toast.selectFile"));
       return;
     }
     setBusy(true);
@@ -81,11 +64,11 @@ export function GuestImportClient() {
       fd.set("source", source);
       const r = await previewGuestImport(undefined, fd);
       if (!r.success) {
-        toast.error("Falha", r.error);
+        toast.error(tc("common.errorGeneric"), r.error);
         return;
       }
       if (!r.data) {
-        toast.error("Resposta inesperada do servidor");
+        toast.error(t("toast.unexpectedResponse"));
         return;
       }
       setPreview(r.data);
@@ -110,11 +93,11 @@ export function GuestImportClient() {
         mode,
       });
       if (!r.success) {
-        toast.error("Falha ao importar", r.error);
+        toast.error(t("toast.importFailed"), r.error);
         return;
       }
       if (!r.data) {
-        toast.error("Resposta inesperada do servidor");
+        toast.error(t("toast.unexpectedResponse"));
         return;
       }
       setResult(r.data);
@@ -132,15 +115,13 @@ export function GuestImportClient() {
           href="/dashboard/guests"
           className="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-300"
         >
-          <ArrowLeft className="h-4 w-4" /> Voltar para convidados
+          <ArrowLeft className="h-4 w-4" /> {t("backToGuests")}
         </Link>
         <h1 className="mt-2 text-xl font-semibold text-zinc-100 md:text-2xl">
-          Importar lista de convidados
+          {t("title")}
         </h1>
         <p className="text-sm text-zinc-400">
-          Suba o arquivo exportado de outro sistema (hoje:{" "}
-          {IMPORTER_OPTIONS.map((o) => o.label).join(", ")}). Você verá um preview antes de
-          confirmar.
+          {t("subtitle", { sources: IMPORTER_OPTIONS.map((o) => o.label).join(", ") })}
         </p>
       </div>
 
@@ -151,7 +132,7 @@ export function GuestImportClient() {
         >
           <div>
             <label className="mb-1 block text-sm font-medium text-zinc-400">
-              Arquivo (.xlsx ou .csv)
+              {t("upload.fileLabel")}
             </label>
             <input
               type="file"
@@ -160,20 +141,17 @@ export function GuestImportClient() {
               onChange={(e) => setFile(e.target.files?.[0] ?? null)}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 file:mr-3 file:rounded-lg file:border-0 file:bg-rose-500/20 file:px-3 file:py-1.5 file:text-rose-200 hover:file:bg-rose-500/30"
             />
-            <p className="mt-1 text-xs text-zinc-500">
-              Tamanho máximo: 5 MB. Até 2000 linhas por importação. Wedy exporta em
-              .xlsx; o próprio sistema exporta em .csv (botão CSV em /dashboard/guests).
-            </p>
+            <p className="mt-1 text-xs text-zinc-500">{t("upload.fileHint")}</p>
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Origem</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("upload.sourceLabel")}</label>
             <select
               value={source}
               onChange={(e) => setSource(e.target.value)}
               className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
-              <option value="AUTO">Detectar automaticamente</option>
+              <option value="AUTO">{t("upload.autoDetect")}</option>
               {IMPORTER_OPTIONS.map((opt) => (
                 <option key={opt.id} value={opt.id}>
                   {opt.label}
@@ -188,7 +166,7 @@ export function GuestImportClient() {
               onClick={() => setShowPaste(true)}
               className="text-xs text-zinc-400 underline hover:text-zinc-200"
             >
-              Prefere colar texto bruto?
+              {t("upload.preferPaste")}
             </button>
             <button
               type="submit"
@@ -200,7 +178,7 @@ export function GuestImportClient() {
               ) : (
                 <Upload className="h-4 w-4" />
               )}
-              Analisar arquivo
+              {t("upload.analyze")}
             </button>
           </div>
         </form>
@@ -209,34 +187,34 @@ export function GuestImportClient() {
       {step === "preview" && preview ? (
         <div className="space-y-4">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
-            <StatTile label="Linhas no arquivo" value={preview.totalRows} accent="rose" />
-            <StatTile label="Novos" value={preview.breakdown.new} accent="emerald" />
+            <StatTile label={t("preview.rowsInFile")} value={preview.totalRows} accent="rose" />
+            <StatTile label={t("preview.new")} value={preview.breakdown.new} accent="emerald" />
             <StatTile
-              label="Já existem (mesmo grupo)"
+              label={t("preview.existingSameGroup")}
               value={preview.breakdown.duplicateSame}
               accent="zinc"
             />
             <StatTile
-              label="Divergentes"
+              label={t("preview.divergent")}
               value={preview.breakdown.duplicateDiff}
               accent="amber"
             />
           </div>
 
           <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-            <h2 className="text-sm font-semibold text-zinc-100">Origem detectada</h2>
+            <h2 className="text-sm font-semibold text-zinc-100">{t("preview.detectedSource")}</h2>
             <p className="text-sm text-zinc-400">
               {preview.sourceLabel} —{" "}
-              <span className="text-zinc-500">arquivo válido, headers reconhecidos.</span>
+              <span className="text-zinc-500">{t("preview.fileValid")}</span>
             </p>
           </section>
 
           <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
             <h2 className="mb-2 text-sm font-semibold text-zinc-100">
-              Grupos detectados ({preview.groupsPreview.length})
+              {t("preview.detectedGroups", { count: preview.groupsPreview.length })}
             </h2>
             {preview.groupsPreview.length === 0 ? (
-              <p className="text-sm text-zinc-500">Nenhum grupo na planilha.</p>
+              <p className="text-sm text-zinc-500">{t("preview.noGroups")}</p>
             ) : (
               <ul className="flex max-h-40 flex-wrap gap-1.5 overflow-y-auto">
                 {preview.groupsPreview.map((g) => (
@@ -246,11 +224,11 @@ export function GuestImportClient() {
                   >
                     <span>{g.name}</span>
                     <span className="text-zinc-500">·</span>
-                    <span className="text-zinc-500">{g.count} pessoa(s)</span>
+                    <span className="text-zinc-500">{t("preview.peopleCount", { count: g.count })}</span>
                     {g.pin ? (
                       <>
                         <span className="text-zinc-500">·</span>
-                        <span className="text-rose-300">PIN {g.pin}</span>
+                        <span className="text-rose-300">{t("preview.pin", { pin: g.pin })}</span>
                       </>
                     ) : null}
                   </li>
@@ -261,10 +239,10 @@ export function GuestImportClient() {
 
           <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
             <h2 className="mb-2 text-sm font-semibold text-zinc-100">
-              Tags detectadas ({preview.tagsPreview.length})
+              {t("preview.detectedTags", { count: preview.tagsPreview.length })}
             </h2>
             {preview.tagsPreview.length === 0 ? (
-              <p className="text-sm text-zinc-500">Nenhuma tag.</p>
+              <p className="text-sm text-zinc-500">{t("preview.noTags")}</p>
             ) : (
               <div className="flex flex-wrap gap-1.5">
                 {preview.tagsPreview.map((t) => (
@@ -277,23 +255,20 @@ export function GuestImportClient() {
                 ))}
               </div>
             )}
-            <p className="mt-2 text-xs text-zinc-500">
-              Tags novas serão criadas. Tags com o nome &ldquo;Padrinhos&rdquo;,
-              &ldquo;Madrinha&rdquo; etc. também marcam a flag de padrinho do convidado.
-            </p>
+            <p className="mt-2 text-xs text-zinc-500">{t("preview.tagsNote")}</p>
           </section>
 
           <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
             <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
               <h2 className="text-sm font-semibold text-zinc-100">
-                Amostra (até {preview.sample.length} linhas)
+                {t("preview.sampleTitle", { count: preview.sample.length })}
               </h2>
               <div className="flex gap-1 text-xs">
                 {([
-                  ["all", "Todas"],
-                  ["new", "Novas"],
-                  ["duplicate_same", "Já existem"],
-                  ["duplicate_diff", "Divergentes"],
+                  ["all", t("preview.filterAll")],
+                  ["new", t("preview.filterNew")],
+                  ["duplicate_same", t("preview.filterExisting")],
+                  ["duplicate_diff", t("preview.filterDivergent")],
                 ] as const).map(([id, label]) => (
                   <button
                     type="button"
@@ -315,14 +290,14 @@ export function GuestImportClient() {
 
           <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
             <h2 className="mb-3 text-sm font-semibold text-zinc-100">
-              Como tratar duplicatas
+              {t("mode.heading")}
             </h2>
             <div className="space-y-2">
-              {MODE_OPTIONS.map((opt) => (
+              {MODE_OPTION_IDS.map((id) => (
                 <label
-                  key={opt.id}
+                  key={id}
                   className={`flex cursor-pointer items-start gap-3 rounded-xl border p-3 ${
-                    mode === opt.id
+                    mode === id
                       ? "border-rose-500/40 bg-rose-500/5"
                       : "border-zinc-800 hover:bg-zinc-900"
                   }`}
@@ -330,14 +305,14 @@ export function GuestImportClient() {
                   <input
                     type="radio"
                     name="mode"
-                    value={opt.id}
-                    checked={mode === opt.id}
-                    onChange={() => setMode(opt.id)}
+                    value={id}
+                    checked={mode === id}
+                    onChange={() => setMode(id)}
                     className="mt-1"
                   />
                   <div>
-                    <div className="text-sm font-medium text-zinc-100">{opt.label}</div>
-                    <div className="text-xs text-zinc-500">{opt.description}</div>
+                    <div className="text-sm font-medium text-zinc-100">{t(`mode.${id}.label`)}</div>
+                    <div className="text-xs text-zinc-500">{t(`mode.${id}.description`)}</div>
                   </div>
                 </label>
               ))}
@@ -351,7 +326,7 @@ export function GuestImportClient() {
               disabled={busy}
               className="inline-flex items-center gap-1 rounded-xl bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-200 hover:bg-zinc-700"
             >
-              <X className="h-4 w-4" /> Cancelar
+              <X className="h-4 w-4" /> {tc("actions.cancel")}
             </button>
             <button
               type="button"
@@ -364,7 +339,7 @@ export function GuestImportClient() {
               ) : (
                 <ChevronRight className="h-4 w-4" />
               )}
-              Confirmar importação
+              {t("preview.confirmImport")}
             </button>
           </div>
         </div>
@@ -374,25 +349,23 @@ export function GuestImportClient() {
         <div className="space-y-4 rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-5">
           <div className="flex items-center gap-2 text-emerald-200">
             <CheckCircle2 className="h-5 w-5" />
-            <h2 className="text-base font-semibold">Importação concluída</h2>
+            <h2 className="text-base font-semibold">{t("done.title")}</h2>
           </div>
           <ul className="text-sm text-zinc-300">
             <li>
-              <strong className="text-zinc-100">{result.created}</strong> convidado(s) criados.
+              {t.rich("done.created", { count: result.created, b })}
             </li>
             <li>
-              <strong className="text-zinc-100">{result.updated}</strong> convidado(s)
-              atualizados.
+              {t.rich("done.updated", { count: result.updated, b })}
             </li>
             <li>
-              <strong className="text-zinc-100">{result.skipped}</strong> linha(s) puladas.
+              {t.rich("done.skipped", { count: result.skipped, b })}
             </li>
             <li>
-              <strong className="text-zinc-100">{result.groupsCreated}</strong> grupo(s)
-              criados.
+              {t.rich("done.groupsCreated", { count: result.groupsCreated, b })}
             </li>
             <li>
-              <strong className="text-zinc-100">{result.tagsCreated}</strong> tag(s) criadas.
+              {t.rich("done.tagsCreated", { count: result.tagsCreated, b })}
             </li>
           </ul>
           <div className="flex flex-wrap gap-2">
@@ -400,7 +373,7 @@ export function GuestImportClient() {
               href="/dashboard/guests"
               className="rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500"
             >
-              Ver lista de convidados
+              {t("done.viewList")}
             </Link>
             <button
               type="button"
@@ -412,7 +385,7 @@ export function GuestImportClient() {
               }}
               className="rounded-xl bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-700"
             >
-              Importar outra
+              {t("done.importAnother")}
             </button>
           </div>
         </div>

--- a/src/app/dashboard/guests/page.tsx
+++ b/src/app/dashboard/guests/page.tsx
@@ -1,10 +1,12 @@
 import { prisma } from "@/lib/prisma";
 import { headers } from "next/headers";
+import { getTranslations } from "next-intl/server";
 import GuestsClient from "./guests-client";
 
 export const dynamic = "force-dynamic";
 
 export default async function GuestsPage() {
+  const t = await getTranslations("dashboard.guests");
   const guests = await prisma.guest.findMany({
     where: { deletedAt: null },
     orderBy: [{ rsvpStatus: "asc" }, { name: "asc" }],
@@ -18,10 +20,8 @@ export default async function GuestsPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Convidados</h1>
-        <p className="text-sm text-zinc-500">
-          Gerencie a lista, envie links únicos de RSVP e acompanhe confirmações.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
       <GuestsClient guests={guests} baseUrl={baseUrl} />
     </div>

--- a/src/app/dashboard/honeymoon/honeymoon-client.tsx
+++ b/src/app/dashboard/honeymoon/honeymoon-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
 import {
   BedDouble,
   Briefcase,
@@ -49,15 +50,8 @@ type Honeymoon = {
   items: Item[];
 };
 
-const KIND_LABEL: Record<string, string> = {
-  FLIGHT: "Voo",
-  HOTEL: "Hospedagem",
-  TRANSFER: "Transfer",
-  ACTIVITY: "Passeio",
-  DOCUMENT: "Documento",
-  BAGGAGE: "Bagagem",
-  OTHER: "Outro",
-};
+const KIND_KEYS = ["FLIGHT", "HOTEL", "TRANSFER", "ACTIVITY", "DOCUMENT", "BAGGAGE", "OTHER"] as const;
+const STATUS_KEYS = ["PLANNED", "BOOKED", "CONFIRMED", "PAID", "CANCELLED"] as const;
 
 const KIND_ICON: Record<string, React.ComponentType<{ className?: string }>> = {
   FLIGHT: Plane,
@@ -69,15 +63,9 @@ const KIND_ICON: Record<string, React.ComponentType<{ className?: string }>> = {
   OTHER: Briefcase,
 };
 
-const STATUS_LABEL: Record<string, string> = {
-  PLANNED: "Planejado",
-  BOOKED: "Reservado",
-  CONFIRMED: "Confirmado",
-  PAID: "Pago",
-  CANCELLED: "Cancelado",
-};
-
 export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon }) {
+  const t = useTranslations("dashboard.honeymoon");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [editingInfo, setEditingInfo] = useState(false);
   const [busyInfo, setBusyInfo] = useState(false);
@@ -115,9 +103,9 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
       try {
         const r = await updateHoneymoon(undefined, formData);
         if (r.success) {
-          toast.success("Atualizado");
+          toast.success(t("toast.updated"));
           setEditingInfo(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusyInfo(false);
       }
@@ -130,9 +118,9 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
       try {
         const r = await createHoneymoonItem(undefined, formData);
         if (r.success) {
-          toast.success("Item adicionado");
+          toast.success(t("toast.itemAdded"));
           setOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusyItem(false);
       }
@@ -145,9 +133,9 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
       try {
         const r = await updateHoneymoonItem(undefined, formData);
         if (r.success) {
-          toast.success("Item atualizado");
+          toast.success(t("toast.itemUpdated"));
           setEditing(null);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setUpdateBusy(false);
       }
@@ -160,9 +148,9 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
     startTransition(async () => {
       const r = await deleteHoneymoonItem(id);
       if (r.success) {
-        toast.success("Item removido");
+        toast.success(t("toast.itemRemoved"));
         setDeleting(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.failed"), r.error);
     });
   }
 
@@ -172,8 +160,8 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
         {!editingInfo ? (
           <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
             <div>
-              <p className="text-xs uppercase tracking-wider text-zinc-500">Destino</p>
-              <h2 className="mt-1 text-2xl font-bold text-white">{honeymoon.destination ?? "Ainda não decidido"}</h2>
+              <p className="text-xs uppercase tracking-wider text-zinc-500">{t("info.destination")}</p>
+              <h2 className="mt-1 text-2xl font-bold text-white">{honeymoon.destination ?? t("info.notDecided")}</h2>
               <p className="mt-1 text-sm text-zinc-400">
                 {honeymoon.startDate ? formatDateBR(honeymoon.startDate) : "—"}
                 {" → "}
@@ -185,7 +173,7 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
             </div>
             <div className="flex flex-col items-end gap-2">
               <div className="rounded-xl border border-zinc-800 bg-zinc-950/50 px-4 py-2">
-                <p className="text-[10px] uppercase tracking-wider text-zinc-500">Orçamento</p>
+                <p className="text-[10px] uppercase tracking-wider text-zinc-500">{t("info.budget")}</p>
                 <p className="text-lg font-bold text-zinc-100">
                   {honeymoon.budget
                     ? new Intl.NumberFormat("pt-BR", { style: "currency", currency: honeymoon.currency }).format(honeymoon.budget)
@@ -193,7 +181,7 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
                 </p>
               </div>
               <div className="rounded-xl border border-zinc-800 bg-zinc-950/50 px-4 py-2">
-                <p className="text-[10px] uppercase tracking-wider text-zinc-500">Comprometido</p>
+                <p className="text-[10px] uppercase tracking-wider text-zinc-500">{t("info.committed")}</p>
                 <p className="text-lg font-bold text-rose-300">{formatCurrency(totals.totalCost)}</p>
               </div>
               <button
@@ -201,32 +189,32 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
                 onClick={() => setEditingInfo(true)}
                 className="text-xs text-rose-300 hover:text-rose-200"
               >
-                Editar dados da viagem
+                {t("info.editTrip")}
               </button>
             </div>
           </div>
         ) : (
           <form action={handleInfoSubmit} className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Field name="destination" label="Destino" defaultValue={honeymoon.destination ?? ""} />
+            <Field name="destination" label={t("info.destination")} defaultValue={honeymoon.destination ?? ""} />
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:col-span-2">
-              <Field name="startDate" label="Saída" type="date" defaultValue={honeymoon.startDate ? toIsoDate(new Date(honeymoon.startDate)) : ""} />
-              <Field name="endDate" label="Volta" type="date" defaultValue={honeymoon.endDate ? toIsoDate(new Date(honeymoon.endDate)) : ""} />
+              <Field name="startDate" label={t("info.departure")} type="date" defaultValue={honeymoon.startDate ? toIsoDate(new Date(honeymoon.startDate)) : ""} />
+              <Field name="endDate" label={t("info.return")} type="date" defaultValue={honeymoon.endDate ? toIsoDate(new Date(honeymoon.endDate)) : ""} />
             </div>
-            <Field name="budget" label="Orçamento" type="number" step="0.01" defaultValue={honeymoon.budget?.toString() ?? ""} />
+            <Field name="budget" label={t("info.budget")} type="number" step="0.01" defaultValue={honeymoon.budget?.toString() ?? ""} />
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Moeda</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.currency")}</label>
               <select
                 name="currency"
                 defaultValue={honeymoon.currency}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
               >
-                <option value="BRL">Real (BRL)</option>
-                <option value="USD">Dólar (USD)</option>
-                <option value="EUR">Euro (EUR)</option>
+                <option value="BRL">{t("currency.brl")}</option>
+                <option value="USD">{t("currency.usd")}</option>
+                <option value="EUR">{t("currency.eur")}</option>
               </select>
             </div>
             <div className="sm:col-span-2">
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.notes")}</label>
               <textarea
                 name="notes"
                 rows={3}
@@ -241,7 +229,7 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
                 onClick={() => setEditingInfo(false)}
                 className="rounded-xl bg-zinc-800 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700"
               >
-                Cancelar
+                {tc("actions.cancel")}
               </button>
               <button
                 type="submit"
@@ -249,7 +237,7 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
                 className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
               >
                 {busyInfo ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-                Salvar
+                {tc("actions.save")}
               </button>
             </div>
           </form>
@@ -262,13 +250,13 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
           onClick={() => setOpen(true)}
           className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500"
         >
-          <Plus className="h-4 w-4" /> Novo item
+          <Plus className="h-4 w-4" /> {t("actions.newItem")}
         </button>
       </div>
 
       {honeymoon.items.length === 0 ? (
         <p className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/30 p-8 text-center text-sm text-zinc-500">
-          Nada adicionado ainda. Comece pelos voos e hotéis.
+          {t("list.empty")}
         </p>
       ) : (
         <div className="space-y-4">
@@ -278,7 +266,7 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
               <section key={kind} className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-5">
                 <div className="mb-3 flex items-center gap-2 text-zinc-100">
                   <Icon className="h-5 w-5" />
-                  <h3 className="font-semibold">{KIND_LABEL[kind] ?? kind}</h3>
+                  <h3 className="font-semibold">{(KIND_KEYS as readonly string[]).includes(kind) ? t(`kind.${kind}`) : kind}</h3>
                   <span className="text-xs text-zinc-500">({items.length})</span>
                 </div>
                 <ul className="space-y-2">
@@ -293,7 +281,7 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
                           {it.vendor ? <span>{it.vendor}</span> : null}
                           {it.startAt ? <span>📅 {formatDateBR(it.startAt)}</span> : null}
                           {it.confirmationNumber ? <span>#{it.confirmationNumber}</span> : null}
-                          <span>{STATUS_LABEL[it.status] ?? it.status}</span>
+                          <span>{(STATUS_KEYS as readonly string[]).includes(it.status) ? t(`status.${it.status}`) : it.status}</span>
                         </div>
                       </div>
                       <div className="flex items-center gap-3">
@@ -308,7 +296,7 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
                         <button
                           type="button"
                           onClick={() => setEditing(it)}
-                          aria-label="Editar"
+                          aria-label={tc("actions.edit")}
                           className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
                         >
                           <Pencil className="h-4 w-4" />
@@ -316,7 +304,7 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
                         <button
                           type="button"
                           onClick={() => setDeleting(it)}
-                          aria-label="Excluir"
+                          aria-label={tc("actions.delete")}
                           className="rounded-lg p-1.5 text-zinc-400 hover:bg-rose-500/10 hover:text-rose-400"
                         >
                           <Trash2 className="h-4 w-4" />
@@ -346,8 +334,8 @@ export default function HoneymoonClient({ honeymoon }: { honeymoon: Honeymoon })
 
       <ConfirmDialog
         open={!!deleting}
-        title="Excluir item?"
-        confirmLabel="Excluir"
+        title={t("delete.confirmTitle")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
@@ -369,35 +357,37 @@ function ItemModal({
   onClose: () => void;
   formAction: (formData: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.honeymoon");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-lg rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
         <h2 className="text-lg font-semibold text-white">
-          {mode === "create" ? "Novo item" : "Editar item"}
+          {mode === "create" ? t("form.titleCreate") : t("form.titleEdit")}
         </h2>
         <form action={formAction} className="mt-4 grid gap-3 sm:grid-cols-2">
           {item ? <input type="hidden" name="id" value={item.id} /> : null}
           <div className="sm:col-span-2">
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Tipo</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.kind")}</label>
             <select
               name="kind"
               defaultValue={item?.kind ?? "ACTIVITY"}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
-              {Object.entries(KIND_LABEL).map(([k, v]) => (
+              {KIND_KEYS.map((k) => (
                 <option key={k} value={k}>
-                  {v}
+                  {t(`kind.${k}`)}
                 </option>
               ))}
             </select>
           </div>
-          <Field name="title" label="Título" required defaultValue={item?.title ?? ""} />
-          <Field name="vendor" label="Companhia / fornecedor" defaultValue={item?.vendor ?? ""} />
-          <Field name="startAt" label="Início" type="date" defaultValue={item?.startAt ? toIsoDate(new Date(item.startAt)) : ""} />
-          <Field name="endAt" label="Fim" type="date" defaultValue={item?.endAt ? toIsoDate(new Date(item.endAt)) : ""} />
-          <Field name="amount" label="Valor" type="number" step="0.01" defaultValue={item?.amount?.toString() ?? ""} />
+          <Field name="title" label={t("form.title")} required defaultValue={item?.title ?? ""} />
+          <Field name="vendor" label={t("form.vendor")} defaultValue={item?.vendor ?? ""} />
+          <Field name="startAt" label={t("form.start")} type="date" defaultValue={item?.startAt ? toIsoDate(new Date(item.startAt)) : ""} />
+          <Field name="endAt" label={t("form.end")} type="date" defaultValue={item?.endAt ? toIsoDate(new Date(item.endAt)) : ""} />
+          <Field name="amount" label={t("form.amount")} type="number" step="0.01" defaultValue={item?.amount?.toString() ?? ""} />
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Moeda</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.currency")}</label>
             <select
               name="currency"
               defaultValue={item?.currency ?? "BRL"}
@@ -408,23 +398,23 @@ function ItemModal({
               <option value="EUR">EUR</option>
             </select>
           </div>
-          <Field name="confirmationNumber" label="Localizador" defaultValue={item?.confirmationNumber ?? ""} />
+          <Field name="confirmationNumber" label={t("form.confirmationNumber")} defaultValue={item?.confirmationNumber ?? ""} />
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Status</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.status")}</label>
             <select
               name="status"
               defaultValue={item?.status ?? "PLANNED"}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
-              {Object.entries(STATUS_LABEL).map(([k, v]) => (
+              {STATUS_KEYS.map((k) => (
                 <option key={k} value={k}>
-                  {v}
+                  {t(`status.${k}`)}
                 </option>
               ))}
             </select>
           </div>
           <div className="sm:col-span-2">
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.notes")}</label>
             <textarea
               name="notes"
               rows={2}
@@ -439,14 +429,14 @@ function ItemModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/honeymoon/page.tsx
+++ b/src/app/dashboard/honeymoon/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { ensureHoneymoon } from "@/app/actions/honeymoonActions";
 import HoneymoonClient from "./honeymoon-client";
@@ -5,6 +6,7 @@ import HoneymoonClient from "./honeymoon-client";
 export const dynamic = "force-dynamic";
 
 export default async function HoneymoonPage() {
+  const t = await getTranslations("dashboard.honeymoon");
   await ensureHoneymoon();
   const honeymoon = await prisma.honeymoon.findUnique({
     where: { id: "singleton" },
@@ -16,10 +18,8 @@ export default async function HoneymoonPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Lua de mel</h1>
-        <p className="text-sm text-zinc-500">
-          Roteiro, reservas, documentos e orçamento da viagem pós-casamento.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
       <HoneymoonClient honeymoon={honeymoon!} />
     </div>

--- a/src/app/dashboard/income/income-client.tsx
+++ b/src/app/dashboard/income/income-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
 import { CheckCircle2, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
 import {
   createIncome,
@@ -26,17 +27,19 @@ type IncomeRow = {
   notes: string | null;
 };
 
-const SOURCE_LABEL: Record<string, string> = {
-  SALARY: "Salário",
-  BONUS: "Bônus / 13º",
-  GIFT: "Presente em dinheiro",
-  FREELANCE: "Freela",
-  SALE: "Venda",
-  RESTITUTION: "Restituição IR",
-  OTHER: "Outro",
-};
+const SOURCE_KEYS = [
+  "SALARY",
+  "BONUS",
+  "GIFT",
+  "FREELANCE",
+  "SALE",
+  "RESTITUTION",
+  "OTHER",
+] as const;
 
 export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
+  const t = useTranslations("dashboard.income");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<IncomeRow | null>(null);
@@ -58,15 +61,21 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
 
   const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(incomes, 20);
 
+  function sourceLabel(source: string): string {
+    return SOURCE_KEYS.includes(source as (typeof SOURCE_KEYS)[number])
+      ? t(`source.${source}`)
+      : source;
+  }
+
   function handleCreate(formData: FormData) {
     setBusy(true);
     startTransition(async () => {
       try {
         const r = await createIncome(undefined, formData);
         if (r.success) {
-          toast.success("Receita registrada");
+          toast.success(t("toast.created"));
           setOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.fail"), r.error);
       } finally {
         setBusy(false);
       }
@@ -79,9 +88,9 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
       try {
         const r = await updateIncome(undefined, formData);
         if (r.success) {
-          toast.success("Receita atualizada");
+          toast.success(t("toast.updated"));
           setEditing(null);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.fail"), r.error);
       } finally {
         setUpdatingBusy(false);
       }
@@ -91,8 +100,8 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
   function handleReceived(row: IncomeRow) {
     startTransition(async () => {
       const r = await markIncomeReceived(row.id);
-      if (r.success) toast.success("Marcada como recebida");
-      else toast.error("Falha", r.error);
+      if (r.success) toast.success(t("toast.marked"));
+      else toast.error(t("toast.fail"), r.error);
     });
   }
 
@@ -102,18 +111,18 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
     startTransition(async () => {
       const r = await deleteIncome(id);
       if (r.success) {
-        toast.success("Receita removida");
+        toast.success(t("toast.deleted"));
         setDeleting(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.fail"), r.error);
     });
   }
 
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <SummaryCard label="Total estimado" value={totals.total} accent="zinc" />
-        <SummaryCard label="A receber" value={totals.expected} accent="amber" />
-        <SummaryCard label="Recebido" value={totals.received} accent="emerald" />
+        <SummaryCard label={t("summary.total")} value={totals.total} accent="zinc" />
+        <SummaryCard label={t("summary.expected")} value={totals.expected} accent="amber" />
+        <SummaryCard label={t("summary.received")} value={totals.received} accent="emerald" />
       </div>
 
       <div className="flex justify-end">
@@ -122,7 +131,7 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
           onClick={() => setOpen(true)}
           className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-lg hover:bg-rose-500"
         >
-          <Plus className="h-4 w-4" /> Nova receita
+          <Plus className="h-4 w-4" /> {t("actions.new")}
         </button>
       </div>
 
@@ -131,19 +140,19 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
           <table className="w-full text-left text-sm text-zinc-400">
             <thead className="border-b border-zinc-800 bg-zinc-900/80 text-xs uppercase text-zinc-500">
               <tr>
-                <th className="px-6 py-4 font-medium">Título</th>
-                <th className="px-6 py-4 font-medium">Origem</th>
-                <th className="px-6 py-4 font-medium">Valor</th>
-                <th className="px-6 py-4 font-medium">Data prevista</th>
-                <th className="px-6 py-4 font-medium">Status</th>
-                <th className="px-6 py-4 text-right font-medium">Ações</th>
+                <th className="px-6 py-4 font-medium">{t("table.title")}</th>
+                <th className="px-6 py-4 font-medium">{t("table.source")}</th>
+                <th className="px-6 py-4 font-medium">{t("table.amount")}</th>
+                <th className="px-6 py-4 font-medium">{t("table.expectedDate")}</th>
+                <th className="px-6 py-4 font-medium">{t("table.status")}</th>
+                <th className="px-6 py-4 text-right font-medium">{t("table.actions")}</th>
               </tr>
             </thead>
             <tbody>
               {incomes.length === 0 ? (
                 <tr>
                   <td colSpan={6} className="px-6 py-8 text-center text-zinc-500">
-                    Nenhuma receita cadastrada.
+                    {t("table.empty")}
                   </td>
                 </tr>
               ) : (
@@ -152,13 +161,13 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
                     <td className="px-6 py-4">
                       <div className="text-zinc-200">{row.title}</div>
                       {row.givenByName ? (
-                        <div className="text-xs text-zinc-500">de {row.givenByName}</div>
+                        <div className="text-xs text-zinc-500">{t("row.givenBy", { name: row.givenByName })}</div>
                       ) : null}
                       {row.frequency === "MONTHLY" ? (
-                        <div className="text-[10px] uppercase tracking-wider text-sky-400">Mensal</div>
+                        <div className="text-[10px] uppercase tracking-wider text-sky-400">{t("frequency.MONTHLY")}</div>
                       ) : null}
                     </td>
-                    <td className="px-6 py-4">{SOURCE_LABEL[row.source] ?? row.source}</td>
+                    <td className="px-6 py-4">{sourceLabel(row.source)}</td>
                     <td className="px-6 py-4 font-medium text-emerald-400">{formatCurrency(row.amount)}</td>
                     <td className="px-6 py-4">{row.expectedDate ? formatDateBR(row.expectedDate) : "—"}</td>
                     <td className="px-6 py-4">
@@ -171,7 +180,11 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
                               : "bg-amber-500/10 text-amber-400 border-amber-500/20"
                         }`}
                       >
-                        {row.status === "RECEIVED" ? "Recebida" : row.status === "CANCELLED" ? "Cancelada" : "Prevista"}
+                        {row.status === "RECEIVED"
+                          ? t("status.RECEIVED")
+                          : row.status === "CANCELLED"
+                            ? t("status.CANCELLED")
+                            : t("status.EXPECTED")}
                       </span>
                     </td>
                     <td className="px-6 py-4 text-right">
@@ -183,13 +196,13 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
                             className="flex items-center gap-1 rounded-lg px-2 py-1 text-emerald-400 hover:bg-emerald-500/10"
                           >
                             <CheckCircle2 className="h-4 w-4" />
-                            <span className="text-xs">Recebi</span>
+                            <span className="text-xs">{t("actions.received")}</span>
                           </button>
                         ) : null}
                         <button
                           type="button"
                           onClick={() => setEditing(row)}
-                          aria-label="Editar"
+                          aria-label={tc("actions.edit")}
                           className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
                         >
                           <Pencil className="h-4 w-4" />
@@ -197,7 +210,7 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
                         <button
                           type="button"
                           onClick={() => setDeleting(row)}
-                          aria-label="Excluir"
+                          aria-label={tc("actions.delete")}
                           className="rounded-lg p-1.5 text-zinc-400 hover:bg-rose-500/10 hover:text-rose-400"
                         >
                           <Trash2 className="h-4 w-4" />
@@ -236,8 +249,8 @@ export default function IncomeClient({ incomes }: { incomes: IncomeRow[] }) {
 
       <ConfirmDialog
         open={!!deleting}
-        title="Excluir receita?"
-        confirmLabel="Excluir"
+        title={t("confirmDelete.title")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
@@ -282,33 +295,35 @@ function IncomeFormModal({
   onClose: () => void;
   formAction: (formData: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.income");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
         <h2 className="text-lg font-semibold text-white">
-          {mode === "create" ? "Nova receita" : "Editar receita"}
+          {mode === "create" ? t("form.titleCreate") : t("form.titleEdit")}
         </h2>
         <form action={formAction} className="mt-4 space-y-3">
           {income ? <input type="hidden" name="id" value={income.id} /> : null}
-          <Field name="title" label="Título" required defaultValue={income?.title ?? ""} />
+          <Field name="title" label={t("form.title")} required defaultValue={income?.title ?? ""} />
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Origem</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.source")}</label>
               <select
                 name="source"
                 defaultValue={income?.source ?? "SALARY"}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
               >
-                {Object.entries(SOURCE_LABEL).map(([k, v]) => (
+                {SOURCE_KEYS.map((k) => (
                   <option key={k} value={k}>
-                    {v}
+                    {t(`source.${k}`)}
                   </option>
                 ))}
               </select>
             </div>
             <Field
               name="amount"
-              label="Valor (R$)"
+              label={t("form.amount")}
               type="number"
               step="0.01"
               required
@@ -318,45 +333,45 @@ function IncomeFormModal({
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Field
               name="expectedDate"
-              label="Data prevista"
+              label={t("form.expectedDate")}
               type="date"
               defaultValue={
                 income?.expectedDate ? toIsoDate(new Date(income.expectedDate)) : ""
               }
             />
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Frequência</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.frequency")}</label>
               <select
                 name="frequency"
                 defaultValue={income?.frequency ?? "ONE_TIME"}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
               >
-                <option value="ONE_TIME">Avulsa</option>
-                <option value="MONTHLY">Mensal</option>
+                <option value="ONE_TIME">{t("frequency.ONE_TIME")}</option>
+                <option value="MONTHLY">{t("frequency.MONTHLY")}</option>
               </select>
             </div>
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Status</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.status")}</label>
               <select
                 name="status"
                 defaultValue={income?.status ?? "EXPECTED"}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
               >
-                <option value="EXPECTED">Prevista</option>
-                <option value="RECEIVED">Recebida</option>
-                <option value="CANCELLED">Cancelada</option>
+                <option value="EXPECTED">{t("status.EXPECTED")}</option>
+                <option value="RECEIVED">{t("status.RECEIVED")}</option>
+                <option value="CANCELLED">{t("status.CANCELLED")}</option>
               </select>
             </div>
             <Field
               name="givenByName"
-              label="Dado por (presente)"
+              label={t("form.givenByName")}
               defaultValue={income?.givenByName ?? ""}
             />
           </div>
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.notes")}</label>
             <textarea
               name="notes"
               rows={2}
@@ -371,14 +386,14 @@ function IncomeFormModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/income/page.tsx
+++ b/src/app/dashboard/income/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { requireFinanceAccess } from "@/lib/finance-access";
 import IncomeClient from "./income-client";
@@ -6,6 +7,7 @@ export const dynamic = "force-dynamic";
 
 export default async function IncomePage() {
   await requireFinanceAccess();
+  const t = await getTranslations("dashboard.income");
 
   const incomes = await prisma.income.findMany({
     where: { deletedAt: null },
@@ -15,10 +17,8 @@ export default async function IncomePage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Receitas e ganhos</h1>
-        <p className="text-sm text-zinc-500">
-          Renda recorrente, bônus, presentes em dinheiro e vendas pré-casamento.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
       <IncomeClient incomes={incomes} />
     </div>

--- a/src/app/dashboard/insights/insights-client.tsx
+++ b/src/app/dashboard/insights/insights-client.tsx
@@ -13,6 +13,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { useTranslations } from "next-intl";
 import { AlertTriangle, TrendingDown, TrendingUp } from "lucide-react";
 import { formatCurrency, formatDateBR } from "@/lib/format";
 import type {
@@ -56,6 +57,7 @@ export default function InsightsClient({
   burndown,
   waterfall,
 }: Props) {
+  const t = useTranslations("dashboard.insights");
   return (
     <div className="space-y-6">
       <HealthCard health={health} />
@@ -70,8 +72,8 @@ export default function InsightsClient({
         className="scroll-mt-24 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm"
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-zinc-100">Curva S — Previsto vs Realizado</h2>
-          <span className="text-xs text-zinc-500">Banda = contingência configurada</span>
+          <h2 className="text-lg font-semibold text-zinc-100">{t("sCurve.title")}</h2>
+          <span className="text-xs text-zinc-500">{t("sCurve.hint")}</span>
         </div>
         <SCurve data={sCurve} valueFormatter={(n) => formatCurrency(n)} />
       </section>
@@ -81,8 +83,8 @@ export default function InsightsClient({
         className="scroll-mt-24 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm"
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-zinc-100">Burndown de Tarefas</h2>
-          <span className="text-xs text-zinc-500">Ideal vs real até a data do evento</span>
+          <h2 className="text-lg font-semibold text-zinc-100">{t("burndown.title")}</h2>
+          <span className="text-xs text-zinc-500">{t("burndown.hint")}</span>
         </div>
         <Burndown data={burndown} />
       </section>
@@ -94,8 +96,8 @@ export default function InsightsClient({
         className="scroll-mt-24 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm"
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-zinc-100">Variação por Categoria</h2>
-          <span className="text-xs text-zinc-500">Verde = poupou · Rosa = estourou</span>
+          <h2 className="text-lg font-semibold text-zinc-100">{t("waterfall.title")}</h2>
+          <span className="text-xs text-zinc-500">{t("waterfall.hint")}</span>
         </div>
         <Waterfall data={waterfall} valueFormatter={(n) => formatCurrency(n)} />
       </section>
@@ -108,6 +110,7 @@ export default function InsightsClient({
 }
 
 function HealthCard({ health }: { health: HealthScoreResult }) {
+  const t = useTranslations("dashboard.insights");
   const tone =
     health.score >= 75
       ? "border-emerald-500/30 bg-emerald-500/5 text-emerald-200"
@@ -121,14 +124,14 @@ function HealthCard({ health }: { health: HealthScoreResult }) {
         <div className="flex items-center gap-4">
           <ScoreGauge score={health.score} />
           <div>
-            <p className="text-xs uppercase tracking-wider opacity-70">Health Score</p>
+            <p className="text-xs uppercase tracking-wider opacity-70">{t("health.label")}</p>
             <p className="text-3xl font-bold">{health.score}/100</p>
             <p className="mt-1 text-xs opacity-70">
               {health.score >= 75
-                ? "Projeto saudável."
+                ? t("health.statusGood")
                 : health.score >= 50
-                  ? "Atenção em alguns pontos."
-                  : "Precisa de ajustes urgentes."}
+                  ? t("health.statusWarn")
+                  : t("health.statusBad")}
             </p>
           </div>
         </div>
@@ -190,10 +193,11 @@ function CashflowProjection({
   cashflow: MonthlyPoint[];
   worstBalance: number;
 }) {
+  const t = useTranslations("dashboard.insights");
   return (
     <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-zinc-100">Fluxo de caixa projetado</h3>
+        <h3 className="text-lg font-semibold text-zinc-100">{t("cashflow.title")}</h3>
         <span
           className={`rounded-full border px-2 py-0.5 text-xs ${
             worstBalance >= 0
@@ -201,16 +205,13 @@ function CashflowProjection({
               : "border-rose-500/30 bg-rose-500/10 text-rose-300"
           }`}
         >
-          Pior saldo: {formatCurrency(worstBalance)}
+          {t("cashflow.worstBalance", { value: formatCurrency(worstBalance) })}
         </span>
       </div>
-      <p className="mt-1 text-xs text-zinc-500">
-        Saldo cumulativo até o evento, considerando aportes existentes + receitas previstas −
-        pagamentos pendentes.
-      </p>
+      <p className="mt-1 text-xs text-zinc-500">{t("cashflow.description")}</p>
       <div className="mt-4 h-72 w-full">
         {cashflow.length === 0 ? (
-          <p className="py-10 text-center text-sm text-zinc-500">Sem dados ainda.</p>
+          <p className="py-10 text-center text-sm text-zinc-500">{t("noData")}</p>
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={cashflow}>
@@ -234,7 +235,10 @@ function CashflowProjection({
                   borderRadius: 12,
                   color: "#fff",
                 }}
-                formatter={(value, name) => [formatCurrency(Number(value)), labelForKey(String(name))]}
+                formatter={(value, name) => [
+                  formatCurrency(Number(value)),
+                  labelForKey(String(name), t),
+                ]}
               />
               <Area
                 type="monotone"
@@ -252,6 +256,7 @@ function CashflowProjection({
 }
 
 function WaterfallChart({ cashflow }: { cashflow: MonthlyPoint[] }) {
+  const t = useTranslations("dashboard.insights");
   const data = cashflow.map((c) => ({
     monthLabel: c.monthLabel,
     income: c.income,
@@ -262,13 +267,11 @@ function WaterfallChart({ cashflow }: { cashflow: MonthlyPoint[] }) {
 
   return (
     <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-      <h3 className="text-lg font-semibold text-zinc-100">Entradas e saídas por mês</h3>
-      <p className="mt-1 text-xs text-zinc-500">
-        Barras verdes = receitas. Barras vermelhas = pagamentos. Zona vermelha de fundo = saldo negativo projetado.
-      </p>
+      <h3 className="text-lg font-semibold text-zinc-100">{t("monthlyFlow.title")}</h3>
+      <p className="mt-1 text-xs text-zinc-500">{t("monthlyFlow.description")}</p>
       <div className="mt-4 h-72 w-full">
         {data.length === 0 ? (
-          <p className="py-10 text-center text-sm text-zinc-500">Sem dados ainda.</p>
+          <p className="py-10 text-center text-sm text-zinc-500">{t("noData")}</p>
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={data}>
@@ -286,7 +289,10 @@ function WaterfallChart({ cashflow }: { cashflow: MonthlyPoint[] }) {
                   borderRadius: 12,
                   color: "#fff",
                 }}
-                formatter={(value, name) => [formatCurrency(Math.abs(Number(value))), labelForKey(String(name))]}
+                formatter={(value, name) => [
+                  formatCurrency(Math.abs(Number(value))),
+                  labelForKey(String(name), t),
+                ]}
               />
               <Bar dataKey="income" stackId="flow" fill="#10b981" radius={[4, 4, 0, 0]}>
                 {data.map((_, i) => (
@@ -315,6 +321,7 @@ function WhatIfSimulator({
   cashflow: MonthlyPoint[];
   eventDate: Date;
 }) {
+  const t = useTranslations("dashboard.insights");
   const [amount, setAmount] = useState("");
   const [date, setDate] = useState("");
 
@@ -344,33 +351,41 @@ function WhatIfSimulator({
 
   return (
     <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-      <h3 className="text-lg font-semibold text-zinc-100">Posso fechar esse contrato agora?</h3>
+      <h3 className="text-lg font-semibold text-zinc-100">{t("whatIf.title")}</h3>
       <p className="mt-1 text-xs text-zinc-500">
-        Simule adicionar um pagamento futuro e veja o impacto no fluxo de caixa até{" "}
-        {formatDateBR(eventDate)}.
+        {t("whatIf.description", { date: formatDateBR(eventDate) })}
       </p>
       <div className="mt-4 grid gap-3 sm:grid-cols-3">
-        <Input label="Valor (R$)" type="number" step="0.01" value={amount} onChange={setAmount} />
-        <Input label="Data prevista" type="date" value={date} onChange={setDate} />
+        <Input
+          label={t("whatIf.amountLabel")}
+          type="number"
+          step="0.01"
+          value={amount}
+          onChange={setAmount}
+        />
+        <Input label={t("whatIf.dateLabel")} type="date" value={date} onChange={setDate} />
         <div className="flex items-end">
           {result ? (
             <ResultBadge tone={result.lowestAfter >= 0 ? "ok" : "bad"} />
           ) : (
-            <span className="text-xs text-zinc-500">Preencha valor e data</span>
+            <span className="text-xs text-zinc-500">{t("whatIf.fillPrompt")}</span>
           )}
         </div>
       </div>
 
       {result ? (
         <div className="mt-4 grid gap-3 sm:grid-cols-3">
-          <Stat label={`Saldo em ${result.monthLabel ?? "—"}`} value={formatCurrency(result.postBalance)} />
           <Stat
-            label="Pior saldo até o evento"
+            label={t("whatIf.balanceAt", { month: result.monthLabel ?? "—" })}
+            value={formatCurrency(result.postBalance)}
+          />
+          <Stat
+            label={t("whatIf.worstBalance")}
             value={formatCurrency(result.lowestAfter)}
             accent={result.lowestAfter >= 0 ? "emerald" : "rose"}
           />
           <Stat
-            label="Saldo final no evento"
+            label={t("whatIf.finalBalance")}
             value={formatCurrency(result.finalAfter)}
             accent={result.finalAfter >= 0 ? "emerald" : "rose"}
           />
@@ -381,30 +396,30 @@ function WhatIfSimulator({
 }
 
 function ResultBadge({ tone }: { tone: "ok" | "bad" }) {
+  const t = useTranslations("dashboard.insights");
   if (tone === "ok")
     return (
       <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-300">
-        <TrendingUp className="h-3 w-3" /> Pode fechar
+        <TrendingUp className="h-3 w-3" /> {t("whatIf.canAfford")}
       </span>
     );
   return (
     <span className="inline-flex items-center gap-1 rounded-full border border-rose-500/30 bg-rose-500/10 px-3 py-1 text-xs text-rose-300">
-      <TrendingDown className="h-3 w-3" /> Estoura o caixa
+      <TrendingDown className="h-3 w-3" /> {t("whatIf.exceedsCash")}
     </span>
   );
 }
 
 function CreepCard({ items }: { items: CategoryCreep[] }) {
+  const t = useTranslations("dashboard.insights");
   if (items.length === 0) return null;
   const positives = items.filter((i) => i.delta > 0);
   return (
     <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-      <h3 className="text-lg font-semibold text-zinc-100">Variação por categoria</h3>
-      <p className="mt-1 text-xs text-zinc-500">
-        Compara estimado vs contratado em cada categoria. Itens com aumento &gt; 10% precisam de atenção.
-      </p>
+      <h3 className="text-lg font-semibold text-zinc-100">{t("creep.title")}</h3>
+      <p className="mt-1 text-xs text-zinc-500">{t("creep.description")}</p>
       {positives.length === 0 ? (
-        <p className="mt-4 text-sm text-zinc-500">Nenhuma categoria está acima do estimado.</p>
+        <p className="mt-4 text-sm text-zinc-500">{t("creep.allWithinBudget")}</p>
       ) : null}
       <ul className="mt-4 space-y-2">
         {items.map((c) => {
@@ -434,8 +449,8 @@ function CreepCard({ items }: { items: CategoryCreep[] }) {
                 </span>
               </div>
               <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-400">
-                <span>Estimado: {formatCurrency(c.estimated)}</span>
-                <span>Contratado: {formatCurrency(c.actual)}</span>
+                <span>{t("creep.estimated", { value: formatCurrency(c.estimated) })}</span>
+                <span>{t("creep.contracted", { value: formatCurrency(c.actual) })}</span>
                 <span className={c.delta > 0 ? "text-rose-300" : "text-emerald-300"}>
                   {c.delta > 0 ? "+" : ""}
                   {formatCurrency(c.delta)}
@@ -458,14 +473,15 @@ function HeatmapCard({
   eventDate: Date;
   daysToEvent: number;
 }) {
+  const t = useTranslations("dashboard.insights");
   if (heatmap.length === 0) return null;
   const maxAmount = Math.max(...heatmap.map((c) => c.amount), 0);
 
   return (
     <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-      <h3 className="text-lg font-semibold text-zinc-100">Concentração de pagamentos pendentes</h3>
+      <h3 className="text-lg font-semibold text-zinc-100">{t("heatmap.title")}</h3>
       <p className="mt-1 text-xs text-zinc-500">
-        Até {formatDateBR(eventDate)} ({daysToEvent} dias). Quanto mais intenso, mais concentrado o dia.
+        {t("heatmap.description", { date: formatDateBR(eventDate), days: daysToEvent })}
       </p>
       <div className="mt-4 flex flex-wrap gap-1">
         {heatmap.map((c) => {
@@ -474,7 +490,11 @@ function HeatmapCard({
           return (
             <div
               key={c.date}
-              title={`${formatDateBR(c.date)} · ${formatCurrency(c.amount)} (${c.count} pagamento(s))`}
+              title={t("heatmap.cellTitle", {
+                date: formatDateBR(c.date),
+                value: formatCurrency(c.amount),
+                count: c.count,
+              })}
               className="h-7 w-7 rounded-md border border-zinc-800"
               style={{ background: `rgba(244, 63, 94, ${alpha})` }}
             />
@@ -531,9 +551,9 @@ function Input({
   );
 }
 
-function labelForKey(k: string): string {
-  if (k === "ending") return "Saldo final";
-  if (k === "income") return "Receitas";
-  if (k === "outflow") return "Pagamentos";
+function labelForKey(k: string, t: (key: string) => string): string {
+  if (k === "ending") return t("chartLegend.ending");
+  if (k === "income") return t("chartLegend.income");
+  if (k === "outflow") return t("chartLegend.outflow");
   return k;
 }

--- a/src/app/dashboard/insights/page.tsx
+++ b/src/app/dashboard/insights/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { getEventConfig, daysUntil } from "@/lib/event-config";
 import { resolveCategoryColor, resolveCategoryLabel } from "@/lib/categories";
@@ -18,6 +19,7 @@ export const dynamic = "force-dynamic";
 
 export default async function InsightsPage() {
   await requireFinanceAccess();
+  const t = await getTranslations("dashboard.insights");
 
   const cfg = await getEventConfig();
   if (!cfg.eventDate) redirect("/dashboard/onboarding");
@@ -130,10 +132,8 @@ export default async function InsightsPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Insights financeiros</h1>
-        <p className="text-sm text-zinc-500">
-          Projeção, saúde do projeto e detector de orçamento por categoria.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("header.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("header.subtitle")}</p>
       </div>
       <InsightsClient
         eventDate={eventDate}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
   Users,
   Wallet,
 } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { loadDashboardData } from "@/lib/reports/dashboard-data";
 import { canViewSensitiveFinance } from "@/lib/permissions";
@@ -31,14 +32,15 @@ export default async function DashboardPage() {
   const session = await auth();
   const role = (session?.user as { role?: string } | undefined)?.role;
   const finance = canViewSensitiveFinance(role);
+  const t = await getTranslations("dashboard.home");
 
   const data = await loadDashboardData(role);
 
   const subtitle = data.eventDate
     ? data.coupleNames
       ? `${data.coupleNames} · ${formatDateBR(data.eventDate)}`
-      : `Casamento em ${formatDateBR(data.eventDate)}`
-    : "Configure seu evento para começar";
+      : t("header.weddingOn", { date: formatDateBR(data.eventDate) })
+    : t("header.configurePrompt");
 
   const trendData = data.paidMonthly.map((m) => ({ label: m.label, value: m.value }));
 
@@ -57,7 +59,7 @@ export default async function DashboardPage() {
       <InstallPrompt />
       <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
         <div className="min-w-0">
-          <h1 className="text-2xl font-bold tracking-tight">Visão Geral</h1>
+          <h1 className="text-2xl font-bold tracking-tight">{t("header.title")}</h1>
           <p className="break-words text-sm text-zinc-500">{subtitle}</p>
         </div>
         {data.daysToEvent !== null ? <CountdownPill days={data.daysToEvent} /> : null}
@@ -71,11 +73,8 @@ export default async function DashboardPage() {
         >
           <Sparkles className="mt-0.5 h-5 w-5 shrink-0 text-rose-300" />
           <div>
-            <h3 className="font-semibold text-rose-100">Vamos configurar seu casamento?</h3>
-            <p className="mt-1 text-sm text-zinc-300">
-              Em menos de 2 minutos você define a data, os nomes do casal e como as
-              notificações vão funcionar. Clique aqui para iniciar o assistente.
-            </p>
+            <h3 className="font-semibold text-rose-100">{t("onboarding.title")}</h3>
+            <p className="mt-1 text-sm text-zinc-300">{t("onboarding.body")}</p>
           </div>
         </Link>
       ) : null}
@@ -84,10 +83,14 @@ export default async function DashboardPage() {
         <div className="flex items-center gap-3 rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-red-400 shadow-sm backdrop-blur-sm">
           <AlertCircle className="h-5 w-5" />
           <div>
-            <h3 className="font-semibold">Alerta de Quitação!</h3>
+            <h3 className="font-semibold">{t("quitAlert.title")}</h3>
             <p className="text-sm">
-              Faltam {data.daysToEvent} dia(s) e ainda há saldo devedor de{" "}
-              {finance ? formatCurrency(data.remainingBalance) : "valores pendentes"}.
+              {t("quitAlert.body", {
+                days: data.daysToEvent ?? 0,
+                balance: finance
+                  ? formatCurrency(data.remainingBalance)
+                  : t("quitAlert.pendingValues"),
+              })}
             </p>
           </div>
         </div>
@@ -97,68 +100,73 @@ export default async function DashboardPage() {
         {finance ? (
           <>
             <KpiCard
-              title="Orçamento Total"
+              title={t("kpi.totalBudget.title")}
               value={formatCurrency(data.totalBudget)}
               icon={<Wallet className="h-5 w-5" />}
-              hint={`Contingência: ${formatCurrency(data.contingencyFund)}`}
+              hint={t("kpi.totalBudget.hint", { value: formatCurrency(data.contingencyFund) })}
             />
             <KpiCard
-              title="Total Já Pago"
+              title={t("kpi.totalPaid.title")}
               value={formatCurrency(data.totalPaid)}
               icon={<CreditCard className="h-5 w-5" />}
               accent="emerald"
               trend={trendData}
-              hint={`${Math.round(data.paidPct * 100)}% do orçamento`}
+              hint={t("kpi.totalPaid.hint", { pct: Math.round(data.paidPct * 100) })}
             />
             <KpiCard
-              title="Saldo Devedor"
+              title={t("kpi.remainingBalance.title")}
               value={formatCurrency(data.remainingBalance)}
               icon={<TrendingDown className="h-5 w-5" />}
               accent="rose"
             />
             <KpiCard
-              title="Cobertura de Caixa"
+              title={t("kpi.cashCoverage.title")}
               value={formatCurrency(data.totalAssets)}
               icon={<Wallet className="h-5 w-5" />}
               accent="emerald"
               hint={
                 data.remainingBalance > 0
-                  ? `${Math.min(100, Math.round((data.totalAssets / data.remainingBalance) * 100))}% do saldo devedor`
-                  : "Saldo quitado"
+                  ? t("kpi.cashCoverage.hintPct", {
+                      pct: Math.min(100, Math.round((data.totalAssets / data.remainingBalance) * 100)),
+                    })
+                  : t("kpi.cashCoverage.hintPaid")
               }
             />
           </>
         ) : (
           <>
             <KpiCard
-              title="Fornecedores"
+              title={t("kpi.vendors.title")}
               value={`${data.vendorFunnel.CONTRACTED + data.vendorFunnel.FINALIZED}/${
                 data.vendorFunnel.NEGOTIATION + data.vendorFunnel.CONTRACTED + data.vendorFunnel.FINALIZED
               }`}
               icon={<Users className="h-5 w-5" />}
               accent="violet"
-              hint={`${Math.round(data.contractedPct * 100)}% contratados`}
+              hint={t("kpi.vendors.hint", { pct: Math.round(data.contractedPct * 100) })}
             />
             <KpiCard
-              title="Tarefas"
+              title={t("kpi.tasks.title")}
               value={`${data.tasksStats.done}/${data.tasksStats.total}`}
               icon={<CheckCircle2 className="h-5 w-5" />}
               accent="emerald"
               hint={
                 data.tasksStats.overdue > 0
-                  ? `${data.tasksStats.overdue} atrasada(s)`
-                  : "Tudo em dia"
+                  ? t("kpi.tasks.hintOverdue", { count: data.tasksStats.overdue })
+                  : t("kpi.tasks.hintUpToDate")
               }
             />
             <KpiCard
-              title="Convidados"
+              title={t("kpi.guests.title")}
               value={`${data.rsvp.confirmed}`}
               icon={<Users className="h-5 w-5" />}
               accent="emerald"
-              hint={`${data.guestsTotal} no total · ${data.rsvp.confirmed} confirmados`}
+              hint={t("kpi.guests.hint", {
+                total: data.guestsTotal,
+                confirmed: data.rsvp.confirmed,
+              })}
             />
             <KpiCard
-              title="Dias para o evento"
+              title={t("kpi.daysToEvent.title")}
               value={data.daysToEvent !== null ? String(data.daysToEvent) : "—"}
               icon={<CalendarHeart className="h-5 w-5" />}
               accent="rose"
@@ -173,10 +181,13 @@ export default async function DashboardPage() {
         <FunnelCard funnel={data.vendorFunnel} />
         {finance ? (
           <KpiCard
-            title="Resumo do Orçamento"
+            title={t("kpi.budgetSummary.title")}
             value={formatCurrency(data.totalBudget)}
             icon={<Wallet className="h-5 w-5" />}
-            hint={`Contratado: ${formatCurrency(data.totalContracted)} · Pago: ${formatCurrency(data.totalPaid)}`}
+            hint={t("kpi.budgetSummary.hint", {
+              contracted: formatCurrency(data.totalContracted),
+              paid: formatCurrency(data.totalPaid),
+            })}
             href="/dashboard/insights"
           />
         ) : (
@@ -189,7 +200,7 @@ export default async function DashboardPage() {
           <>
             <div className="flex flex-col rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm lg:max-h-[380px]">
               <div className="mb-3 flex shrink-0 items-center justify-between">
-                <h2 className="text-sm font-semibold text-zinc-200">Distribuição do Orçamento</h2>
+                <h2 className="text-sm font-semibold text-zinc-200">{t("budgetDistribution.title")}</h2>
                 <PieChartIcon className="h-4 w-4 text-zinc-500" />
               </div>
               <div className="h-[260px] lg:h-auto lg:min-h-0 lg:flex-1">
@@ -199,12 +210,12 @@ export default async function DashboardPage() {
 
             <div className="flex flex-col rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm lg:max-h-[380px]">
               <div className="mb-3 flex shrink-0 items-center justify-between">
-                <h2 className="text-sm font-semibold text-zinc-200">Próximos Vencimentos</h2>
+                <h2 className="text-sm font-semibold text-zinc-200">{t("upcomingPayments.title")}</h2>
                 <CalendarClock className="h-4 w-4 text-zinc-500" />
               </div>
               <div className="custom-scrollbar min-h-0 flex-1 space-y-3 overflow-y-auto pr-2">
                 {data.upcomingPayments.length === 0 ? (
-                  <p className="text-sm text-zinc-500">Nenhum pagamento para os próximos 30 dias.</p>
+                  <p className="text-sm text-zinc-500">{t("upcomingPayments.empty")}</p>
                 ) : (
                   data.upcomingPayments.map((p) => (
                     <div
@@ -214,7 +225,7 @@ export default async function DashboardPage() {
                       <div className="min-w-0 flex-1">
                         <p className="truncate font-medium text-zinc-200">{p.vendorName}</p>
                         <p className="mt-0.5 text-xs text-zinc-500">
-                          Venc.: {formatDateBR(p.dueDate)}
+                          {t("upcomingPayments.dueLabel", { date: formatDateBR(p.dueDate) })}
                         </p>
                       </div>
                       <span className="shrink-0 pl-3 font-semibold text-rose-400">{formatCurrency(p.amount)}</span>
@@ -257,17 +268,18 @@ export default async function DashboardPage() {
   );
 }
 
-function CountdownPill({ days }: { days: number }) {
+async function CountdownPill({ days }: { days: number }) {
+  const t = await getTranslations("dashboard.home");
   const status =
     days < 0
-      ? { text: "Evento já passou", tone: "bg-zinc-800 text-zinc-400 border-zinc-700" }
+      ? { text: t("countdown.past"), tone: "bg-zinc-800 text-zinc-400 border-zinc-700" }
       : days === 0
-        ? { text: "Hoje é o dia!", tone: "bg-rose-500/15 text-rose-300 border-rose-500/30" }
+        ? { text: t("countdown.today"), tone: "bg-rose-500/15 text-rose-300 border-rose-500/30" }
         : days <= 30
-          ? { text: `Faltam ${days} dias`, tone: "bg-rose-500/10 text-rose-300 border-rose-500/30" }
+          ? { text: t("countdown.remaining", { days }), tone: "bg-rose-500/10 text-rose-300 border-rose-500/30" }
           : days <= 90
-            ? { text: `Faltam ${days} dias`, tone: "bg-amber-500/10 text-amber-300 border-amber-500/30" }
-            : { text: `Faltam ${days} dias`, tone: "bg-emerald-500/10 text-emerald-300 border-emerald-500/30" };
+            ? { text: t("countdown.remaining", { days }), tone: "bg-amber-500/10 text-amber-300 border-amber-500/30" }
+            : { text: t("countdown.remaining", { days }), tone: "bg-emerald-500/10 text-emerald-300 border-emerald-500/30" };
 
   return (
     <span className={`inline-flex items-center gap-2 self-start rounded-full border px-3 py-1.5 text-sm font-medium ${status.tone}`}>

--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { requireFinanceAccess } from "@/lib/finance-access";
 import PaymentsClient from "./payments-client";
@@ -7,6 +8,7 @@ export const dynamic = "force-dynamic";
 
 export default async function PaymentsPage() {
   await requireFinanceAccess();
+  const t = await getTranslations("dashboard.payments");
 
   const [payments, vendors] = await Promise.all([
     prisma.payment.findMany({
@@ -23,7 +25,7 @@ export default async function PaymentsPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight text-white">Pagamentos</h1>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("title")}</h1>
       </div>
       <PaymentsClient payments={payments} vendors={vendors} />
     </div>

--- a/src/app/dashboard/payments/payments-calendar.tsx
+++ b/src/app/dashboard/payments/payments-calendar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   ArrowLeft,
   Calendar as CalendarIcon,
@@ -26,22 +27,15 @@ type Props = {
   onDelete: (payment: PaymentWithVendor) => void;
 };
 
-const MONTH_NAMES = [
-  "Janeiro",
-  "Fevereiro",
-  "Março",
-  "Abril",
-  "Maio",
-  "Junho",
-  "Julho",
-  "Agosto",
-  "Setembro",
-  "Outubro",
-  "Novembro",
-  "Dezembro",
-];
-
-const WEEKDAY_NAMES = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
+const WEEKDAY_KEYS = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+] as const;
 
 export default function PaymentsCalendar({
   payments,
@@ -50,6 +44,10 @@ export default function PaymentsCalendar({
   onEdit,
   onDelete,
 }: Props) {
+  const t = useTranslations("dashboard.payments");
+  const tc = useTranslations("common");
+  const monthName = (index: number) => t(`calendar.month.${index}`);
+  const weekdayNames = WEEKDAY_KEYS.map((k) => tc(`weekday.short.${k}`));
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
   const [selectedMonth, setSelectedMonth] = useState<number | null>(null);
   const [selectedDay, setSelectedDay] = useState<number | null>(null);
@@ -208,7 +206,12 @@ export default function PaymentsCalendar({
     return (
       <span
         className="font-medium text-rose-400"
-        title={`Base ${formatCurrency(adj.amount)} + multa ${formatCurrency(adj.lateFee)} + juros ${formatCurrency(adj.interest)} (${adj.lateDays} dia(s) em atraso)`}
+        title={t("amount.adjustedTooltip", {
+          base: formatCurrency(adj.amount),
+          lateFee: formatCurrency(adj.lateFee),
+          interest: formatCurrency(adj.interest),
+          days: adj.lateDays,
+        })}
       >
         <span className="text-zinc-500 line-through text-xs mr-1">{formatCurrency(adj.amount)}</span>{" "}
         <span>{formatCurrency(adj.adjusted)}</span>
@@ -233,13 +236,13 @@ export default function PaymentsCalendar({
               className="group flex items-center gap-1.5 rounded-xl border border-zinc-800 bg-zinc-950 px-3.5 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-900 transition-colors hover:text-white"
             >
               <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-0.5" />
-              <span>Visão Anual</span>
+              <span>{t("calendar.annualView")}</span>
             </button>
           )}
           <h2 className="text-xl font-bold text-white tracking-tight">
             {selectedMonth === null
-              ? `Calendário Financeiro de ${currentYear}`
-              : `${MONTH_NAMES[selectedMonth]} de ${currentYear}`}
+              ? t("calendar.yearTitle", { year: currentYear })
+              : t("calendar.monthTitle", { month: monthName(selectedMonth), year: currentYear })}
           </h2>
         </div>
 
@@ -250,7 +253,7 @@ export default function PaymentsCalendar({
               <button
                 onClick={handlePrevYear}
                 className="rounded-xl border border-zinc-800 bg-zinc-950 p-2 text-zinc-400 hover:bg-zinc-900 hover:text-white transition-colors"
-                aria-label="Ano anterior"
+                aria-label={t("calendar.prevYear")}
               >
                 <ChevronLeft className="h-4 w-4" />
               </button>
@@ -258,7 +261,7 @@ export default function PaymentsCalendar({
               <button
                 onClick={handleNextYear}
                 className="rounded-xl border border-zinc-800 bg-zinc-950 p-2 text-zinc-400 hover:bg-zinc-900 hover:text-white transition-colors"
-                aria-label="Próximo ano"
+                aria-label={t("calendar.nextYear")}
               >
                 <ChevronRight className="h-4 w-4" />
               </button>
@@ -268,17 +271,17 @@ export default function PaymentsCalendar({
               <button
                 onClick={handlePrevMonth}
                 className="rounded-xl border border-zinc-800 bg-zinc-950 p-2 text-zinc-400 hover:bg-zinc-900 hover:text-white transition-colors"
-                aria-label="Mês anterior"
+                aria-label={t("calendar.prevMonth")}
               >
                 <ChevronLeft className="h-4 w-4" />
               </button>
               <span className="px-3 text-sm font-semibold text-zinc-200">
-                {MONTH_NAMES[selectedMonth]}
+                {monthName(selectedMonth)}
               </span>
               <button
                 onClick={handleNextMonth}
                 className="rounded-xl border border-zinc-800 bg-zinc-950 p-2 text-zinc-400 hover:bg-zinc-900 hover:text-white transition-colors"
-                aria-label="Próximo mês"
+                aria-label={t("calendar.nextMonth")}
               >
                 <ChevronRight className="h-4 w-4" />
               </button>
@@ -305,12 +308,12 @@ export default function PaymentsCalendar({
                 <div className="flex items-start justify-between">
                   <div>
                     <h3 className="text-lg font-bold text-zinc-100 group-hover:text-rose-400 transition-colors">
-                      {MONTH_NAMES[monthIndex]}
+                      {monthName(monthIndex)}
                     </h3>
                     <p className="text-xs text-zinc-500">
                       {totalCount === 0
-                        ? "Sem gastos agendados"
-                        : `${totalCount} ${totalCount === 1 ? "pagamento" : "pagamentos"}`}
+                        ? t("calendar.noScheduled")
+                        : t("calendar.paymentCount", { count: totalCount })}
                     </p>
                   </div>
                   <CalendarIcon className="h-4 w-4 text-zinc-600 group-hover:text-rose-500/60 transition-colors" />
@@ -319,17 +322,17 @@ export default function PaymentsCalendar({
                 {/* Valores Resumidos */}
                 <div className="mt-5 space-y-1">
                   <div className="flex justify-between text-xs text-zinc-400">
-                    <span>Total Planejado:</span>
+                    <span>{t("calendar.totalPlanned")}</span>
                     <span className="font-semibold text-zinc-200">{formatCurrency(total)}</span>
                   </div>
                   {hasPayments && (
                     <>
                       <div className="flex justify-between text-[11px] text-zinc-500">
-                        <span>Pago ({paidCount}):</span>
+                        <span>{t("calendar.paidWithCount", { count: paidCount })}</span>
                         <span className="text-emerald-400">{formatCurrency(paid)}</span>
                       </div>
                       <div className="flex justify-between text-[11px] text-zinc-500">
-                        <span>Pendente ({pendingCount}):</span>
+                        <span>{t("calendar.pendingWithCount", { count: pendingCount })}</span>
                         <span className="text-amber-400">{formatCurrency(pending)}</span>
                       </div>
                     </>
@@ -346,8 +349,8 @@ export default function PaymentsCalendar({
                       />
                     </div>
                     <div className="flex justify-between text-[9px] text-zinc-500 font-mono">
-                      <span>PROGRESsO</span>
-                      <span>{Math.round(progress)}% pago</span>
+                      <span>{t("calendar.progress")}</span>
+                      <span>{t("calendar.percentPaid", { percent: Math.round(progress) })}</span>
                     </div>
                   </div>
                 )}
@@ -362,7 +365,7 @@ export default function PaymentsCalendar({
           <div className="rounded-2xl border border-zinc-800 bg-zinc-900/30 p-4 backdrop-blur-md shadow-xl">
             {/* Dias da Semana */}
             <div className="grid grid-cols-7 gap-1 text-center text-xs font-semibold uppercase tracking-wider text-zinc-500 pb-3 border-b border-zinc-800/50 mb-2">
-              {WEEKDAY_NAMES.map((name) => (
+              {weekdayNames.map((name) => (
                 <div key={name} className="py-1">
                   {name}
                 </div>
@@ -432,7 +435,7 @@ export default function PaymentsCalendar({
                       ))}
                       {dayPayments.length > 2 && (
                         <div className="text-center text-[9px] font-mono text-zinc-500 py-0.5">
-                          +{dayPayments.length - 2} outros
+                          {t("calendar.moreOthers", { count: dayPayments.length - 2 })}
                         </div>
                       )}
                     </div>
@@ -449,8 +452,8 @@ export default function PaymentsCalendar({
                 <TrendingUp className="h-4 w-4 text-rose-500" />
                 <span>
                   {selectedDay === null
-                    ? `Todos os Gastos de ${MONTH_NAMES[selectedMonth]}`
-                    : `Gastos de ${selectedDay} de ${MONTH_NAMES[selectedMonth]}`}
+                    ? t("calendar.allExpensesOf", { month: monthName(selectedMonth) })
+                    : t("calendar.expensesOfDay", { day: selectedDay, month: monthName(selectedMonth) })}
                 </span>
                 <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-xs text-zinc-400">
                   {detailedPayments.length}
@@ -461,7 +464,7 @@ export default function PaymentsCalendar({
                   onClick={() => setSelectedDay(null)}
                   className="text-xs text-rose-400 hover:text-rose-300 font-medium"
                 >
-                  Ver todos do mês
+                  {t("calendar.viewAllMonth")}
                 </button>
               )}
             </div>
@@ -472,19 +475,19 @@ export default function PaymentsCalendar({
                 <table className="w-full text-left text-sm text-zinc-400">
                   <thead className="border-b border-zinc-800 bg-zinc-950/40 text-xs uppercase tracking-wider text-zinc-500">
                     <tr>
-                      <th className="px-6 py-4 font-medium">Vencimento</th>
-                      <th className="px-6 py-4 font-medium">Fornecedor</th>
-                      <th className="px-6 py-4 font-medium">Valor</th>
-                      <th className="px-6 py-4 font-medium">Parcela</th>
-                      <th className="px-6 py-4 font-medium">Status</th>
-                      <th className="px-6 py-4 text-right font-medium">Ações</th>
+                      <th className="px-6 py-4 font-medium">{t("table.dueDate")}</th>
+                      <th className="px-6 py-4 font-medium">{t("table.vendor")}</th>
+                      <th className="px-6 py-4 font-medium">{tc("labels.amount")}</th>
+                      <th className="px-6 py-4 font-medium">{t("table.installment")}</th>
+                      <th className="px-6 py-4 font-medium">{tc("labels.status")}</th>
+                      <th className="px-6 py-4 text-right font-medium">{tc("labels.actions")}</th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-zinc-850">
                     {detailedPayments.length === 0 ? (
                       <tr>
                         <td colSpan={6} className="px-6 py-8 text-center text-zinc-500">
-                          Nenhum gasto registrado para este período.
+                          {t("calendar.noExpenses")}
                         </td>
                       </tr>
                     ) : (
@@ -515,7 +518,7 @@ export default function PaymentsCalendar({
                                   : "bg-amber-500/10 text-amber-400 border-amber-500/20"
                               }`}
                             >
-                              {payment.status === "PAID" ? "Pago" : "Pendente"}
+                              {payment.status === "PAID" ? tc("status.paid") : tc("status.pending")}
                             </span>
                           </td>
                           <td className="px-6 py-4">
@@ -525,27 +528,27 @@ export default function PaymentsCalendar({
                                   type="button"
                                   onClick={() => onMarkPaid(payment)}
                                   className="flex items-center gap-1 rounded-lg px-2.5 py-1 text-emerald-400 transition-colors hover:bg-emerald-500/10"
-                                  aria-label="Quitar"
+                                  aria-label={t("actions.markPaid")}
                                 >
                                   <CheckCircle2 className="h-4 w-4" />
-                                  <span className="text-xs font-semibold">Quitar</span>
+                                  <span className="text-xs font-semibold">{t("actions.markPaid")}</span>
                                 </button>
                               ) : (
                                 <button
                                   type="button"
                                   onClick={() => onUndoPaid(payment)}
                                   className="flex items-center gap-1 rounded-lg px-2.5 py-1 text-amber-400 transition-colors hover:bg-amber-500/10"
-                                  aria-label="Estornar"
+                                  aria-label={t("actions.revert")}
                                 >
                                   <RotateCcw className="h-4 w-4" />
-                                  <span className="text-xs font-semibold">Estornar</span>
+                                  <span className="text-xs font-semibold">{t("actions.revert")}</span>
                                 </button>
                               )}
                               <button
                                 type="button"
                                 onClick={() => onEdit(payment)}
                                 className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
-                                aria-label="Editar"
+                                aria-label={tc("actions.edit")}
                               >
                                 <Pencil className="h-4 w-4" />
                               </button>
@@ -553,7 +556,7 @@ export default function PaymentsCalendar({
                                 type="button"
                                 onClick={() => onDelete(payment)}
                                 className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-rose-500/10 hover:text-rose-400"
-                                aria-label="Excluir"
+                                aria-label={tc("actions.delete")}
                               >
                                 <Trash2 className="h-4 w-4" />
                               </button>

--- a/src/app/dashboard/payments/payments-client.tsx
+++ b/src/app/dashboard/payments/payments-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
 import {
   CheckCircle2,
   Layers,
@@ -35,15 +36,25 @@ type Props = {
   vendors: Vendor[];
 };
 
-const METHODS: { value: PaymentMethod; label: string }[] = [
-  { value: "PIX", label: "PIX" },
-  { value: "BOLETO", label: "Boleto" },
-  { value: "CREDIT", label: "Cartão de Crédito" },
-  { value: "TRANSFER", label: "Transferência" },
-  { value: "CASH", label: "Dinheiro" },
-];
+const METHOD_VALUES: PaymentMethod[] = ["PIX", "BOLETO", "CREDIT", "TRANSFER", "CASH"];
+
+type MethodTranslator = (key: string) => string;
+
+function MethodOptions({ t }: { t: MethodTranslator }) {
+  return (
+    <>
+      {METHOD_VALUES.map((value) => (
+        <option key={value} value={value}>
+          {t(`method.${value}`)}
+        </option>
+      ))}
+    </>
+  );
+}
 
 export default function PaymentsClient({ payments, vendors }: Props) {
+  const t = useTranslations("dashboard.payments");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [isCreateOpen, setCreateOpen] = useState(false);
   const [isInstallmentsOpen, setInstallmentsOpen] = useState(false);
@@ -65,11 +76,11 @@ export default function PaymentsClient({ payments, vendors }: Props) {
           ? await createSplitPayment(undefined, formData)
           : await createPayment(undefined, formData);
         if (r.success) {
-          toast.success(isSplit ? "Entrada e saldo registrados" : "Pagamento criado");
+          toast.success(isSplit ? t("toast.splitCreated") : t("toast.created"));
           setCreateOpen(false);
           setIsSplit(false);
         } else {
-          toast.error("Falha ao criar", r.error);
+          toast.error(t("toast.createFailed"), r.error);
         }
       } finally {
         setCreating(false);
@@ -83,10 +94,10 @@ export default function PaymentsClient({ payments, vendors }: Props) {
       try {
         const r = await updatePayment(undefined, formData);
         if (r.success) {
-          toast.success("Pagamento atualizado");
+          toast.success(t("toast.updated"));
           setEditing(null);
         } else {
-          toast.error("Falha ao atualizar", r.error);
+          toast.error(t("toast.updateFailed"), r.error);
         }
       } finally {
         setUpdating(false);
@@ -108,16 +119,16 @@ export default function PaymentsClient({ payments, vendors }: Props) {
   function handleMarkPaid(payment: PaymentWithVendor) {
     startTransition(async () => {
       const r = await markPaymentAsPaid(payment.id);
-      if (r.success) toast.success("Pagamento quitado");
-      else toast.error("Falha", r.error);
+      if (r.success) toast.success(t("toast.markedPaid"));
+      else toast.error(t("toast.genericFailed"), r.error);
     });
   }
 
   function handleUndo(payment: PaymentWithVendor) {
     startTransition(async () => {
       const r = await undoPaymentPaid(payment.id);
-      if (r.success) toast.success("Pagamento estornado");
-      else toast.error("Falha", r.error);
+      if (r.success) toast.success(t("toast.reverted"));
+      else toast.error(t("toast.genericFailed"), r.error);
     });
   }
 
@@ -127,10 +138,10 @@ export default function PaymentsClient({ payments, vendors }: Props) {
     startTransition(async () => {
       const r = await deletePayment(target.id);
       if (r.success) {
-        toast.success("Pagamento excluído");
+        toast.success(t("toast.deleted"));
         setDeleting(null);
       } else {
-        toast.error("Falha ao excluir", r.error);
+        toast.error(t("toast.deleteFailed"), r.error);
       }
     });
   }
@@ -150,7 +161,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                     setSearch(e.target.value);
                     setPage(1);
                   }}
-                  placeholder="Buscar por fornecedor..."
+                  placeholder={t("list.searchPlaceholder")}
                   className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
                 />
               </div>
@@ -162,9 +173,9 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                 }}
                 className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
               >
-                <option value="ALL">Todos os status</option>
-                <option value="PENDING">Pendente</option>
-                <option value="PAID">Pago</option>
+                <option value="ALL">{t("filter.allStatus")}</option>
+                <option value="PENDING">{tc("status.pending")}</option>
+                <option value="PAID">{tc("status.paid")}</option>
               </select>
             </>
           ) : (
@@ -182,7 +193,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                   : "text-zinc-400 hover:text-zinc-200"
               }`}
             >
-              Lista
+              {t("view.list")}
             </button>
             <button
               onClick={() => setViewMode("calendar")}
@@ -192,7 +203,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                   : "text-zinc-400 hover:text-zinc-200"
               }`}
             >
-              Calendário
+              {t("view.calendar")}
             </button>
           </div>
           <button
@@ -200,14 +211,14 @@ export default function PaymentsClient({ payments, vendors }: Props) {
             className="flex items-center justify-center gap-2 rounded-xl border border-zinc-700 px-3.5 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-800 transition-colors"
           >
             <Layers className="h-4 w-4" />
-            <span className="hidden md:inline">Gerar Parcelas</span>
+            <span className="hidden md:inline">{t("actions.generateInstallments")}</span>
           </button>
           <button
             onClick={() => setCreateOpen(true)}
             className="flex items-center justify-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-lg transition-colors hover:bg-rose-500"
           >
             <Plus className="h-4 w-4" />
-            <span className="hidden md:inline">Novo Pagamento</span>
+            <span className="hidden md:inline">{t("actions.new")}</span>
           </button>
         </div>
       </div>
@@ -219,20 +230,20 @@ export default function PaymentsClient({ payments, vendors }: Props) {
               <table className="w-full text-left text-sm text-zinc-400">
                 <thead className="border-b border-zinc-800 bg-zinc-900/80 text-xs uppercase text-zinc-500">
                   <tr>
-                    <th className="px-6 py-4 font-medium">Vencimento</th>
-                    <th className="px-6 py-4 font-medium">Fornecedor</th>
-                    <th className="px-6 py-4 font-medium">Valor</th>
-                    <th className="px-6 py-4 font-medium">Método</th>
-                    <th className="px-6 py-4 font-medium">Parcela</th>
-                    <th className="px-6 py-4 font-medium">Status</th>
-                    <th className="px-6 py-4 text-right font-medium">Ações</th>
+                    <th className="px-6 py-4 font-medium">{t("table.dueDate")}</th>
+                    <th className="px-6 py-4 font-medium">{t("table.vendor")}</th>
+                    <th className="px-6 py-4 font-medium">{tc("labels.amount")}</th>
+                    <th className="px-6 py-4 font-medium">{t("table.method")}</th>
+                    <th className="px-6 py-4 font-medium">{t("table.installment")}</th>
+                    <th className="px-6 py-4 font-medium">{tc("labels.status")}</th>
+                    <th className="px-6 py-4 text-right font-medium">{tc("labels.actions")}</th>
                   </tr>
                 </thead>
                 <tbody>
                   {filtered.length === 0 ? (
                     <tr>
                       <td colSpan={7} className="px-6 py-8 text-center text-zinc-500">
-                        {payments.length === 0 ? "Nenhum pagamento cadastrado." : "Nenhum resultado para o filtro."}
+                        {payments.length === 0 ? t("list.empty") : t("list.noResults")}
                       </td>
                     </tr>
                   ) : (
@@ -257,7 +268,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                                 : "bg-amber-500/10 text-amber-400 border-amber-500/20"
                             }`}
                           >
-                            {payment.status === "PAID" ? "Pago" : "Pendente"}
+                            {payment.status === "PAID" ? tc("status.paid") : tc("status.pending")}
                           </span>
                         </td>
                         <td className="px-6 py-4">
@@ -267,27 +278,27 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                                 type="button"
                                 onClick={() => handleMarkPaid(payment)}
                                 className="flex items-center gap-1 rounded-lg px-2 py-1 text-emerald-400 transition-colors hover:bg-emerald-500/10"
-                                aria-label="Quitar"
+                                aria-label={t("actions.markPaid")}
                               >
                                 <CheckCircle2 className="h-4 w-4" />
-                                <span className="text-xs">Quitar</span>
+                                <span className="text-xs">{t("actions.markPaid")}</span>
                               </button>
                             ) : (
                               <button
                                 type="button"
                                 onClick={() => handleUndo(payment)}
                                 className="flex items-center gap-1 rounded-lg px-2 py-1 text-amber-400 transition-colors hover:bg-amber-500/10"
-                                aria-label="Estornar"
+                                aria-label={t("actions.revert")}
                               >
                                 <RotateCcw className="h-4 w-4" />
-                                <span className="text-xs">Estornar</span>
+                                <span className="text-xs">{t("actions.revert")}</span>
                               </button>
                             )}
                             <button
                               type="button"
                               onClick={() => setEditing(payment)}
                               className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
-                              aria-label="Editar"
+                              aria-label={tc("actions.edit")}
                             >
                               <Pencil className="h-4 w-4" />
                             </button>
@@ -295,7 +306,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                               type="button"
                               onClick={() => setDeleting(payment)}
                               className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-rose-500/10 hover:text-rose-400"
-                              aria-label="Excluir"
+                              aria-label={tc("actions.delete")}
                             >
                               <Trash2 className="h-4 w-4" />
                             </button>
@@ -312,7 +323,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
           <div className="space-y-3 md:hidden">
             {filtered.length === 0 ? (
               <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-8 text-center text-sm text-zinc-500">
-                {payments.length === 0 ? "Nenhum pagamento cadastrado." : "Nenhum resultado para o filtro."}
+                {payments.length === 0 ? t("list.empty") : t("list.noResults")}
               </div>
             ) : (
               pageItems.map((payment) => (
@@ -320,7 +331,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
                       <p className="truncate font-semibold text-zinc-100">{payment.vendor.name}</p>
-                      <p className="mt-1 text-xs text-zinc-500">Vence em {formatDateBR(payment.dueDate)}</p>
+                      <p className="mt-1 text-xs text-zinc-500">{t("card.dueOn", { date: formatDateBR(payment.dueDate) })}</p>
                     </div>
                     <span
                       className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${
@@ -329,7 +340,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                           : "bg-amber-500/10 text-amber-400 border-amber-500/20"
                       }`}
                     >
-                      {payment.status === "PAID" ? "Pago" : "Pendente"}
+                      {payment.status === "PAID" ? tc("status.paid") : tc("status.pending")}
                     </span>
                   </div>
                   <div className="mt-3 flex items-end justify-between">
@@ -350,7 +361,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                           type="button"
                           onClick={() => handleMarkPaid(payment)}
                           className="rounded-lg bg-emerald-500/10 p-2 text-emerald-400"
-                          aria-label="Quitar"
+                          aria-label={t("actions.markPaid")}
                         >
                           <CheckCircle2 className="h-4 w-4" />
                         </button>
@@ -359,7 +370,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                           type="button"
                           onClick={() => handleUndo(payment)}
                           className="rounded-lg bg-amber-500/10 p-2 text-amber-400"
-                          aria-label="Estornar"
+                          aria-label={t("actions.revert")}
                         >
                           <RotateCcw className="h-4 w-4" />
                         </button>
@@ -368,7 +379,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                         type="button"
                         onClick={() => setEditing(payment)}
                         className="rounded-lg bg-zinc-800/60 p-2 text-zinc-300"
-                        aria-label="Editar"
+                        aria-label={tc("actions.edit")}
                       >
                         <Pencil className="h-4 w-4" />
                       </button>
@@ -376,7 +387,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                         type="button"
                         onClick={() => setDeleting(payment)}
                         className="rounded-lg bg-zinc-800/60 p-2 text-rose-400"
-                        aria-label="Excluir"
+                        aria-label={tc("actions.delete")}
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>
@@ -411,7 +422,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
           <div className="my-4 w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 shadow-2xl">
             <div className="p-6">
               <div className="mb-4 flex items-center justify-between">
-                <h2 className="text-xl font-bold text-white">Novo Pagamento</h2>
+                <h2 className="text-xl font-bold text-white">{t("form.createTitle")}</h2>
                 <label className="flex cursor-pointer items-center gap-2 text-sm text-zinc-400">
                   <input
                     type="checkbox"
@@ -419,19 +430,19 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                     onChange={(e) => setIsSplit(e.target.checked)}
                     className="accent-rose-500"
                   />
-                  <span>Entrada + Saldo</span>
+                  <span>{t("form.splitToggle")}</span>
                 </label>
               </div>
 
               <form action={handleCreate} className="space-y-4">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-zinc-400">Fornecedor</label>
+                  <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.vendor")}</label>
                   <select
                     name="vendorId"
                     required
                     className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
                   >
-                    <option value="">Selecione...</option>
+                    <option value="">{t("form.selectPlaceholder")}</option>
                     {vendors.map((v) => (
                       <option key={v.id} value={v.id}>
                         {v.name}
@@ -444,7 +455,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                   <>
                     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                       <div>
-                        <label className="mb-1 block text-sm font-medium text-zinc-400">Valor (R$)</label>
+                        <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.amount")}</label>
                         <input
                           type="number"
                           step="0.01"
@@ -454,7 +465,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                         />
                       </div>
                       <div>
-                        <label className="mb-1 block text-sm font-medium text-zinc-400">Vencimento</label>
+                        <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.dueDate")}</label>
                         <input
                           type="date"
                           name="dueDate"
@@ -465,34 +476,30 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                     </div>
                     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                       <div>
-                        <label className="mb-1 block text-sm font-medium text-zinc-400">Método</label>
+                        <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.method")}</label>
                         <select
                           name="method"
                           required
                           className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
                         >
-                          {METHODS.map((m) => (
-                            <option key={m.value} value={m.value}>
-                              {m.label}
-                            </option>
-                          ))}
+                          <MethodOptions t={t} />
                         </select>
                       </div>
                       <div>
-                        <label className="mb-1 block text-sm font-medium text-zinc-400">Status</label>
+                        <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.status")}</label>
                         <select
                           name="status"
                           defaultValue="PENDING"
                           className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
                         >
-                          <option value="PENDING">Pendente</option>
-                          <option value="PAID">Pago</option>
+                          <option value="PENDING">{tc("status.pending")}</option>
+                          <option value="PAID">{tc("status.paid")}</option>
                         </select>
                       </div>
                     </div>
                     <div>
                       <p className="mb-1 text-sm font-medium text-zinc-400">
-                        Parcelas <span className="text-xs text-zinc-500">(opcional)</span>
+                        {t("form.installments")} <span className="text-xs text-zinc-500">{tc("labels.optional")}</span>
                       </p>
                       <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
                         <input
@@ -500,29 +507,29 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                           name="installmentNumber"
                           min="1"
                           max="999"
-                          placeholder="ex: 1"
-                          aria-label="Número da parcela atual"
+                          placeholder={t("form.installmentNumberPlaceholder")}
+                          aria-label={t("form.installmentNumberLabel")}
                           className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
                         />
-                        <span className="text-zinc-500">de</span>
+                        <span className="text-zinc-500">{t("form.installmentOf")}</span>
                         <input
                           type="number"
                           name="totalInstallments"
                           min="1"
                           max="999"
-                          placeholder="ex: 12"
-                          aria-label="Total de parcelas"
+                          placeholder={t("form.totalInstallmentsPlaceholder")}
+                          aria-label={t("form.totalInstallmentsLabel")}
                           className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
                         />
                       </div>
                       <p className="mt-1 text-[11px] text-zinc-500">
-                        Deixe em branco para pagamento único.
+                        {t("form.installmentsHint")}
                       </p>
                     </div>
                     <div className="grid grid-cols-2 gap-3">
                       <div>
                         <label className="mb-1 block text-sm font-medium text-zinc-400">
-                          Multa (%) <span className="text-xs text-zinc-500">opcional</span>
+                          {t("form.lateFee")} <span className="text-xs text-zinc-500">{t("form.optionalShort")}</span>
                         </label>
                         <input
                           type="number"
@@ -530,13 +537,13 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                           min="0"
                           max="100"
                           name="lateFeePercent"
-                          placeholder="ex: 2"
+                          placeholder={t("form.lateFeePlaceholder")}
                           className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
                         />
                       </div>
                       <div>
                         <label className="mb-1 block text-sm font-medium text-zinc-400">
-                          Juros %/mês <span className="text-xs text-zinc-500">opcional</span>
+                          {t("form.interest")} <span className="text-xs text-zinc-500">{t("form.optionalShort")}</span>
                         </label>
                         <input
                           type="number"
@@ -544,7 +551,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                           min="0"
                           max="100"
                           name="interestPercentPerMonth"
-                          placeholder="ex: 1"
+                          placeholder={t("form.interestPlaceholder")}
                           className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
                         />
                       </div>
@@ -554,11 +561,11 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                   <>
                     <div className="space-y-3 rounded-lg border border-zinc-800 bg-zinc-950/50 p-3">
                       <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
-                        1. Entrada (paga hoje)
+                        {t("split.depositTitle")}
                       </h3>
                       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                         <div>
-                          <label className="mb-1 block text-sm font-medium text-zinc-400">Valor (R$)</label>
+                          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.amount")}</label>
                           <input
                             type="number"
                             step="0.01"
@@ -568,17 +575,13 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                           />
                         </div>
                         <div>
-                          <label className="mb-1 block text-sm font-medium text-zinc-400">Método</label>
+                          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.method")}</label>
                           <select
                             name="depositMethod"
                             required
                             className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2 text-zinc-200 outline-none focus:border-rose-500/50"
                           >
-                            {METHODS.map((m) => (
-                              <option key={m.value} value={m.value}>
-                                {m.label}
-                              </option>
-                            ))}
+                            <MethodOptions t={t} />
                           </select>
                         </div>
                       </div>
@@ -586,11 +589,11 @@ export default function PaymentsClient({ payments, vendors }: Props) {
 
                     <div className="space-y-3 rounded-lg border border-zinc-800 bg-zinc-950/50 p-3">
                       <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
-                        2. Saldo final (pendente)
+                        {t("split.balanceTitle")}
                       </h3>
                       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                         <div>
-                          <label className="mb-1 block text-sm font-medium text-zinc-400">Valor (R$)</label>
+                          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.amount")}</label>
                           <input
                             type="number"
                             step="0.01"
@@ -600,7 +603,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                           />
                         </div>
                         <div>
-                          <label className="mb-1 block text-sm font-medium text-zinc-400">Vencimento</label>
+                          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.dueDate")}</label>
                           <input
                             type="date"
                             name="finalDueDate"
@@ -610,17 +613,13 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                         </div>
                       </div>
                       <div>
-                        <label className="mb-1 block text-sm font-medium text-zinc-400">Método do saldo</label>
+                        <label className="mb-1 block text-sm font-medium text-zinc-400">{t("split.balanceMethod")}</label>
                         <select
                           name="finalMethod"
                           defaultValue="PIX"
                           className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2 text-zinc-200 outline-none focus:border-rose-500/50"
                         >
-                          {METHODS.map((m) => (
-                            <option key={m.value} value={m.value}>
-                              {m.label}
-                            </option>
-                          ))}
+                          <MethodOptions t={t} />
                         </select>
                       </div>
                     </div>
@@ -636,14 +635,14 @@ export default function PaymentsClient({ payments, vendors }: Props) {
                     }}
                     className="flex-1 rounded-xl bg-zinc-800 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
                   >
-                    Cancelar
+                    {tc("actions.cancel")}
                   </button>
                   <button
                     type="submit"
                     disabled={isCreating}
                     className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2.5 text-sm font-medium text-white transition-colors hover:bg-rose-500 disabled:opacity-50"
                   >
-                    {isCreating ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+                    {isCreating ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
                   </button>
                 </div>
               </form>
@@ -664,13 +663,16 @@ export default function PaymentsClient({ payments, vendors }: Props) {
 
       <ConfirmDialog
         open={!!deleting}
-        title="Excluir pagamento?"
+        title={t("delete.title")}
         description={
           deleting
-            ? `Pagamento de ${formatCurrency(deleting.amount)} para ${deleting.vendor.name}.\nEssa ação fará exclusão lógica e o registro sumirá das listagens.`
+            ? t("delete.description", {
+                amount: formatCurrency(deleting.amount),
+                vendor: deleting.vendor.name,
+              })
             : undefined
         }
-        confirmLabel="Excluir"
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
@@ -681,7 +683,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
           vendors={vendors}
           onClose={() => setInstallmentsOpen(false)}
           onSuccess={() => {
-            toast.success("Parcelas geradas");
+            toast.success(t("toast.installmentsGenerated"));
             setInstallmentsOpen(false);
             startTransition(() => {});
           }}
@@ -692,6 +694,7 @@ export default function PaymentsClient({ payments, vendors }: Props) {
 }
 
 function AmountCell({ payment }: { payment: PaymentWithVendor }) {
+  const t = useTranslations("dashboard.payments");
   const adj = computeAdjustedAmount({
     amount: payment.amount,
     dueDate: payment.dueDate,
@@ -706,7 +709,12 @@ function AmountCell({ payment }: { payment: PaymentWithVendor }) {
   return (
     <span
       className="font-medium text-rose-400"
-      title={`Base ${formatCurrency(adj.amount)} + multa ${formatCurrency(adj.lateFee)} + juros ${formatCurrency(adj.interest)} (${adj.lateDays} dia(s) em atraso)`}
+      title={t("amount.adjustedTooltip", {
+        base: formatCurrency(adj.amount),
+        lateFee: formatCurrency(adj.lateFee),
+        interest: formatCurrency(adj.interest),
+        days: adj.lateDays,
+      })}
     >
       <span className="text-zinc-500 line-through">{formatCurrency(adj.amount)}</span>{" "}
       <span>{formatCurrency(adj.adjusted)}</span>
@@ -726,6 +734,8 @@ function InstallmentsModal({
   onClose: () => void;
   onSuccess: () => void;
 }) {
+  const t = useTranslations("dashboard.payments");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [busy, setBusy] = useState(false);
   const [count, setCount] = useState(10);
@@ -757,7 +767,7 @@ function InstallmentsModal({
     });
     setBusy(false);
     if (!res.success) {
-      toast.error("Erro", res.error);
+      toast.error(tc("common.errorGeneric"), res.error);
       return;
     }
     startTransition(() => onSuccess());
@@ -774,12 +784,12 @@ function InstallmentsModal({
         onSubmit={submit}
         className="my-4 w-full max-w-md space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900 p-5"
       >
-        <h2 className="text-base font-semibold text-zinc-100">Gerar parcelas</h2>
+        <h2 className="text-base font-semibold text-zinc-100">{t("installmentsModal.title")}</h2>
         <p className="text-xs text-zinc-500">
-          Cria N pagamentos pendentes com intervalo fixo. Útil para contratos parcelados.
+          {t("installmentsModal.description")}
         </p>
         <label className="block space-y-1">
-          <span className="text-xs font-medium text-zinc-400">Fornecedor</span>
+          <span className="text-xs font-medium text-zinc-400">{t("form.vendor")}</span>
           <select
             value={vendorId}
             onChange={(e) => setVendorId(e.target.value)}
@@ -795,7 +805,7 @@ function InstallmentsModal({
         </label>
         <div className="grid grid-cols-2 gap-3">
           <label className="block space-y-1">
-            <span className="text-xs font-medium text-zinc-400">Valor total (R$)</span>
+            <span className="text-xs font-medium text-zinc-400">{t("installmentsModal.totalAmount")}</span>
             <input
               type="number"
               step="0.01"
@@ -807,7 +817,7 @@ function InstallmentsModal({
             />
           </label>
           <label className="block space-y-1">
-            <span className="text-xs font-medium text-zinc-400">Nº de parcelas</span>
+            <span className="text-xs font-medium text-zinc-400">{t("installmentsModal.count")}</span>
             <input
               type="number"
               min={1}
@@ -820,11 +830,11 @@ function InstallmentsModal({
           </label>
         </div>
         <p className="text-xs text-zinc-500">
-          Cada parcela: <strong className="text-zinc-200">{installmentValue}</strong>
+          {t("installmentsModal.eachInstallment")} <strong className="text-zinc-200">{installmentValue}</strong>
         </p>
         <div className="grid grid-cols-2 gap-3">
           <label className="block space-y-1">
-            <span className="text-xs font-medium text-zinc-400">1ª data</span>
+            <span className="text-xs font-medium text-zinc-400">{t("installmentsModal.firstDate")}</span>
             <input
               type="date"
               value={firstDueDate}
@@ -834,7 +844,7 @@ function InstallmentsModal({
             />
           </label>
           <label className="block space-y-1">
-            <span className="text-xs font-medium text-zinc-400">Intervalo (dias)</span>
+            <span className="text-xs font-medium text-zinc-400">{t("installmentsModal.intervalDays")}</span>
             <input
               type="number"
               min={1}
@@ -847,22 +857,18 @@ function InstallmentsModal({
           </label>
         </div>
         <label className="block space-y-1">
-          <span className="text-xs font-medium text-zinc-400">Método</span>
+          <span className="text-xs font-medium text-zinc-400">{t("form.method")}</span>
           <select
             value={method}
             onChange={(e) => setMethod(e.target.value as PaymentMethod)}
             className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100"
           >
-            {METHODS.map((m) => (
-              <option key={m.value} value={m.value}>
-                {m.label}
-              </option>
-            ))}
+            <MethodOptions t={t} />
           </select>
         </label>
         <div className="grid grid-cols-2 gap-3">
           <label className="block space-y-1">
-            <span className="text-xs font-medium text-zinc-400">Multa (%) opcional</span>
+            <span className="text-xs font-medium text-zinc-400">{t("installmentsModal.lateFee")}</span>
             <input
               type="number"
               step="0.1"
@@ -871,11 +877,11 @@ function InstallmentsModal({
               value={lateFeePercent}
               onChange={(e) => setLateFeePercent(e.target.value)}
               className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100"
-              placeholder="ex: 2"
+              placeholder={t("form.lateFeePlaceholder")}
             />
           </label>
           <label className="block space-y-1">
-            <span className="text-xs font-medium text-zinc-400">Juros %/mês opcional</span>
+            <span className="text-xs font-medium text-zinc-400">{t("installmentsModal.interest")}</span>
             <input
               type="number"
               step="0.1"
@@ -884,12 +890,12 @@ function InstallmentsModal({
               value={interestPercentPerMonth}
               onChange={(e) => setInterestPercentPerMonth(e.target.value)}
               className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100"
-              placeholder="ex: 1"
+              placeholder={t("form.interestPlaceholder")}
             />
           </label>
         </div>
         <label className="block space-y-1">
-          <span className="text-xs font-medium text-zinc-400">Notas</span>
+          <span className="text-xs font-medium text-zinc-400">{t("form.notes")}</span>
           <textarea
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
@@ -905,14 +911,14 @@ function InstallmentsModal({
             disabled={busy}
             className="rounded-lg px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
           >
-            Cancelar
+            {tc("actions.cancel")}
           </button>
           <button
             type="submit"
             disabled={busy}
             className="rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-60"
           >
-            {busy ? "Gerando..." : `Gerar ${count} parcelas`}
+            {busy ? t("installmentsModal.generating") : t("installmentsModal.generateButton", { count })}
           </button>
         </div>
       </form>
@@ -933,15 +939,17 @@ function EditPaymentModal({
   formAction: (formData: FormData) => void;
   onClose: () => void;
 }) {
+  const t = useTranslations("dashboard.payments");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 shadow-2xl">
         <form action={formAction} className="space-y-4 p-6">
-          <h2 className="text-xl font-bold text-white">Editar pagamento</h2>
+          <h2 className="text-xl font-bold text-white">{t("form.editTitle")}</h2>
           <input type="hidden" name="id" value={payment.id} />
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Fornecedor</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.vendor")}</label>
             <select
               name="vendorId"
               defaultValue={payment.vendorId}
@@ -961,7 +969,7 @@ function EditPaymentModal({
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Valor (R$)</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.amount")}</label>
               <input
                 type="number"
                 step="0.01"
@@ -972,7 +980,7 @@ function EditPaymentModal({
               />
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Vencimento</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.dueDate")}</label>
               <input
                 type="date"
                 name="dueDate"
@@ -985,36 +993,32 @@ function EditPaymentModal({
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Método</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.method")}</label>
               <select
                 name="method"
                 defaultValue={payment.method ?? "PIX"}
                 required
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
               >
-                {METHODS.map((m) => (
-                  <option key={m.value} value={m.value}>
-                    {m.label}
-                  </option>
-                ))}
+                <MethodOptions t={t} />
               </select>
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Status</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.status")}</label>
               <select
                 name="status"
                 defaultValue={payment.status}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
               >
-                <option value="PENDING">Pendente</option>
-                <option value="PAID">Pago</option>
+                <option value="PENDING">{tc("status.pending")}</option>
+                <option value="PAID">{tc("status.paid")}</option>
               </select>
             </div>
           </div>
 
           <div>
             <p className="mb-1 text-sm font-medium text-zinc-400">
-              Parcelas <span className="text-xs text-zinc-500">(opcional)</span>
+              {t("form.installments")} <span className="text-xs text-zinc-500">{tc("labels.optional")}</span>
             </p>
             <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
               <input
@@ -1022,20 +1026,20 @@ function EditPaymentModal({
                 name="installmentNumber"
                 min="1"
                 max="999"
-                placeholder="ex: 1"
+                placeholder={t("form.installmentNumberPlaceholder")}
                 defaultValue={payment.installmentNumber ?? ""}
-                aria-label="Número da parcela atual"
+                aria-label={t("form.installmentNumberLabel")}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
               />
-              <span className="text-zinc-500">de</span>
+              <span className="text-zinc-500">{t("form.installmentOf")}</span>
               <input
                 type="number"
                 name="totalInstallments"
                 min="1"
                 max="999"
-                placeholder="ex: 12"
+                placeholder={t("form.totalInstallmentsPlaceholder")}
                 defaultValue={payment.totalInstallments ?? ""}
-                aria-label="Total de parcelas"
+                aria-label={t("form.totalInstallmentsLabel")}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
               />
             </div>
@@ -1044,7 +1048,7 @@ function EditPaymentModal({
           <div className="grid grid-cols-2 gap-3">
             <div>
               <label className="mb-1 block text-sm font-medium text-zinc-400">
-                Multa (%) <span className="text-xs text-zinc-500">opcional</span>
+                {t("form.lateFee")} <span className="text-xs text-zinc-500">{t("form.optionalShort")}</span>
               </label>
               <input
                 type="number"
@@ -1053,13 +1057,13 @@ function EditPaymentModal({
                 max="100"
                 name="lateFeePercent"
                 defaultValue={payment.lateFeePercent ?? ""}
-                placeholder="ex: 2"
+                placeholder={t("form.lateFeePlaceholder")}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
               />
             </div>
             <div>
               <label className="mb-1 block text-sm font-medium text-zinc-400">
-                Juros %/mês <span className="text-xs text-zinc-500">opcional</span>
+                {t("form.interest")} <span className="text-xs text-zinc-500">{t("form.optionalShort")}</span>
               </label>
               <input
                 type="number"
@@ -1068,14 +1072,14 @@ function EditPaymentModal({
                 max="100"
                 name="interestPercentPerMonth"
                 defaultValue={payment.interestPercentPerMonth ?? ""}
-                placeholder="ex: 1"
+                placeholder={t("form.interestPlaceholder")}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
               />
             </div>
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.notes")}</label>
             <textarea
               name="notes"
               rows={2}
@@ -1091,14 +1095,14 @@ function EditPaymentModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2.5 text-sm font-medium text-white transition-colors hover:bg-rose-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/reports/activity/page.tsx
+++ b/src/app/dashboard/reports/activity/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ChevronLeft, Activity } from "lucide-react";
 import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { canManageUsers } from "@/lib/permissions";
@@ -8,57 +9,63 @@ import { formatDateTimeBR } from "@/lib/format";
 
 export const dynamic = "force-dynamic";
 
-const ACTION_LABEL: Record<string, string> = {
-  CREATE: "criou",
-  UPDATE: "atualizou",
-  DELETE: "removeu",
-  RESTORE: "restaurou",
-  MARK_PAID: "marcou como pago",
-  UNDO_PAID: "desfez pagamento",
-  STATUS_CHANGE: "mudou status",
-  UPLOAD: "fez upload",
-  DOWNLOAD: "baixou",
-  REPLACE: "substituiu",
-  SIGN: "assinou",
-  ARCHIVE: "arquivou",
-  RESET_PASSWORD: "redefiniu senha",
-  RESET_2FA: "removeu 2FA",
-  CHANGE_OWN_PASSWORD: "trocou própria senha",
-  LOGIN: "fez login",
-  BULK_CREATE: "criou em massa",
-  ASSIGN_TABLE: "atribuiu mesa",
-  UNASSIGN_TABLE: "removeu de mesa",
-  RSVP_GROUP_RESPOND: "respondeu RSVP em grupo",
-  MARK_PIX_RECEIVED: "marcou PIX recebido",
-  ONBOARDING_COUPLE: "completou etapa do casal",
-  ONBOARDING_BUDGET: "completou etapa do orçamento",
-  ONBOARDING_FINISH: "finalizou onboarding",
-};
+const ACTION_KEYS = new Set([
+  "CREATE",
+  "UPDATE",
+  "DELETE",
+  "RESTORE",
+  "MARK_PAID",
+  "UNDO_PAID",
+  "STATUS_CHANGE",
+  "UPLOAD",
+  "DOWNLOAD",
+  "REPLACE",
+  "SIGN",
+  "ARCHIVE",
+  "RESET_PASSWORD",
+  "RESET_2FA",
+  "CHANGE_OWN_PASSWORD",
+  "LOGIN",
+  "BULK_CREATE",
+  "ASSIGN_TABLE",
+  "UNASSIGN_TABLE",
+  "RSVP_GROUP_RESPOND",
+  "MARK_PIX_RECEIVED",
+  "ONBOARDING_COUPLE",
+  "ONBOARDING_BUDGET",
+  "ONBOARDING_FINISH",
+]);
 
-const ENTITY_LABEL: Record<string, string> = {
-  Vendor: "fornecedor",
-  Payment: "pagamento",
-  BudgetItem: "item de orçamento",
-  Asset: "ativo",
-  EventSettings: "configurações do evento",
-  User: "usuário",
-  SecuritySettings: "configurações de segurança",
-  SeatingTable: "mesa",
-  Guest: "convidado",
-  GuestGroup: "grupo de convidados",
-  Gift: "presente",
-  Contract: "contrato",
-  Attachment: "anexo",
-};
+const ENTITY_KEYS = new Set([
+  "Vendor",
+  "Payment",
+  "BudgetItem",
+  "Asset",
+  "EventSettings",
+  "User",
+  "SecuritySettings",
+  "SeatingTable",
+  "Guest",
+  "GuestGroup",
+  "Gift",
+  "Contract",
+  "Attachment",
+]);
 
 type SearchParams = Promise<{ entity?: string }>;
 
 export default async function AuditTimelinePage({ searchParams }: { searchParams: SearchParams }) {
   const session = await auth();
+  const t = await getTranslations("dashboard.reports.activity");
   const role = (session?.user as { role?: string } | undefined)?.role;
   if (!canManageUsers(role)) {
     redirect("/dashboard/reports");
   }
+
+  const actionLabel = (action: string) =>
+    ACTION_KEYS.has(action) ? t(`action.${action}`) : action.toLowerCase();
+  const entityLabel = (entity: string) =>
+    ENTITY_KEYS.has(entity) ? t(`entity.${entity}`) : entity;
 
   const params = await searchParams;
   const entityFilter = params?.entity?.trim() || null;
@@ -89,12 +96,10 @@ export default async function AuditTimelinePage({ searchParams }: { searchParams
           className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
         >
           <ChevronLeft className="h-3 w-3" />
-          Voltar para relatórios
+          {t("back")}
         </Link>
-        <h1 className="mt-2 text-2xl font-bold tracking-tight">Timeline de Atividade</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Últimas 100 alterações registradas no sistema. Filtre por entidade abaixo.
-        </p>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="mt-1 text-sm text-zinc-500">{t("subtitle")}</p>
       </div>
 
       <div className="flex flex-wrap gap-2">
@@ -106,7 +111,7 @@ export default async function AuditTimelinePage({ searchParams }: { searchParams
               : "border-zinc-700 bg-zinc-800/50 text-zinc-400 hover:text-zinc-200"
           }`}
         >
-          Todas
+          {t("filterAll")}
         </Link>
         {entities.map((e) => (
           <Link
@@ -118,7 +123,7 @@ export default async function AuditTimelinePage({ searchParams }: { searchParams
                 : "border-zinc-700 bg-zinc-800/50 text-zinc-400 hover:text-zinc-200"
             }`}
           >
-            {ENTITY_LABEL[e] ?? e}
+            {entityLabel(e)}
           </Link>
         ))}
       </div>
@@ -126,7 +131,7 @@ export default async function AuditTimelinePage({ searchParams }: { searchParams
       <ol className="space-y-3">
         {logs.length === 0 ? (
           <li className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 text-center text-sm text-zinc-500">
-            Sem registros de auditoria ainda.
+            {t("empty")}
           </li>
         ) : (
           logs.map((log) => {
@@ -139,11 +144,9 @@ export default async function AuditTimelinePage({ searchParams }: { searchParams
                 <Activity className="mt-0.5 h-4 w-4 shrink-0 text-zinc-500" />
                 <div className="min-w-0 flex-1">
                   <p className="text-sm text-zinc-200">
-                    <span className="font-semibold">{user?.name || user?.email || "Sistema"}</span>{" "}
-                    {ACTION_LABEL[log.action] ?? log.action.toLowerCase()}{" "}
-                    <span className="text-zinc-400">
-                      {ENTITY_LABEL[log.entity] ?? log.entity}
-                    </span>{" "}
+                    <span className="font-semibold">{user?.name || user?.email || t("systemActor")}</span>{" "}
+                    {actionLabel(log.action)}{" "}
+                    <span className="text-zinc-400">{entityLabel(log.entity)}</span>{" "}
                     <span className="text-xs text-zinc-500">#{log.entityId.slice(0, 8)}</span>
                   </p>
                   <p className="mt-1 text-xs text-zinc-500">{formatDateTimeBR(log.createdAt)}</p>

--- a/src/app/dashboard/reports/gifts/gifts-report-client.tsx
+++ b/src/app/dashboard/reports/gifts/gifts-report-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   LineChart,
   Line,
@@ -26,53 +27,54 @@ export function GiftsReportClient({
   result: GiftsAnalytics;
   showFinance: boolean;
 }) {
+  const t = useTranslations("dashboard.reports.gifts");
   const typeDonut: DonutDatum[] = [
-    { name: "Dinheiro", value: result.byType.cash, color: "#22c55e" },
-    { name: "Itens", value: result.byType.item, color: "#8b5cf6" },
+    { name: t("type.cash"), value: result.byType.cash, color: "#22c55e" },
+    { name: t("type.item"), value: result.byType.item, color: "#8b5cf6" },
   ].filter((d) => d.value > 0);
 
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
-        <Tile label="Presentes" value={result.totalCount} />
+        <Tile label={t("tiles.count")} value={result.totalCount} />
         {showFinance ? (
-          <Tile label="Total em dinheiro" value={formatCurrency(result.totalCash)} color="text-emerald-400" />
+          <Tile label={t("tiles.totalCash")} value={formatCurrency(result.totalCash)} color="text-emerald-400" />
         ) : (
-          <Tile label="Em dinheiro" value={`${result.byType.cash}`} color="text-emerald-400" />
+          <Tile label={t("tiles.cashCount")} value={`${result.byType.cash}`} color="text-emerald-400" />
         )}
         <Tile
-          label="Agradecidos"
+          label={t("tiles.thanked")}
           value={`${Math.round(result.thankedPct * 100)}%`}
           color="text-zinc-100"
-          sub={`${result.thankedCount} de ${result.totalCount}`}
+          sub={t("tiles.thankedSub", { count: result.thankedCount, total: result.totalCount })}
         />
         {showFinance ? (
           <Tile
-            label="Lua de mel (PIX)"
+            label={t("tiles.honeymoon")}
             value={formatCurrency(result.honeymoonShareTotal)}
             color="text-violet-400"
-            sub={`${result.honeymoonShareCount} contribuição(ões)`}
+            sub={t("tiles.contributions", { count: result.honeymoonShareCount })}
           />
         ) : (
           <Tile
-            label="Lua de mel (PIX)"
+            label={t("tiles.honeymoon")}
             value={`${result.honeymoonShareCount}`}
             color="text-violet-400"
-            sub="contribuições"
+            sub={t("tiles.contributionsShort")}
           />
         )}
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-semibold text-zinc-100">Distribuição (CASH × ITEM)</h2>
-          <Donut data={typeDonut} valueFormatter={(n) => `${n} presente(s)`} />
+          <h2 className="mb-4 text-lg font-semibold text-zinc-100">{t("distribution.title")}</h2>
+          <Donut data={typeDonut} valueFormatter={(n) => t("distribution.giftCount", { count: n })} />
         </div>
 
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-semibold text-zinc-100">Captação cumulativa</h2>
+          <h2 className="mb-4 text-lg font-semibold text-zinc-100">{t("cumulative.title")}</h2>
           {result.weeklyAccum.length === 0 ? (
-            <p className="text-sm text-zinc-500">Sem dados de recebimento.</p>
+            <p className="text-sm text-zinc-500">{t("cumulative.empty")}</p>
           ) : (
             <div className="h-[260px] w-full">
               <ResponsiveContainer width="100%" height="100%">
@@ -89,7 +91,7 @@ export function GiftsReportClient({
                     itemStyle={{ color: "#fff" }}
                     formatter={(v, name) => {
                       const isCumulative = name === "cumulative";
-                      const label = isCumulative ? "Acumulado (R$)" : "Quantidade";
+                      const label = isCumulative ? t("cumulative.legendAmount") : t("cumulative.legendCount");
                       const display =
                         isCumulative && showFinance ? formatCurrency(Number(v ?? 0)) : String(v ?? 0);
                       return [display, label];
@@ -121,9 +123,9 @@ export function GiftsReportClient({
       </div>
 
       <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-        <h2 className="mb-4 text-lg font-semibold text-zinc-100">Top givers</h2>
+        <h2 className="mb-4 text-lg font-semibold text-zinc-100">{t("topGivers.title")}</h2>
         {result.topGivers.length === 0 ? (
-          <p className="text-sm text-zinc-500">Sem presentes registrados.</p>
+          <p className="text-sm text-zinc-500">{t("topGivers.empty")}</p>
         ) : (
           <ul className="space-y-2">
             {result.topGivers.map((g, i) => (
@@ -136,7 +138,7 @@ export function GiftsReportClient({
                   {g.name}
                 </span>
                 <span className="flex items-center gap-3">
-                  <span className="text-xs text-zinc-500">{g.count} presente(s)</span>
+                  <span className="text-xs text-zinc-500">{t("topGivers.giftCount", { count: g.count })}</span>
                   {showFinance && g.total > 0 ? (
                     <span className="font-semibold text-emerald-300">{formatCurrency(g.total)}</span>
                   ) : null}

--- a/src/app/dashboard/reports/gifts/page.tsx
+++ b/src/app/dashboard/reports/gifts/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { canViewSensitiveFinance } from "@/lib/permissions";
@@ -10,6 +11,7 @@ export const dynamic = "force-dynamic";
 
 export default async function GiftsReportPage() {
   const session = await auth();
+  const t = await getTranslations("dashboard.reports.gifts");
   const role = (session?.user as { role?: string } | undefined)?.role;
   const finance = canViewSensitiveFinance(role);
 
@@ -39,13 +41,10 @@ export default async function GiftsReportPage() {
           className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
         >
           <ChevronLeft className="h-3 w-3" />
-          Voltar para relatórios
+          {t("back")}
         </Link>
-        <h1 className="mt-2 text-2xl font-bold tracking-tight">Presentes</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Análise de presentes recebidos: dinheiro vs itens, agradecimentos pendentes,
-          cota da lua de mel e top givers.
-        </p>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="mt-1 text-sm text-zinc-500">{t("subtitle")}</p>
       </div>
 
       <GiftsReportClient result={result} showFinance={finance} />

--- a/src/app/dashboard/reports/guests/guests-report-client.tsx
+++ b/src/app/dashboard/reports/guests/guests-report-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Donut, type DonutDatum } from "@/components/charts/donut";
 import { StackedBar, type StackSeries } from "@/components/charts/stacked-bar";
 import type { GuestsAnalytics } from "@/lib/reports/guests-analytics";
@@ -11,19 +12,21 @@ const RSVP_COLORS: Record<string, string> = {
   INVITED: "#71717a",
 };
 
-const STACK_SERIES: StackSeries[] = [
-  { key: "CONFIRMED", label: "Confirmados", color: "#22c55e" },
-  { key: "MAYBE", label: "Talvez", color: "#f59e0b" },
-  { key: "INVITED", label: "Pendentes", color: "#71717a" },
-  { key: "DECLINED", label: "Recusas", color: "#f43f5e" },
-];
-
 export function GuestsReportClient({ result }: { result: GuestsAnalytics }) {
+  const t = useTranslations("dashboard.reports.guests");
+
+  const STACK_SERIES: StackSeries[] = [
+    { key: "CONFIRMED", label: t("status.confirmed"), color: "#22c55e" },
+    { key: "MAYBE", label: t("status.maybe"), color: "#f59e0b" },
+    { key: "INVITED", label: t("status.pending"), color: "#71717a" },
+    { key: "DECLINED", label: t("status.declined"), color: "#f43f5e" },
+  ];
+
   const donutData: DonutDatum[] = [
-    { name: "Confirmados", value: result.byStatus.CONFIRMED, color: RSVP_COLORS.CONFIRMED },
-    { name: "Talvez", value: result.byStatus.MAYBE, color: RSVP_COLORS.MAYBE },
-    { name: "Recusas", value: result.byStatus.DECLINED, color: RSVP_COLORS.DECLINED },
-    { name: "Pendentes", value: result.byStatus.INVITED, color: RSVP_COLORS.INVITED },
+    { name: t("status.confirmed"), value: result.byStatus.CONFIRMED, color: RSVP_COLORS.CONFIRMED },
+    { name: t("status.maybe"), value: result.byStatus.MAYBE, color: RSVP_COLORS.MAYBE },
+    { name: t("status.declined"), value: result.byStatus.DECLINED, color: RSVP_COLORS.DECLINED },
+    { name: t("status.pending"), value: result.byStatus.INVITED, color: RSVP_COLORS.INVITED },
   ].filter((d) => d.value > 0);
 
   const groupData = result.byGroup.map((g) => ({
@@ -37,23 +40,24 @@ export function GuestsReportClient({ result }: { result: GuestsAnalytics }) {
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
-        <Tile label="Convidados" value={result.totalInvited} />
-        <Tile label="Confirmados" value={result.totalConfirmed} color="text-emerald-400" />
-        <Tile label="+ Acompanhantes" value={result.plusOnesConfirmed} color="text-violet-400" />
-        <Tile label="Crianças" value={result.children} />
+        <Tile label={t("tiles.invited")} value={result.totalInvited} />
+        <Tile label={t("tiles.confirmed")} value={result.totalConfirmed} color="text-emerald-400" />
+        <Tile label={t("tiles.plusOnes")} value={result.plusOnesConfirmed} color="text-violet-400" />
+        <Tile label={t("tiles.children")} value={result.children} />
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-semibold text-zinc-100">Status do RSVP</h2>
-          <Donut data={donutData} valueFormatter={(n) => `${n} pessoa(s)`} />
+          <h2 className="mb-4 text-lg font-semibold text-zinc-100">{t("rsvp.title")}</h2>
+          <Donut data={donutData} valueFormatter={(n) => t("rsvp.peopleCount", { count: n })} />
           <p className="mt-2 text-center text-xs text-zinc-500">
-            Total efetivo (com +1s): <span className="font-semibold text-zinc-200">{result.effectiveConfirmed}</span>
+            {t("rsvp.effectiveLabel")}{" "}
+            <span className="font-semibold text-zinc-200">{result.effectiveConfirmed}</span>
           </p>
         </div>
 
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-semibold text-zinc-100">Por grupo</h2>
+          <h2 className="mb-4 text-lg font-semibold text-zinc-100">{t("byGroup.title")}</h2>
           {groupData.length > 0 ? (
             <StackedBar
               data={groupData}
@@ -62,24 +66,24 @@ export function GuestsReportClient({ result }: { result: GuestsAnalytics }) {
               height={Math.max(220, groupData.length * 36 + 60)}
             />
           ) : (
-            <p className="text-sm text-zinc-500">Nenhum grupo de convidados cadastrado.</p>
+            <p className="text-sm text-zinc-500">{t("byGroup.empty")}</p>
           )}
         </div>
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-semibold text-zinc-100">VIPs & Padrinhos</h2>
+          <h2 className="mb-4 text-lg font-semibold text-zinc-100">{t("vips.title")}</h2>
           <div className="grid grid-cols-2 gap-4">
-            <Tile label="VIPs confirmados" value={result.vipsConfirmed} color="text-amber-400" />
-            <Tile label="Padrinhos confirmados" value={result.padrinhosConfirmed} color="text-violet-400" />
+            <Tile label={t("vips.vipsConfirmed")} value={result.vipsConfirmed} color="text-amber-400" />
+            <Tile label={t("vips.padrinhosConfirmed")} value={result.padrinhosConfirmed} color="text-violet-400" />
           </div>
         </div>
 
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-semibold text-zinc-100">Top cidades</h2>
+          <h2 className="mb-4 text-lg font-semibold text-zinc-100">{t("cities.title")}</h2>
           {result.byCity.length === 0 ? (
-            <p className="text-sm text-zinc-500">Nenhuma cidade informada.</p>
+            <p className="text-sm text-zinc-500">{t("cities.empty")}</p>
           ) : (
             <ul className="space-y-2">
               {result.byCity.slice(0, 8).map((c) => (

--- a/src/app/dashboard/reports/guests/page.tsx
+++ b/src/app/dashboard/reports/guests/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { buildGuestsAnalytics } from "@/lib/reports/guests-analytics";
 import { GuestsReportClient } from "./guests-report-client";
@@ -7,6 +8,7 @@ import { GuestsReportClient } from "./guests-report-client";
 export const dynamic = "force-dynamic";
 
 export default async function GuestsReportPage() {
+  const t = await getTranslations("dashboard.reports.guests");
   const [guests, groups] = await Promise.all([
     prisma.guest.findMany({
       where: { deletedAt: null },
@@ -37,12 +39,10 @@ export default async function GuestsReportPage() {
           className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
         >
           <ChevronLeft className="h-3 w-3" />
-          Voltar para relatórios
+          {t("back")}
         </Link>
-        <h1 className="mt-2 text-2xl font-bold tracking-tight">Convidados & RSVP</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Taxa de resposta, plus-ones, VIPs, padrinhos e distribuição por grupo/cidade.
-        </p>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="mt-1 text-sm text-zinc-500">{t("subtitle")}</p>
       </div>
 
       <GuestsReportClient result={result} />

--- a/src/app/dashboard/reports/honeymoon/honeymoon-report-client.tsx
+++ b/src/app/dashboard/reports/honeymoon/honeymoon-report-client.tsx
@@ -1,31 +1,36 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { StackedBar, type StackSeries } from "@/components/charts/stacked-bar";
 import { RadialProgress } from "@/components/charts/radial-progress";
 import { formatCurrency } from "@/lib/format";
 import type { HoneymoonProgress } from "@/lib/reports/honeymoon-progress";
 
-const STACK_SERIES: StackSeries[] = [
-  { key: "PAID", label: "Pago", color: "#22c55e" },
-  { key: "CONFIRMED", label: "Confirmado", color: "#8b5cf6" },
-  { key: "BOOKED", label: "Reservado", color: "#3b82f6" },
-  { key: "PLANNED", label: "Planejado", color: "#71717a" },
-  { key: "CANCELLED", label: "Cancelado", color: "#f43f5e" },
-];
-
-const KIND_LABEL: Record<string, string> = {
-  FLIGHT: "Voos",
-  HOTEL: "Hospedagem",
-  TRANSFER: "Translado",
-  ACTIVITY: "Atividades",
-  DOCUMENT: "Documentos",
-  BAGGAGE: "Bagagem",
-  OTHER: "Outros",
-};
+const KIND_KEYS = new Set([
+  "FLIGHT",
+  "HOTEL",
+  "TRANSFER",
+  "ACTIVITY",
+  "DOCUMENT",
+  "BAGGAGE",
+  "OTHER",
+]);
 
 export function HoneymoonReportClient({ result }: { result: HoneymoonProgress }) {
+  const t = useTranslations("dashboard.reports.honeymoon");
+
+  const STACK_SERIES: StackSeries[] = [
+    { key: "PAID", label: t("status.paid"), color: "#22c55e" },
+    { key: "CONFIRMED", label: t("status.confirmed"), color: "#8b5cf6" },
+    { key: "BOOKED", label: t("status.booked"), color: "#3b82f6" },
+    { key: "PLANNED", label: t("status.planned"), color: "#71717a" },
+    { key: "CANCELLED", label: t("status.cancelled"), color: "#f43f5e" },
+  ];
+
+  const kindLabel = (kind: string) => (KIND_KEYS.has(kind) ? t(`kind.${kind}`) : kind);
+
   const byKindData = result.byKind.map((k) => ({
-    name: KIND_LABEL[k.kind] ?? k.kind,
+    name: kindLabel(k.kind),
     PAID: k.counts.PAID,
     CONFIRMED: k.counts.CONFIRMED,
     BOOKED: k.counts.BOOKED,
@@ -36,11 +41,11 @@ export function HoneymoonReportClient({ result }: { result: HoneymoonProgress })
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
-        <Tile label="Itens" value={String(result.itemsCount)} />
-        <Tile label="Reservado" value={formatCurrency(result.bookedBRL)} color="text-violet-400" />
-        <Tile label="Pago" value={formatCurrency(result.paidBRL)} color="text-emerald-400" />
+        <Tile label={t("tiles.items")} value={String(result.itemsCount)} />
+        <Tile label={t("tiles.booked")} value={formatCurrency(result.bookedBRL)} color="text-violet-400" />
+        <Tile label={t("tiles.paid")} value={formatCurrency(result.paidBRL)} color="text-emerald-400" />
         <Tile
-          label="Recebido via PIX (cota)"
+          label={t("tiles.fundedFromGifts")}
           value={formatCurrency(result.fundedFromGiftsBRL)}
           color="text-amber-400"
         />
@@ -48,22 +53,22 @@ export function HoneymoonReportClient({ result }: { result: HoneymoonProgress })
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-          <h2 className="mb-4 text-sm font-semibold text-zinc-200">Cobertura por cota</h2>
+          <h2 className="mb-4 text-sm font-semibold text-zinc-200">{t("coverage.title")}</h2>
           {result.budgetBRL !== null && result.budgetBRL > 0 ? (
             <RadialProgress
               value={result.fundedFromGiftsBRL}
               max={result.budgetBRL}
               label={`${formatCurrency(result.fundedFromGiftsBRL)} / ${formatCurrency(result.budgetBRL)}`}
-              sublabel="contribuições via PIX"
+              sublabel={t("coverage.sublabel")}
               color="#22c55e"
             />
           ) : (
-            <p className="text-sm text-zinc-500">Defina um orçamento total para a lua de mel para ver a cobertura.</p>
+            <p className="text-sm text-zinc-500">{t("coverage.empty")}</p>
           )}
         </div>
 
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm lg:col-span-2">
-          <h2 className="mb-4 text-lg font-semibold text-zinc-100">Por tipo de item</h2>
+          <h2 className="mb-4 text-lg font-semibold text-zinc-100">{t("byKind.title")}</h2>
           {byKindData.length > 0 ? (
             <StackedBar
               data={byKindData}
@@ -72,17 +77,15 @@ export function HoneymoonReportClient({ result }: { result: HoneymoonProgress })
               height={Math.max(220, byKindData.length * 36 + 60)}
             />
           ) : (
-            <p className="text-sm text-zinc-500">Nenhum item adicionado à lua de mel ainda.</p>
+            <p className="text-sm text-zinc-500">{t("byKind.empty")}</p>
           )}
         </div>
       </div>
 
       {Object.keys(result.byCurrency).filter((c) => c !== "BRL").length > 0 ? (
         <div className="rounded-2xl border border-amber-500/30 bg-amber-500/5 p-4">
-          <h3 className="text-sm font-semibold text-amber-300">Valores em moedas estrangeiras</h3>
-          <p className="mt-1 text-xs text-amber-200/80">
-            Os totais acima exibem valores em BRL. Itens em outras moedas:
-          </p>
+          <h3 className="text-sm font-semibold text-amber-300">{t("foreignCurrency.title")}</h3>
+          <p className="mt-1 text-xs text-amber-200/80">{t("foreignCurrency.body")}</p>
           <ul className="mt-2 space-y-1 text-xs text-amber-100">
             {Object.entries(result.byCurrency)
               .filter(([k]) => k !== "BRL")

--- a/src/app/dashboard/reports/honeymoon/page.tsx
+++ b/src/app/dashboard/reports/honeymoon/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { canViewSensitiveFinance } from "@/lib/permissions";
@@ -10,15 +11,14 @@ export const dynamic = "force-dynamic";
 
 export default async function HoneymoonReportPage() {
   const session = await auth();
+  const t = await getTranslations("dashboard.reports.honeymoon");
   const role = (session?.user as { role?: string } | undefined)?.role;
   const finance = canViewSensitiveFinance(role);
   if (!finance) {
     return (
       <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-8 text-center">
-        <h1 className="text-lg font-semibold text-zinc-100">Sem permissão</h1>
-        <p className="mt-2 text-sm text-zinc-400">
-          Esse relatório expõe valores financeiros. Solicite acesso a um administrador.
-        </p>
+        <h1 className="text-lg font-semibold text-zinc-100">{t("noPermission.title")}</h1>
+        <p className="mt-2 text-sm text-zinc-400">{t("noPermission.body")}</p>
       </div>
     );
   }
@@ -42,13 +42,10 @@ export default async function HoneymoonReportPage() {
           className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
         >
           <ChevronLeft className="h-3 w-3" />
-          Voltar para relatórios
+          {t("back")}
         </Link>
-        <h1 className="mt-2 text-2xl font-bold tracking-tight">Lua de Mel</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Status por etapa (PLANNED → PAID), por tipo de item, e cobertura pela cota
-          via PIX dos presentes.
-        </p>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="mt-1 text-sm text-zinc-500">{t("subtitle")}</p>
       </div>
 
       <HoneymoonReportClient result={result} />

--- a/src/app/dashboard/reports/page.tsx
+++ b/src/app/dashboard/reports/page.tsx
@@ -13,13 +13,13 @@ import {
   Users2,
   Waves,
 } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { canViewSensitiveFinance, canManageUsers } from "@/lib/permissions";
 
 type ReportEntry = {
+  key: string;
   href: string;
-  title: string;
-  description: string;
   icon: React.ComponentType<{ className?: string }>;
   finance?: boolean;
   adminOnly?: boolean;
@@ -28,70 +28,59 @@ type ReportEntry = {
 
 const REPORTS: ReportEntry[] = [
   {
+    key: "scurve",
     href: "/dashboard/insights#scurve",
-    title: "Curva S — Previsto vs Realizado",
-    description:
-      "Compara o pagamento previsto com o realizado ao longo do tempo, com banda de contingência.",
     icon: TrendingUp,
     finance: true,
     inInsights: true,
   },
   {
+    key: "vendorFunnel",
     href: "/dashboard/reports/vendor-funnel",
-    title: "Funil de Fornecedores",
-    description: "Acompanhe quantos estão em negociação, contratados e finalizados.",
     icon: Users2,
   },
   {
+    key: "risk",
     href: "/dashboard/reports/risk",
-    title: "Risk Radar",
-    description: "Sinais vermelhos consolidados em um único painel.",
     icon: ShieldAlert,
   },
   {
+    key: "guests",
     href: "/dashboard/reports/guests",
-    title: "Convidados & RSVP",
-    description: "Taxa de resposta, plus-ones, VIPs, distribuição por grupo e cidade.",
     icon: UserCheck,
   },
   {
+    key: "gifts",
     href: "/dashboard/reports/gifts",
-    title: "Presentes",
-    description: "CASH × ITEM, agradecimentos pendentes, top givers e cota da lua de mel.",
     icon: Gift,
   },
   {
+    key: "burndown",
     href: "/dashboard/insights#burndown",
-    title: "Burndown de Tarefas",
-    description: "Compare ritmo ideal vs real de tarefas concluídas até a data do evento.",
     icon: ClipboardList,
     inInsights: true,
   },
   {
+    key: "honeymoon",
     href: "/dashboard/reports/honeymoon",
-    title: "Lua de Mel",
-    description: "Status por etapa e financiamento pelos presentes via PIX.",
     icon: Plane,
     finance: true,
   },
   {
+    key: "trousseau",
     href: "/dashboard/reports/trousseau",
-    title: "Enxoval",
-    description: "Progresso por cômodo e essenciais ainda pendentes.",
     icon: ShoppingBasket,
   },
   {
+    key: "waterfall",
     href: "/dashboard/insights#waterfall",
-    title: "Variação por Categoria",
-    description: "Waterfall mostrando onde o orçamento estourou e quanto.",
     icon: Waves,
     finance: true,
     inInsights: true,
   },
   {
+    key: "activity",
     href: "/dashboard/reports/activity",
-    title: "Timeline de Atividade",
-    description: "Últimas alterações relevantes registradas em auditoria.",
     icon: History,
     adminOnly: true,
   },
@@ -101,6 +90,7 @@ export const dynamic = "force-dynamic";
 
 export default async function ReportsHubPage() {
   const session = await auth();
+  const t = await getTranslations("dashboard.reports.hub");
   const role = (session?.user as { role?: string } | undefined)?.role;
   const finance = canViewSensitiveFinance(role);
   const admin = canManageUsers(role);
@@ -114,11 +104,8 @@ export default async function ReportsHubPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight">Relatórios</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Visualizações analíticas detalhadas por área. Os ícones BI dentro de
-          /dashboard/insights também aparecem aqui como atalho.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="mt-1 text-sm text-zinc-500">{t("subtitle")}</p>
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -135,14 +122,16 @@ export default async function ReportsHubPage() {
               </div>
               <div className="min-w-0 flex-1">
                 <div className="flex items-center justify-between gap-2">
-                  <h2 className="text-sm font-semibold text-zinc-100">{r.title}</h2>
+                  <h2 className="text-sm font-semibold text-zinc-100">
+                    {t(`items.${r.key}.title`)}
+                  </h2>
                   <ChevronRight className="h-4 w-4 shrink-0 text-zinc-500 group-hover:text-rose-300" />
                 </div>
-                <p className="mt-2 text-xs text-zinc-400">{r.description}</p>
+                <p className="mt-2 text-xs text-zinc-400">{t(`items.${r.key}.description`)}</p>
                 {r.inInsights ? (
                   <span className="mt-3 inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-zinc-800/50 px-2 py-0.5 text-[10px] text-zinc-400">
                     <BarChart3 className="h-3 w-3" />
-                    Em Insights
+                    {t("inInsights")}
                   </span>
                 ) : null}
               </div>

--- a/src/app/dashboard/reports/risk/page.tsx
+++ b/src/app/dashboard/reports/risk/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ChevronLeft, AlertCircle, AlertTriangle, ShieldCheck } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { loadDashboardData } from "@/lib/reports/dashboard-data";
 import { canViewSensitiveFinance } from "@/lib/permissions";
@@ -33,6 +34,7 @@ const SEVERITY_STYLES: Record<
 
 export default async function RiskRadarPage() {
   const session = await auth();
+  const t = await getTranslations("dashboard.reports.risk");
   const role = (session?.user as { role?: string } | undefined)?.role;
   const canSeeFinance = canViewSensitiveFinance(role);
 
@@ -47,26 +49,23 @@ export default async function RiskRadarPage() {
           className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
         >
           <ChevronLeft className="h-3 w-3" />
-          Voltar para relatórios
+          {t("back")}
         </Link>
-        <h1 className="mt-2 text-2xl font-bold tracking-tight">Risk Radar</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Sinais consolidados que merecem atenção: liquidez, contratos no prazo, tarefas
-          atrasadas e fornecedores que estouraram o orçamento estimado.
-        </p>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="mt-1 text-sm text-zinc-500">{t("subtitle")}</p>
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <Tile label="Críticos" count={visible.filter((r) => r.severity === "red").length} color="text-rose-400" />
-        <Tile label="Atenção" count={visible.filter((r) => r.severity === "amber").length} color="text-amber-400" />
-        <Tile label="Ok" count={visible.filter((r) => r.severity === "green").length} color="text-emerald-400" />
+        <Tile label={t("tiles.critical")} count={visible.filter((r) => r.severity === "red").length} color="text-rose-400" />
+        <Tile label={t("tiles.warning")} count={visible.filter((r) => r.severity === "amber").length} color="text-amber-400" />
+        <Tile label={t("tiles.ok")} count={visible.filter((r) => r.severity === "green").length} color="text-emerald-400" />
       </div>
 
       <div className="space-y-3">
         {visible.length === 0 ? (
           <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-6 text-emerald-200">
             <ShieldCheck className="h-6 w-6" />
-            <p className="mt-2 text-sm">Sem sinais vermelhos no momento. Bom trabalho.</p>
+            <p className="mt-2 text-sm">{t("empty")}</p>
           </div>
         ) : (
           visible.map((alert: RiskAlert) => {

--- a/src/app/dashboard/reports/trousseau/page.tsx
+++ b/src/app/dashboard/reports/trousseau/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { canViewSensitiveFinance } from "@/lib/permissions";
@@ -10,6 +11,7 @@ export const dynamic = "force-dynamic";
 
 export default async function TrousseauReportPage() {
   const session = await auth();
+  const t = await getTranslations("dashboard.reports.trousseau");
   const role = (session?.user as { role?: string } | undefined)?.role;
   const finance = canViewSensitiveFinance(role);
 
@@ -24,12 +26,10 @@ export default async function TrousseauReportPage() {
           className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
         >
           <ChevronLeft className="h-3 w-3" />
-          Voltar para relatórios
+          {t("back")}
         </Link>
-        <h1 className="mt-2 text-2xl font-bold tracking-tight">Enxoval</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Progresso por cômodo e itens essenciais ainda pendentes.
-        </p>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="mt-1 text-sm text-zinc-500">{t("subtitle")}</p>
       </div>
 
       <TrousseauReportClient result={result} showFinance={finance} />

--- a/src/app/dashboard/reports/trousseau/trousseau-report-client.tsx
+++ b/src/app/dashboard/reports/trousseau/trousseau-report-client.tsx
@@ -1,26 +1,21 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { AlertTriangle } from "lucide-react";
 import { StackedBar, type StackSeries } from "@/components/charts/stacked-bar";
 import { RadialProgress } from "@/components/charts/radial-progress";
 import { formatCurrency } from "@/lib/format";
 import type { TrousseauProgress } from "@/lib/reports/trousseau-progress";
 
-const STACK_SERIES: StackSeries[] = [
-  { key: "GIFTED", label: "Recebidos", color: "#22c55e" },
-  { key: "BOUGHT", label: "Comprados", color: "#3b82f6" },
-  { key: "TO_BUY", label: "A comprar", color: "#71717a" },
-];
-
-const ROOM_LABEL: Record<string, string> = {
-  KITCHEN: "Cozinha",
-  BATHROOM: "Banheiro",
-  BEDROOM: "Quarto",
-  LIVING: "Sala",
-  LAUNDRY: "Lavanderia",
-  ELECTRONICS: "Eletrônicos",
-  OTHER: "Outros",
-};
+const ROOM_KEYS = new Set([
+  "KITCHEN",
+  "BATHROOM",
+  "BEDROOM",
+  "LIVING",
+  "LAUNDRY",
+  "ELECTRONICS",
+  "OTHER",
+]);
 
 export function TrousseauReportClient({
   result,
@@ -29,8 +24,18 @@ export function TrousseauReportClient({
   result: TrousseauProgress;
   showFinance: boolean;
 }) {
+  const t = useTranslations("dashboard.reports.trousseau");
+
+  const STACK_SERIES: StackSeries[] = [
+    { key: "GIFTED", label: t("status.gifted"), color: "#22c55e" },
+    { key: "BOUGHT", label: t("status.bought"), color: "#3b82f6" },
+    { key: "TO_BUY", label: t("status.toBuy"), color: "#71717a" },
+  ];
+
+  const roomLabel = (room: string) => (ROOM_KEYS.has(room) ? t(`room.${room}`) : room);
+
   const byRoomData = result.byRoom.map((r) => ({
-    name: ROOM_LABEL[r.room] ?? r.room,
+    name: roomLabel(r.room),
     TO_BUY: r.counts.TO_BUY,
     BOUGHT: r.counts.BOUGHT,
     GIFTED: r.counts.GIFTED,
@@ -39,22 +44,22 @@ export function TrousseauReportClient({
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
-        <Tile label="Itens" value={String(result.totalCount)} />
+        <Tile label={t("tiles.items")} value={String(result.totalCount)} />
         <Tile
-          label="Conclusão"
+          label={t("tiles.completion")}
           value={`${Math.round(result.completionPct * 100)}%`}
           color="text-emerald-400"
         />
         {showFinance ? (
-          <Tile label="Estimado" value={formatCurrency(result.totalEstimated)} />
+          <Tile label={t("tiles.estimated")} value={formatCurrency(result.totalEstimated)} />
         ) : (
-          <Tile label="Por cômodo" value={String(result.byRoom.length)} />
+          <Tile label={t("tiles.byRoom")} value={String(result.byRoom.length)} />
         )}
         {showFinance ? (
-          <Tile label="Atual" value={formatCurrency(result.totalActual)} color="text-violet-400" />
+          <Tile label={t("tiles.actual")} value={formatCurrency(result.totalActual)} color="text-violet-400" />
         ) : (
           <Tile
-            label="Essenciais pendentes"
+            label={t("tiles.essentialsPending")}
             value={String(result.essentialsPending)}
             color={result.essentialsPending > 0 ? "text-amber-400" : "text-emerald-400"}
           />
@@ -66,29 +71,30 @@ export function TrousseauReportClient({
           <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-300" />
           <div>
             <p className="text-sm font-semibold text-amber-300">
-              {result.essentialsPending} item(ns) ESSENTIAL ainda em &quot;a comprar&quot;
+              {t("essentials.warning", { count: result.essentialsPending })}
             </p>
-            <p className="mt-1 text-xs text-amber-200/80">
-              Priorize esses antes de itens NICE_TO_HAVE ou LUXURY.
-            </p>
+            <p className="mt-1 text-xs text-amber-200/80">{t("essentials.hint")}</p>
           </div>
         </div>
       ) : null}
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
-          <h2 className="mb-4 text-sm font-semibold text-zinc-200">Progresso geral</h2>
+          <h2 className="mb-4 text-sm font-semibold text-zinc-200">{t("overall.title")}</h2>
           <RadialProgress
             value={result.completionPct}
             max={1}
-            label="Concluído"
-            sublabel={`${Math.round(result.completionPct * 100)}% de ${result.totalCount} itens`}
+            label={t("overall.label")}
+            sublabel={t("overall.sublabel", {
+              pct: Math.round(result.completionPct * 100),
+              total: result.totalCount,
+            })}
             color="#22c55e"
           />
         </div>
 
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm lg:col-span-2">
-          <h2 className="mb-4 text-lg font-semibold text-zinc-100">Por cômodo</h2>
+          <h2 className="mb-4 text-lg font-semibold text-zinc-100">{t("byRoom.title")}</h2>
           {byRoomData.length > 0 ? (
             <StackedBar
               data={byRoomData}
@@ -97,7 +103,7 @@ export function TrousseauReportClient({
               height={Math.max(220, byRoomData.length * 36 + 60)}
             />
           ) : (
-            <p className="text-sm text-zinc-500">Nenhum item adicionado ao enxoval ainda.</p>
+            <p className="text-sm text-zinc-500">{t("byRoom.empty")}</p>
           )}
         </div>
       </div>

--- a/src/app/dashboard/reports/vendor-funnel/funnel-client.tsx
+++ b/src/app/dashboard/reports/vendor-funnel/funnel-client.tsx
@@ -1,15 +1,18 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { StackedBar, type StackSeries } from "@/components/charts/stacked-bar";
 import type { VendorFunnelResult } from "@/lib/reports/vendor-funnel";
 
-const SERIES: StackSeries[] = [
-  { key: "NEGOTIATION", label: "Negociando", color: "#f59e0b" },
-  { key: "CONTRACTED", label: "Contratado", color: "#8b5cf6" },
-  { key: "FINALIZED", label: "Finalizado", color: "#22c55e" },
-];
-
 export function FunnelClient({ result }: { result: VendorFunnelResult }) {
+  const t = useTranslations("dashboard.reports.vendorFunnel");
+
+  const SERIES: StackSeries[] = [
+    { key: "NEGOTIATION", label: t("series.negotiating"), color: "#f59e0b" },
+    { key: "CONTRACTED", label: t("series.contracted"), color: "#8b5cf6" },
+    { key: "FINALIZED", label: t("series.finalized"), color: "#22c55e" },
+  ];
+
   const barData = result.perCategory.map((c) => ({
     name: c.categoryLabel,
     NEGOTIATION: c.counts.NEGOTIATION,
@@ -23,31 +26,31 @@ export function FunnelClient({ result }: { result: VendorFunnelResult }) {
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <Tile label="Em negociação" value={totals.NEGOTIATION} color="text-amber-400" />
-        <Tile label="Contratados" value={totals.CONTRACTED} color="text-violet-400" />
-        <Tile label="Finalizados" value={totals.FINALIZED} color="text-emerald-400" />
+        <Tile label={t("tiles.negotiation")} value={totals.NEGOTIATION} color="text-amber-400" />
+        <Tile label={t("tiles.contracted")} value={totals.CONTRACTED} color="text-violet-400" />
+        <Tile label={t("tiles.finalized")} value={totals.FINALIZED} color="text-emerald-400" />
       </div>
 
       <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-sm">
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-zinc-100">Por categoria</h2>
-          <span className="text-xs text-zinc-500">{totalAll} fornecedor(es)</span>
+          <h2 className="text-lg font-semibold text-zinc-100">{t("byCategory.title")}</h2>
+          <span className="text-xs text-zinc-500">{t("byCategory.vendorCount", { count: totalAll })}</span>
         </div>
         <StackedBar data={barData} series={SERIES} horizontal height={Math.max(260, barData.length * 36 + 80)} />
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <Tile
-          label="Tempo médio de negociação → contrato"
+          label={t("avg.negToContract")}
           value={result.avgDaysNegToContract ?? null}
           color="text-zinc-100"
-          unit="dias"
+          unit={t("avg.daysUnit")}
         />
         <Tile
-          label="Tempo médio de contrato → finalização"
+          label={t("avg.contractToFinalized")}
           value={result.avgDaysContractToFinalized ?? null}
           color="text-zinc-100"
-          unit="dias"
+          unit={t("avg.daysUnit")}
         />
       </div>
     </div>

--- a/src/app/dashboard/reports/vendor-funnel/page.tsx
+++ b/src/app/dashboard/reports/vendor-funnel/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import { resolveCategoryLabel } from "@/lib/categories";
 import { buildVendorFunnel } from "@/lib/reports/vendor-funnel";
@@ -8,6 +9,7 @@ import { FunnelClient } from "./funnel-client";
 export const dynamic = "force-dynamic";
 
 export default async function VendorFunnelPage() {
+  const t = await getTranslations("dashboard.reports.vendorFunnel");
   const vendors = await prisma.vendor.findMany({
     where: { deletedAt: null },
     include: { contracts: { where: { deletedAt: null }, select: { signedAt: true, createdAt: true } } },
@@ -33,12 +35,10 @@ export default async function VendorFunnelPage() {
           className="inline-flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300"
         >
           <ChevronLeft className="h-3 w-3" />
-          Voltar para relatórios
+          {t("back")}
         </Link>
-        <h1 className="mt-2 text-2xl font-bold tracking-tight">Funil de Fornecedores</h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Distribuição por estágio e tempo médio entre negociação, contrato e finalização.
-        </p>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="mt-1 text-sm text-zinc-500">{t("subtitle")}</p>
       </div>
 
       <FunnelClient result={result} />

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { getEventConfig } from "@/lib/event-config";
@@ -9,6 +10,7 @@ import SettingsClient from "./settings-client";
 export const dynamic = "force-dynamic";
 
 export default async function SettingsPage() {
+  const t = await getTranslations("dashboard.settings");
   const cfg = await getEventConfig();
   const session = await auth();
   const email = session?.user?.email ?? null;
@@ -69,8 +71,8 @@ export default async function SettingsPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Ajustes</h1>
-        <p className="text-sm text-zinc-500">Configurações do casamento, time e segurança.</p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
       <SettingsClient
         initial={{

--- a/src/app/dashboard/settings/settings-client.tsx
+++ b/src/app/dashboard/settings/settings-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
 import {
   Archive,
   ArchiveRestore,
@@ -126,6 +127,7 @@ export default function SettingsClient({
   securitySettings: SecuritySettings;
   notificationLogs: NotificationLogEntry[];
 }) {
+  const t = useTranslations("dashboard.settings");
   const toast = useToast();
   const [tab, setTab] = useState<Tab>("event");
   const manageUsers = canManageUsers(me?.role);
@@ -135,29 +137,29 @@ export default function SettingsClient({
     <div className="space-y-4">
       <nav className="flex flex-wrap gap-2 rounded-2xl bg-zinc-900/50 p-1 border border-zinc-800 max-w-fit">
         <TabBtn current={tab} value="event" onClick={() => setTab("event")}>
-          Casamento
+          {t("tabs.event")}
         </TabBtn>
         <TabBtn current={tab} value="security" onClick={() => setTab("security")}>
-          Segurança
+          {t("tabs.security")}
         </TabBtn>
         <TabBtn current={tab} value="team" onClick={() => setTab("team")}>
-          Time
+          {t("tabs.team")}
         </TabBtn>
         {manageUsers ? (
           <TabBtn current={tab} value="notifications" onClick={() => setTab("notifications")}>
-            Notificações
+            {t("tabs.notifications")}
           </TabBtn>
         ) : null}
         {isAdmin ? (
           <TabBtn current={tab} value="whatsapp" onClick={() => setTab("whatsapp")}>
-            WhatsApp
+            {t("tabs.whatsapp")}
           </TabBtn>
         ) : null}
         <TabBtn current={tab} value="profile" onClick={() => setTab("profile")}>
-          Perfil
+          {t("tabs.profile")}
         </TabBtn>
         <TabBtn current={tab} value="backup" onClick={() => setTab("backup")}>
-          Backup
+          {t("tabs.backup")}
         </TabBtn>
       </nav>
 
@@ -187,32 +189,30 @@ export default function SettingsClient({
 }
 
 function NotificationsTab({ logs }: { logs: NotificationLogEntry[] }) {
+  const t = useTranslations("dashboard.settings");
   const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(logs, 20);
   return (
     <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
       <div className="flex items-center gap-2">
         <Mail className="h-5 w-5 text-rose-400" />
-        <h2 className="text-lg font-semibold text-white">Envios recentes</h2>
+        <h2 className="text-lg font-semibold text-white">{t("notifications.title")}</h2>
       </div>
-      <p className="mt-1 text-sm text-zinc-500">
-        Últimos envios de e-mail/WhatsApp. Use esta lista para diagnosticar falhas de SMTP ou
-        destinatário inválido (ex.: o admin@admin.com padrão do seed).
-      </p>
+      <p className="mt-1 text-sm text-zinc-500">{t("notifications.subtitle")}</p>
       {logs.length === 0 ? (
         <p className="mt-4 rounded-xl border border-dashed border-zinc-800 px-4 py-8 text-center text-sm text-zinc-500">
-          Nenhum envio registrado ainda.
+          {t("notifications.empty")}
         </p>
       ) : (
         <div className="mt-4 overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-zinc-800 text-left text-xs uppercase tracking-wide text-zinc-500">
-                <th className="py-2 pr-3 font-medium">Quando</th>
-                <th className="py-2 pr-3 font-medium">Tipo</th>
-                <th className="py-2 pr-3 font-medium">Canal</th>
-                <th className="py-2 pr-3 font-medium">Destinatário</th>
-                <th className="py-2 pr-3 font-medium">Status</th>
-                <th className="py-2 font-medium">Erro</th>
+                <th className="py-2 pr-3 font-medium">{t("notifications.col.when")}</th>
+                <th className="py-2 pr-3 font-medium">{t("notifications.col.type")}</th>
+                <th className="py-2 pr-3 font-medium">{t("notifications.col.channel")}</th>
+                <th className="py-2 pr-3 font-medium">{t("notifications.col.recipient")}</th>
+                <th className="py-2 pr-3 font-medium">{t("notifications.col.status")}</th>
+                <th className="py-2 font-medium">{t("notifications.col.error")}</th>
               </tr>
             </thead>
             <tbody>
@@ -297,6 +297,7 @@ function EventTab({
   pixSettings: PixSettings;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [, startTransition] = useTransition();
   const [isPending, setPending] = useState(false);
   const [pixPending, setPixPending] = useState(false);
@@ -308,8 +309,8 @@ function EventTab({
     startTransition(async () => {
       try {
         const r = await updateSettings(undefined, formData);
-        if (r.success) toast.success("Configurações salvas");
-        else toast.error("Falha ao salvar", r.error);
+        if (r.success) toast.success(t("event.toast.saved"));
+        else toast.error(t("event.toast.saveFailed"), r.error);
       } finally {
         setPending(false);
       }
@@ -321,8 +322,8 @@ function EventTab({
     startTransition(async () => {
       try {
         const r = await updatePixSettings(undefined, formData);
-        if (r.success) toast.success("Pix atualizado");
-        else toast.error("Falha ao salvar", r.error);
+        if (r.success) toast.success(t("event.toast.pixSaved"));
+        else toast.error(t("event.toast.saveFailed"), r.error);
       } finally {
         setPixPending(false);
       }
@@ -332,26 +333,26 @@ function EventTab({
   return (
     <div className="space-y-4">
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-        <h2 className="text-lg font-semibold text-zinc-100">Dados do casamento</h2>
+        <h2 className="text-lg font-semibold text-zinc-100">{t("event.title")}</h2>
         <form action={handleSubmit} className="mt-4 grid gap-3 sm:grid-cols-2">
-          <Field name="coupleNames" label="Nomes do casal" defaultValue={initial.coupleNames} />
-          <Field name="eventDate" label="Data do evento" type="date" required defaultValue={initial.eventDate} />
+          <Field name="coupleNames" label={t("event.coupleNames")} defaultValue={initial.coupleNames} />
+          <Field name="eventDate" label={t("event.eventDate")} type="date" required defaultValue={initial.eventDate} />
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Moeda</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("event.currency")}</label>
             <select
               name="currency"
               value={currency}
               onChange={(e) => setCurrency(e.target.value)}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
-              <option value="BRL">Real (BRL)</option>
-              <option value="USD">Dólar (USD)</option>
-              <option value="EUR">Euro (EUR)</option>
+              <option value="BRL">{t("event.currencyBRL")}</option>
+              <option value="USD">{t("event.currencyUSD")}</option>
+              <option value="EUR">{t("event.currencyEUR")}</option>
             </select>
           </div>
           <Field
             name="contingencyPercent"
-            label="Contingência (%)"
+            label={t("event.contingency")}
             type="number"
             step="0.1"
             defaultValue={String(initial.contingencyPercent)}
@@ -363,21 +364,19 @@ function EventTab({
               className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
               {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-              Salvar
+              {t("event.save")}
             </button>
           </div>
         </form>
       </section>
 
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-        <h2 className="text-lg font-semibold text-zinc-100">Pix (cota lua de mel)</h2>
-        <p className="mt-1 text-xs text-zinc-500">
-          Configure a chave Pix do casal para gerar QR Code estático nos presentes em dinheiro.
-        </p>
+        <h2 className="text-lg font-semibold text-zinc-100">{t("pix.title")}</h2>
+        <p className="mt-1 text-xs text-zinc-500">{t("pix.subtitle")}</p>
         <form action={handlePixSubmit} className="mt-4 grid gap-3 sm:grid-cols-2">
-          <Field name="pixKey" label="Chave Pix" defaultValue={pixSettings.pixKey} />
+          <Field name="pixKey" label={t("pix.key")} defaultValue={pixSettings.pixKey} />
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Tipo de chave</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("pix.keyType")}</label>
             <select
               name="pixKeyType"
               value={pixKeyType}
@@ -385,21 +384,21 @@ function EventTab({
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
               <option value="">—</option>
-              <option value="CPF">CPF</option>
-              <option value="CNPJ">CNPJ</option>
-              <option value="EMAIL">Email</option>
-              <option value="PHONE">Telefone</option>
-              <option value="RANDOM">Aleatória</option>
+              <option value="CPF">{t("pix.typeCPF")}</option>
+              <option value="CNPJ">{t("pix.typeCNPJ")}</option>
+              <option value="EMAIL">{t("pix.typeEmail")}</option>
+              <option value="PHONE">{t("pix.typePhone")}</option>
+              <option value="RANDOM">{t("pix.typeRandom")}</option>
             </select>
           </div>
           <Field
             name="pixHolderName"
-            label="Nome do recebedor (máx. 25)"
+            label={t("pix.holderName")}
             defaultValue={pixSettings.pixHolderName}
           />
           <Field
             name="pixCity"
-            label="Cidade do recebedor (máx. 15)"
+            label={t("pix.city")}
             defaultValue={pixSettings.pixCity}
           />
           <div className="sm:col-span-2">
@@ -409,7 +408,7 @@ function EventTab({
               className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
               {pixPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-              Salvar Pix
+              {t("pix.save")}
             </button>
           </div>
         </form>
@@ -427,6 +426,7 @@ function SecurityTab({
   toast: ReturnType<typeof useToast>;
   securitySettings: SecuritySettings;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [, startTransition] = useTransition();
   const [setup, setSetup] = useState<{ secret: string; qrCodeSvg: string } | null>(null);
   const [backupCodes, setBackupCodes] = useState<string[] | null>(null);
@@ -441,7 +441,7 @@ function SecurityTab({
       try {
         const r = await startTwoFactorSetup();
         if (r.success && r.data) setSetup({ secret: r.data.secret, qrCodeSvg: r.data.qrCodeSvg });
-        else if (!r.success) toast.error("Falha", r.error);
+        else if (!r.success) toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -456,8 +456,8 @@ function SecurityTab({
         if (r.success && r.data) {
           setBackupCodes(r.data.backupCodes);
           setSetup(null);
-          toast.success("2FA ativado");
-        } else if (!r.success) toast.error("Falha", r.error);
+          toast.success(t("security.toast.enabled"));
+        } else if (!r.success) toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -469,8 +469,8 @@ function SecurityTab({
     startTransition(async () => {
       try {
         const r = await disableTwoFactor(undefined, formData);
-        if (r.success) toast.success("2FA desativado");
-        else toast.error("Falha", r.error);
+        if (r.success) toast.success(t("security.toast.disabled"));
+        else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -480,7 +480,7 @@ function SecurityTab({
   if (!me) {
     return (
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-        <p className="text-sm text-zinc-400">Faça login para gerenciar segurança.</p>
+        <p className="text-sm text-zinc-400">{t("security.loginRequired")}</p>
       </section>
     );
   }
@@ -491,19 +491,19 @@ function SecurityTab({
         <div className="mb-4 flex items-start gap-3 rounded-xl border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-100">
           <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
           <p>
-            <strong>2FA obrigatório para sua função ({ROLE_LABEL[me.role as Role] ?? me.role})</strong>
-            . Configure agora para manter acesso garantido.
+            <strong>{t("security.requiredWarningStrong", { role: ROLE_LABEL[me.role as Role] ?? me.role })}</strong>
+            {t("security.requiredWarningRest")}
           </p>
         </div>
       ) : null}
 
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold text-zinc-100">Autenticação em dois fatores (2FA)</h2>
+          <h2 className="text-lg font-semibold text-zinc-100">{t("security.title")}</h2>
           <p className="text-sm text-zinc-500">
             {me.twoFactorEnabled
-              ? "Ativada — login pede código do app autenticador."
-              : "Adicione uma camada extra usando Google Authenticator, 1Password ou similar."}
+              ? t("security.descEnabled")
+              : t("security.descDisabled")}
           </p>
         </div>
         <span
@@ -515,11 +515,11 @@ function SecurityTab({
         >
           {me.twoFactorEnabled ? (
             <>
-              <ShieldCheck className="h-3 w-3" /> Ativa
+              <ShieldCheck className="h-3 w-3" /> {t("security.badgeActive")}
             </>
           ) : (
             <>
-              <ShieldOff className="h-3 w-3" /> Inativa
+              <ShieldOff className="h-3 w-3" /> {t("security.badgeInactive")}
             </>
           )}
         </span>
@@ -533,30 +533,28 @@ function SecurityTab({
           className="mt-4 inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
         >
           {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
-          Ativar 2FA
+          {t("security.enable")}
         </button>
       ) : null}
 
       {setup ? (
         <div className="mt-6 grid gap-4 md:grid-cols-2">
           <div>
-            <p className="mb-2 text-sm text-zinc-300">
-              1. Escaneie o QR Code com seu app autenticador (Google Authenticator, 1Password, Authy).
-            </p>
+            <p className="mb-2 text-sm text-zinc-300">{t("security.step1")}</p>
             <div
               className="rounded-2xl border border-zinc-800 bg-zinc-950 p-2"
               dangerouslySetInnerHTML={{ __html: setup.qrCodeSvg }}
             />
             <p className="mt-2 text-[11px] text-zinc-500">
-              Se não conseguir escanear, digite manualmente:{" "}
+              {t("security.manualHint")}{" "}
               <code className="rounded bg-zinc-800 px-1 text-zinc-300">{setup.secret}</code>
             </p>
           </div>
           <form action={handleConfirm} className="space-y-3">
             <input type="hidden" name="secret" value={setup.secret} />
-            <p className="text-sm text-zinc-300">2. Confirme com o código atual mostrado no app.</p>
+            <p className="text-sm text-zinc-300">{t("security.step2")}</p>
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Código de 6 dígitos</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("security.codeLabel")}</label>
               <input
                 type="text"
                 name="token"
@@ -573,14 +571,14 @@ function SecurityTab({
               disabled={busy}
               className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
-              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Confirmar e ativar"}
+              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : t("security.confirmEnable")}
             </button>
             <button
               type="button"
               onClick={() => setSetup(null)}
               className="ml-2 text-xs text-zinc-400 hover:text-zinc-200"
             >
-              Cancelar
+              {t("security.cancel")}
             </button>
           </form>
         </div>
@@ -588,10 +586,8 @@ function SecurityTab({
 
       {backupCodes ? (
         <div className="mt-6 rounded-xl border border-amber-500/30 bg-amber-500/5 p-4">
-          <p className="text-sm font-semibold text-amber-200">🔑 Guarde estes códigos de backup</p>
-          <p className="mt-1 text-xs text-amber-100/70">
-            Use no lugar do código TOTP se perder acesso ao app. Cada um só funciona uma vez.
-          </p>
+          <p className="text-sm font-semibold text-amber-200">{t("security.backupTitle")}</p>
+          <p className="mt-1 text-xs text-amber-100/70">{t("security.backupHint")}</p>
           <ul className="mt-3 grid grid-cols-2 gap-2 font-mono text-sm">
             {backupCodes.map((c) => (
               <li key={c} className="rounded-md bg-zinc-950 px-3 py-1 text-zinc-200">
@@ -604,7 +600,7 @@ function SecurityTab({
             onClick={() => setBackupCodes(null)}
             className="mt-3 text-xs text-amber-200 hover:text-amber-100"
           >
-            Já anotei, ocultar
+            {t("security.backupDismiss")}
           </button>
         </div>
       ) : null}
@@ -615,9 +611,7 @@ function SecurityTab({
           className="mt-4 flex flex-col gap-3 rounded-xl border border-zinc-800 bg-zinc-950/50 p-4 sm:flex-row sm:items-end"
         >
           <div className="flex-1">
-            <label className="mb-1 block text-sm font-medium text-zinc-400">
-              Para desativar, digite um código TOTP ou de backup
-            </label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("security.disableLabel")}</label>
             <input
               type="text"
               name="token"
@@ -631,7 +625,7 @@ function SecurityTab({
             disabled={busy}
             className="rounded-xl bg-rose-500/10 px-4 py-2 text-sm font-medium text-rose-200 hover:bg-rose-500/20 disabled:opacity-50"
           >
-            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Desativar 2FA"}
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : t("security.disable")}
           </button>
         </form>
       ) : null}
@@ -652,6 +646,7 @@ function TeamTab({
   manageUsers: boolean;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.settings");
   const isAdmin = me?.role === "ADMIN";
   const [, startTransition] = useTransition();
   const [createOpen, setCreateOpen] = useState(false);
@@ -687,7 +682,7 @@ function TeamTab({
     startTransition(async () => {
       const r = await run();
       if (r.success) toast.success(label);
-      else toast.error("Falha", r.error);
+      else toast.error(t("toast.failed"), r.error);
     });
   }
 
@@ -696,11 +691,11 @@ function TeamTab({
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-zinc-100">Membros</h2>
+            <h2 className="text-lg font-semibold text-zinc-100">{t("team.title")}</h2>
             <p className="text-sm text-zinc-500">
               {manageUsers
-                ? "Crie usuários direto. O sistema envia as credenciais por email e/ou WhatsApp."
-                : "Apenas administradores e os noivos podem gerenciar membros."}
+                ? t("team.subtitleManage")
+                : t("team.subtitleReadonly")}
             </p>
           </div>
           {manageUsers ? (
@@ -709,7 +704,7 @@ function TeamTab({
               onClick={() => setCreateOpen(true)}
               className="inline-flex items-center gap-2 self-start rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 sm:self-auto"
             >
-              <UserPlus className="h-4 w-4" /> Novo usuário
+              <UserPlus className="h-4 w-4" /> {t("team.newUser")}
             </button>
           ) : null}
         </div>
@@ -720,7 +715,7 @@ function TeamTab({
             <input
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              placeholder="Buscar por nome ou email"
+              placeholder={t("team.searchPlaceholder")}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
             />
           </div>
@@ -729,7 +724,7 @@ function TeamTab({
             onChange={(e) => setRoleFilter(e.target.value as "ALL" | Role)}
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
           >
-            <option value="ALL">Todas as funções</option>
+            <option value="ALL">{t("team.allRoles")}</option>
             {ROLE_OPTIONS.map((r) => (
               <option key={r} value={r}>
                 {ROLE_LABEL[r]}
@@ -743,14 +738,14 @@ function TeamTab({
               onChange={(e) => setShowArchived(e.target.checked)}
               className="h-4 w-4 accent-rose-500"
             />
-            Mostrar arquivados
+            {t("team.showArchived")}
           </label>
         </div>
 
         <ul className="mt-4 space-y-2">
           {filtered.length === 0 ? (
             <li className="rounded-xl border border-dashed border-zinc-800 px-4 py-6 text-center text-sm text-zinc-500">
-              Nenhum membro encontrado com os filtros atuais.
+              {t("team.noMembers")}
             </li>
           ) : null}
           {filtered.map((m) => (
@@ -763,12 +758,12 @@ function TeamTab({
               onResetPassword={() => setResetting(m)}
               onResetTwoFactor={() =>
                 setConfirm({
-                  title: `Redefinir 2FA de ${m.name ?? m.email}?`,
-                  description: "Os códigos atuais deixarão de funcionar. O usuário precisará configurar novamente.",
-                  confirmLabel: "Redefinir",
+                  title: t("team.confirm.reset2faTitle", { name: m.name ?? m.email }),
+                  description: t("team.confirm.reset2faDesc"),
+                  confirmLabel: t("team.confirm.reset2faLabel"),
                   tone: "danger",
                   action: async () => {
-                    runAction("2FA redefinido", () => resetUserTwoFactor(m.id));
+                    runAction(t("team.toast.reset2fa"), () => resetUserTwoFactor(m.id));
                     setConfirm(null);
                   },
                 })
@@ -776,17 +771,19 @@ function TeamTab({
               onToggleActive={() => {
                 const next = !m.isActive;
                 setConfirm({
-                  title: next ? `Reativar ${m.name ?? m.email}?` : `Desativar ${m.name ?? m.email}?`,
+                  title: next
+                    ? t("team.confirm.activateTitle", { name: m.name ?? m.email })
+                    : t("team.confirm.deactivateTitle", { name: m.name ?? m.email }),
                   description: next
-                    ? "O usuário voltará a poder fazer login."
-                    : "O usuário não poderá entrar até ser reativado.",
-                  confirmLabel: next ? "Reativar" : "Desativar",
+                    ? t("team.confirm.activateDesc")
+                    : t("team.confirm.deactivateDesc"),
+                  confirmLabel: next ? t("team.confirm.activateLabel") : t("team.confirm.deactivateLabel"),
                   tone: next ? "default" : "danger",
                   action: async () => {
                     const fd = new FormData();
                     fd.append("id", m.id);
                     fd.append("isActive", next ? "true" : "false");
-                    runAction(next ? "Usuário reativado" : "Usuário desativado", () =>
+                    runAction(next ? t("team.toast.activated") : t("team.toast.deactivated"), () =>
                       updateUser(undefined, fd),
                     );
                     setConfirm(null);
@@ -795,23 +792,23 @@ function TeamTab({
               }}
               onArchive={() =>
                 setConfirm({
-                  title: `Arquivar ${m.name ?? m.email}?`,
-                  description: "O usuário é desativado e some da lista (pode ser restaurado depois).",
-                  confirmLabel: "Arquivar",
+                  title: t("team.confirm.archiveTitle", { name: m.name ?? m.email }),
+                  description: t("team.confirm.archiveDesc"),
+                  confirmLabel: t("team.confirm.archiveLabel"),
                   tone: "danger",
                   action: async () => {
-                    runAction("Usuário arquivado", () => archiveUser(m.id));
+                    runAction(t("team.toast.archived"), () => archiveUser(m.id));
                     setConfirm(null);
                   },
                 })
               }
               onRestore={() =>
                 setConfirm({
-                  title: `Restaurar ${m.name ?? m.email}?`,
-                  description: "O usuário volta para a lista ativa.",
-                  confirmLabel: "Restaurar",
+                  title: t("team.confirm.restoreTitle", { name: m.name ?? m.email }),
+                  description: t("team.confirm.restoreDesc"),
+                  confirmLabel: t("team.confirm.restoreLabel"),
                   action: async () => {
-                    runAction("Usuário restaurado", () => restoreUser(m.id));
+                    runAction(t("team.toast.restored"), () => restoreUser(m.id));
                     setConfirm(null);
                   },
                 })
@@ -885,6 +882,7 @@ function MemberRow({
   onArchive: () => void;
   onRestore: () => void;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [menuOpen, setMenuOpen] = useState(false);
   const isSelf = member.id === meId;
   const archived = !!member.archivedAt;
@@ -908,11 +906,11 @@ function MemberRow({
         <div>
           <p className="text-sm text-zinc-100">
             {member.name ?? member.email}
-            {isSelf ? <span className="ml-1 text-[11px] text-rose-300">(você)</span> : null}
+            {isSelf ? <span className="ml-1 text-[11px] text-rose-300">{t("team.row.you")}</span> : null}
           </p>
           <p className="text-[11px] text-zinc-500">
-            {member.email} · entrou {formatDateBR(member.createdAt)}
-            {member.lastLoginAt ? ` · último login ${formatDateBR(member.lastLoginAt)}` : ""}
+            {member.email} · {t("team.row.joined", { date: formatDateBR(member.createdAt) })}
+            {member.lastLoginAt ? ` · ${t("team.row.lastLogin", { date: formatDateBR(member.lastLoginAt) })}` : ""}
           </p>
         </div>
       </div>
@@ -923,25 +921,25 @@ function MemberRow({
         </span>
         {archived ? (
           <span className="rounded-full border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-[11px] text-zinc-400">
-            Arquivado
+            {t("team.row.archived")}
           </span>
         ) : member.isActive ? (
           <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] text-emerald-300">
-            Ativo
+            {t("team.row.active")}
           </span>
         ) : (
           <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-300">
-            Inativo
+            {t("team.row.inactive")}
           </span>
         )}
         {member.twoFactorEnabled ? (
           <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] text-emerald-300">
-            <ShieldCheck className="h-3 w-3" /> 2FA
+            <ShieldCheck className="h-3 w-3" /> {t("team.row.twoFactor")}
           </span>
         ) : null}
         {member.mustChangePassword ? (
           <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-300">
-            <KeyRound className="h-3 w-3" /> Senha provisória
+            <KeyRound className="h-3 w-3" /> {t("team.row.tempPassword")}
           </span>
         ) : null}
 
@@ -952,7 +950,7 @@ function MemberRow({
               onClick={() => setMenuOpen((v) => !v)}
               onBlur={() => setTimeout(() => setMenuOpen(false), 150)}
               className="rounded-lg p-1.5 text-zinc-300 hover:bg-zinc-800"
-              aria-label="Ações"
+              aria-label={t("team.row.actions")}
             >
               <MoreVertical className="h-4 w-4" />
             </button>
@@ -960,7 +958,7 @@ function MemberRow({
               <div className="absolute right-0 z-10 mt-1 w-56 overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950 shadow-xl">
                 <MenuItem
                   icon={<Pencil className="h-4 w-4" />}
-                  label="Editar"
+                  label={t("team.menu.edit")}
                   onClick={() => {
                     setMenuOpen(false);
                     onEdit();
@@ -969,7 +967,7 @@ function MemberRow({
                 />
                 <MenuItem
                   icon={<KeyRound className="h-4 w-4" />}
-                  label="Redefinir senha"
+                  label={t("team.menu.resetPassword")}
                   onClick={() => {
                     setMenuOpen(false);
                     onResetPassword();
@@ -978,7 +976,7 @@ function MemberRow({
                 />
                 <MenuItem
                   icon={<RefreshCw className="h-4 w-4" />}
-                  label="Redefinir 2FA"
+                  label={t("team.menu.reset2fa")}
                   onClick={() => {
                     setMenuOpen(false);
                     onResetTwoFactor();
@@ -987,7 +985,7 @@ function MemberRow({
                 />
                 <MenuItem
                   icon={member.isActive ? <PowerOff className="h-4 w-4" /> : <Power className="h-4 w-4" />}
-                  label={member.isActive ? "Desativar" : "Reativar"}
+                  label={member.isActive ? t("team.menu.deactivate") : t("team.menu.activate")}
                   onClick={() => {
                     setMenuOpen(false);
                     onToggleActive();
@@ -997,7 +995,7 @@ function MemberRow({
                 {archived ? (
                   <MenuItem
                     icon={<ArchiveRestore className="h-4 w-4" />}
-                    label="Restaurar"
+                    label={t("team.menu.restore")}
                     onClick={() => {
                       setMenuOpen(false);
                       onRestore();
@@ -1006,7 +1004,7 @@ function MemberRow({
                 ) : (
                   <MenuItem
                     icon={<Archive className="h-4 w-4" />}
-                    label="Arquivar"
+                    label={t("team.menu.archive")}
                     onClick={() => {
                       setMenuOpen(false);
                       onArchive();
@@ -1066,6 +1064,7 @@ function CreateUserModal({
   toast: ReturnType<typeof useToast>;
   minPasswordLength: number;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [, startTransition] = useTransition();
   const [busy, setBusy] = useState(false);
   const [showPwd, setShowPwd] = useState(false);
@@ -1088,9 +1087,9 @@ function CreateUserModal({
       try {
         const r = await createUser(undefined, formData);
         if (r.success) {
-          toast.success("Usuário criado");
+          toast.success(t("team.toast.created"));
           onClose();
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -1098,22 +1097,20 @@ function CreateUserModal({
   }
 
   return (
-    <Modal onClose={onClose} title="Novo usuário">
+    <Modal onClose={onClose} title={t("team.create.title")}>
       <form action={handle} className="space-y-3">
-        <Field name="name" label="Nome" required />
-        <Field name="email" label="Email" type="email" required />
+        <Field name="name" label={t("team.create.name")} required />
+        <Field name="email" label={t("team.create.email")} type="email" required />
         <Field
           name="phone"
-          label="Telefone (WhatsApp, opcional)"
+          label={t("team.create.phone")}
           placeholder="+5511999999999"
           pattern="^\+\d{10,15}$"
         />
-        <p className="-mt-2 text-[11px] text-zinc-500">
-          Formato E.164 (com + e DDI). Usado para enviar credenciais e lembretes.
-        </p>
+        <p className="-mt-2 text-[11px] text-zinc-500">{t("team.create.phoneHint")}</p>
         <div>
           <label className="mb-1 block text-sm font-medium text-zinc-400">
-            Senha provisória (mínimo {minPasswordLength} caracteres)
+            {t("team.create.tempPassword", { min: minPasswordLength })}
           </label>
           <div className="flex gap-2">
             <input
@@ -1130,22 +1127,20 @@ function CreateUserModal({
               onClick={() => setShowPwd((v) => !v)}
               className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 text-xs text-zinc-300 hover:bg-zinc-800"
             >
-              {showPwd ? "Ocultar" : "Mostrar"}
+              {showPwd ? t("team.password.hide") : t("team.password.show")}
             </button>
             <button
               type="button"
               onClick={generate}
               className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 text-xs text-zinc-300 hover:bg-zinc-800"
             >
-              Gerar
+              {t("team.password.generate")}
             </button>
           </div>
-          <p className="mt-1 text-[11px] text-zinc-500">
-            O usuário será obrigado a trocar a senha no primeiro login.
-          </p>
+          <p className="mt-1 text-[11px] text-zinc-500">{t("team.create.mustChangeHint")}</p>
         </div>
         <div>
-          <label className="mb-1 block text-sm font-medium text-zinc-400">Função</label>
+          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("team.create.role")}</label>
           <select
             name="role"
             defaultValue="PLANNER"
@@ -1164,7 +1159,7 @@ function CreateUserModal({
             onClick={onClose}
             className="rounded-xl px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
           >
-            Cancelar
+            {t("team.create.cancel")}
           </button>
           <button
             type="submit"
@@ -1172,7 +1167,7 @@ function CreateUserModal({
             className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
           >
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <UserCheck className="h-4 w-4" />}
-            Criar usuário
+            {t("team.create.submit")}
           </button>
         </div>
       </form>
@@ -1191,6 +1186,7 @@ function EditUserModal({
   onClose: () => void;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [, startTransition] = useTransition();
   const [busy, setBusy] = useState(false);
   const isSelf = member.id === meId;
@@ -1202,9 +1198,9 @@ function EditUserModal({
       try {
         const r = await updateUser(undefined, formData);
         if (r.success) {
-          toast.success("Usuário atualizado");
+          toast.success(t("team.toast.updated"));
           onClose();
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -1212,19 +1208,19 @@ function EditUserModal({
   }
 
   return (
-    <Modal onClose={onClose} title={`Editar ${member.name ?? member.email}`}>
+    <Modal onClose={onClose} title={t("team.edit.title", { name: member.name ?? member.email })}>
       <form action={handle} className="space-y-3">
-        <Field name="name" label="Nome" required defaultValue={member.name ?? ""} />
-        <Field name="email" label="E-mail" type="email" required defaultValue={member.email} />
+        <Field name="name" label={t("team.edit.name")} required defaultValue={member.name ?? ""} />
+        <Field name="email" label={t("team.edit.email")} type="email" required defaultValue={member.email} />
         <Field
           name="phone"
-          label="Telefone (WhatsApp, opcional)"
+          label={t("team.edit.phone")}
           placeholder="+5511999999999"
           pattern="^\+\d{10,15}$"
           defaultValue={member.phone ?? ""}
         />
         <div>
-          <label className="mb-1 block text-sm font-medium text-zinc-400">Função</label>
+          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("team.edit.role")}</label>
           <select
             name="role"
             defaultValue={member.role}
@@ -1238,7 +1234,7 @@ function EditUserModal({
             ))}
           </select>
           {isSelf ? (
-            <p className="mt-1 text-[11px] text-zinc-500">Você não pode alterar a própria função.</p>
+            <p className="mt-1 text-[11px] text-zinc-500">{t("team.edit.selfRoleHint")}</p>
           ) : null}
         </div>
         <div className="flex justify-end gap-2 pt-2">
@@ -1247,7 +1243,7 @@ function EditUserModal({
             onClick={onClose}
             className="rounded-xl px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
           >
-            Cancelar
+            {t("team.edit.cancel")}
           </button>
           <button
             type="submit"
@@ -1255,7 +1251,7 @@ function EditUserModal({
             className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
           >
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-            Salvar
+            {t("team.edit.submit")}
           </button>
         </div>
       </form>
@@ -1274,6 +1270,7 @@ function ResetPasswordModal({
   toast: ReturnType<typeof useToast>;
   minPasswordLength: number;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [, startTransition] = useTransition();
   const [busy, setBusy] = useState(false);
   const [password, setPassword] = useState("");
@@ -1297,9 +1294,9 @@ function ResetPasswordModal({
       try {
         const r = await resetUserPassword(undefined, formData);
         if (r.success) {
-          toast.success("Senha redefinida — compartilhe a nova com o usuário");
+          toast.success(t("team.toast.passwordReset"));
           onClose();
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -1307,13 +1304,11 @@ function ResetPasswordModal({
   }
 
   return (
-    <Modal onClose={onClose} title={`Redefinir senha de ${member.name ?? member.email}`}>
+    <Modal onClose={onClose} title={t("team.reset.title", { name: member.name ?? member.email })}>
       <form action={handle} className="space-y-3">
-        <p className="text-sm text-zinc-400">
-          O usuário será obrigado a trocar a senha no próximo login.
-        </p>
+        <p className="text-sm text-zinc-400">{t("team.reset.hint")}</p>
         <div>
-          <label className="mb-1 block text-sm font-medium text-zinc-400">Nova senha provisória</label>
+          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("team.reset.newPassword")}</label>
           <div className="flex gap-2">
             <input
               name="newPassword"
@@ -1329,14 +1324,14 @@ function ResetPasswordModal({
               onClick={() => setShow((v) => !v)}
               className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 text-xs text-zinc-300 hover:bg-zinc-800"
             >
-              {show ? "Ocultar" : "Mostrar"}
+              {show ? t("team.password.hide") : t("team.password.show")}
             </button>
             <button
               type="button"
               onClick={generate}
               className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 text-xs text-zinc-300 hover:bg-zinc-800"
             >
-              Gerar
+              {t("team.password.generate")}
             </button>
           </div>
         </div>
@@ -1346,7 +1341,7 @@ function ResetPasswordModal({
             onClick={onClose}
             className="rounded-xl px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
           >
-            Cancelar
+            {t("team.reset.cancel")}
           </button>
           <button
             type="submit"
@@ -1354,7 +1349,7 @@ function ResetPasswordModal({
             className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
           >
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <KeyRound className="h-4 w-4" />}
-            Redefinir
+            {t("team.reset.submit")}
           </button>
         </div>
       </form>
@@ -1369,6 +1364,7 @@ function SecuritySettingsCard({
   initial: SecuritySettings;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [, startTransition] = useTransition();
   const [busy, setBusy] = useState(false);
   const [selected, setSelected] = useState<Role[]>(initial.require2FARoles);
@@ -1386,8 +1382,8 @@ function SecuritySettingsCard({
     startTransition(async () => {
       try {
         const r = await updateSecuritySettings(undefined, fd);
-        if (r.success) toast.success("Política de segurança salva");
-        else toast.error("Falha", r.error);
+        if (r.success) toast.success(t("policy.toast.saved"));
+        else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -1396,14 +1392,12 @@ function SecuritySettingsCard({
 
   return (
     <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-      <h2 className="text-lg font-semibold text-zinc-100">Política de segurança</h2>
-      <p className="text-sm text-zinc-500">
-        Defina quem precisa de 2FA obrigatório e o tamanho mínimo de senha.
-      </p>
+      <h2 className="text-lg font-semibold text-zinc-100">{t("policy.title")}</h2>
+      <p className="text-sm text-zinc-500">{t("policy.subtitle")}</p>
 
       <div className="mt-4 space-y-4">
         <div>
-          <p className="mb-2 text-sm font-medium text-zinc-300">2FA obrigatório nas funções:</p>
+          <p className="mb-2 text-sm font-medium text-zinc-300">{t("policy.require2faLabel")}</p>
           <div className="flex flex-wrap gap-2">
             {ROLE_OPTIONS.map((r) => {
               const active = selected.includes(r);
@@ -1427,9 +1421,7 @@ function SecuritySettingsCard({
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-zinc-400">
-            Tamanho mínimo da senha
-          </label>
+          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("policy.minPasswordLength")}</label>
           <input
             type="number"
             min={6}
@@ -1447,7 +1439,7 @@ function SecuritySettingsCard({
           className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
         >
           {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-          Salvar política
+          {t("policy.save")}
         </button>
       </div>
     </section>
@@ -1461,6 +1453,7 @@ function ProfileTab({
   me: Me;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [, startTransition] = useTransition();
   const [busy, setBusy] = useState(false);
 
@@ -1469,8 +1462,8 @@ function ProfileTab({
     startTransition(async () => {
       try {
         const r = await updateOwnProfile(undefined, formData);
-        if (r.success) toast.success("Nome atualizado");
-        else toast.error("Falha", r.error);
+        if (r.success) toast.success(t("profile.toast.nameUpdated"));
+        else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -1483,9 +1476,9 @@ function ProfileTab({
       try {
         const r = await changeOwnPassword(undefined, formData);
         if (r.success) {
-          toast.success("Senha atualizada");
+          toast.success(t("profile.toast.passwordUpdated"));
           (document.getElementById("own-password-form") as HTMLFormElement | null)?.reset();
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -1495,7 +1488,7 @@ function ProfileTab({
   if (!me) {
     return (
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-        <p className="text-sm text-zinc-400">Faça login para gerenciar o perfil.</p>
+        <p className="text-sm text-zinc-400">{t("profile.loginRequired")}</p>
       </section>
     );
   }
@@ -1503,36 +1496,34 @@ function ProfileTab({
   return (
     <div className="space-y-4">
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-        <h2 className="text-lg font-semibold text-zinc-100">Meu perfil</h2>
+        <h2 className="text-lg font-semibold text-zinc-100">{t("profile.title")}</h2>
         <p className="text-sm text-zinc-500">
-          Email: <span className="text-zinc-300">{me.email}</span> · Função:{" "}
+          {t("profile.emailLabel")} <span className="text-zinc-300">{me.email}</span> · {t("profile.roleLabel")}{" "}
           <span className="text-zinc-300">{ROLE_LABEL[me.role as Role] ?? me.role}</span>
         </p>
         <p className="mt-1 text-[11px] text-zinc-500">
-          {me.lastLoginAt ? `Último login: ${formatDateTimeBR(me.lastLoginAt)} · ` : ""}
-          {me.passwordUpdatedAt ? `Senha atualizada em ${formatDateBR(me.passwordUpdatedAt)}` : "Senha nunca trocada"}
+          {me.lastLoginAt ? `${t("profile.lastLogin", { date: formatDateTimeBR(me.lastLoginAt) })} · ` : ""}
+          {me.passwordUpdatedAt ? t("profile.passwordUpdatedAt", { date: formatDateBR(me.passwordUpdatedAt) }) : t("profile.passwordNeverChanged")}
         </p>
         <form action={handleName} className="mt-4 grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
-          <Field name="name" label="Nome de exibição" required defaultValue={me.name ?? ""} />
+          <Field name="name" label={t("profile.displayName")} required defaultValue={me.name ?? ""} />
           <button
             type="submit"
             disabled={busy}
             className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
           >
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-            Salvar nome
+            {t("profile.saveName")}
           </button>
         </form>
       </section>
 
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-        <h2 className="text-lg font-semibold text-zinc-100">Trocar minha senha</h2>
-        <p className="text-sm text-zinc-500">
-          Digite a senha atual e a nova. A nova precisa ser diferente da atual.
-        </p>
+        <h2 className="text-lg font-semibold text-zinc-100">{t("profile.changePasswordTitle")}</h2>
+        <p className="text-sm text-zinc-500">{t("profile.changePasswordHint")}</p>
         <form id="own-password-form" action={handlePassword} className="mt-4 grid gap-3 sm:grid-cols-2">
-          <Field name="currentPassword" label="Senha atual" type="password" required />
-          <Field name="newPassword" label="Nova senha" type="password" required />
+          <Field name="currentPassword" label={t("profile.currentPassword")} type="password" required />
+          <Field name="newPassword" label={t("profile.newPassword")} type="password" required />
           <div className="sm:col-span-2">
             <button
               type="submit"
@@ -1540,22 +1531,22 @@ function ProfileTab({
               className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
               {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <KeyRound className="h-4 w-4" />}
-              Atualizar senha
+              {t("profile.updatePassword")}
             </button>
           </div>
         </form>
       </section>
 
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-        <h2 className="text-lg font-semibold text-zinc-100">Autenticação em dois fatores</h2>
+        <h2 className="text-lg font-semibold text-zinc-100">{t("profile.twoFactorTitle")}</h2>
         <p className="text-sm text-zinc-500">
           {me.twoFactorEnabled
-            ? "Ativada. Você pode desativar na aba Segurança."
-            : "Inativa. Ative na aba Segurança para reforçar sua conta."}
+            ? t("profile.twoFactorEnabled")
+            : t("profile.twoFactorDisabled")}
         </p>
         <p className="mt-3 inline-flex items-center gap-1 text-sm text-rose-300">
           <Users className="h-4 w-4" />
-          Veja a aba “Segurança” para configurar.
+          {t("profile.twoFactorSeeTab")}
         </p>
       </section>
     </div>
@@ -1597,6 +1588,7 @@ function BackupTab({
   isAdmin: boolean;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [file, setFile] = useState<File | null>(null);
   const [validation, setValidation] = useState<BackupValidationResponse | null>(null);
   const [validating, setValidating] = useState(false);
@@ -1615,7 +1607,7 @@ function BackupTab({
 
   async function handleValidate() {
     if (!file) {
-      toast.error("Selecione um arquivo de backup primeiro.");
+      toast.error(t("backup.toast.selectFirst"));
       return;
     }
     setValidating(true);
@@ -1628,12 +1620,12 @@ function BackupTab({
       const body = (await res.json()) as BackupValidationResponse;
       setValidation(body);
       if (!res.ok || !body.ok) {
-        toast.error(body.error ?? "Arquivo de backup inválido.");
+        toast.error(body.error ?? t("backup.toast.invalidFile"));
       } else {
-        toast.success("Arquivo de backup validado.");
+        toast.success(t("backup.toast.validated"));
       }
     } catch (err) {
-      toast.error("Falha ao validar arquivo", (err as Error).message);
+      toast.error(t("backup.toast.validateFailed"), (err as Error).message);
     } finally {
       setValidating(false);
     }
@@ -1652,13 +1644,13 @@ function BackupTab({
       const body = (await res.json()) as BackupRestoreResponse;
       setLastRestore(body);
       if (!res.ok || !body.ok) {
-        toast.error(body.error ?? "Falha ao restaurar backup.");
+        toast.error(body.error ?? t("backup.toast.restoreFailed"));
       } else {
-        toast.success("Backup restaurado com sucesso. Recarregando…");
+        toast.success(t("backup.toast.restored"));
         setTimeout(() => window.location.reload(), 1500);
       }
     } catch (err) {
-      toast.error("Falha ao restaurar", (err as Error).message);
+      toast.error(t("backup.toast.restoreError"), (err as Error).message);
     } finally {
       setRestoring(false);
     }
@@ -1675,36 +1667,30 @@ function BackupTab({
   return (
     <div className="space-y-4">
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-        <h2 className="text-lg font-semibold text-zinc-100">Exportar backup</h2>
-        <p className="mt-1 text-sm text-zinc-500">
-          Baixa um JSON com fornecedores, pagamentos, aportes, configurações, convidados e tudo
-          mais. Inclui checksum SHA-256 para validação.
-        </p>
+        <h2 className="text-lg font-semibold text-zinc-100">{t("backup.exportTitle")}</h2>
+        <p className="mt-1 text-sm text-zinc-500">{t("backup.exportSubtitle")}</p>
         <a
           href="/api/backup"
           download
           className="mt-4 inline-flex items-center gap-2 rounded-xl bg-zinc-800 px-4 py-2.5 text-sm font-medium text-white hover:bg-zinc-700"
         >
-          <Download className="h-4 w-4" /> Exportar backup JSON
+          <Download className="h-4 w-4" /> {t("backup.exportButton")}
         </a>
-        <p className="mt-3 text-xs text-zinc-500">
-          Faça um backup mensal e antes/depois do casamento. Guarde em local seguro — o arquivo
-          contém dados sensíveis.
-        </p>
+        <p className="mt-3 text-xs text-zinc-500">{t("backup.exportHint")}</p>
       </section>
 
       <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 space-y-4">
         <div>
-          <h2 className="text-lg font-semibold text-zinc-100">Restaurar backup</h2>
+          <h2 className="text-lg font-semibold text-zinc-100">{t("backup.restoreTitle")}</h2>
           <p className="mt-1 text-sm text-zinc-500">
             {isAdmin
-              ? "Carregue um JSON exportado por este sistema. O restore apaga e recria todos os dados na transação. Só admins."
-              : "Apenas administradores podem restaurar backups. Você pode validar o arquivo aqui, mas o restore exige role ADMIN."}
+              ? t("backup.restoreSubtitleAdmin")
+              : t("backup.restoreSubtitleReadonly")}
           </p>
         </div>
 
         <label className="block">
-          <span className="text-xs font-medium text-zinc-400">Arquivo .json</span>
+          <span className="text-xs font-medium text-zinc-400">{t("backup.fileLabel")}</span>
           <input
             type="file"
             accept="application/json,.json"
@@ -1736,7 +1722,7 @@ function BackupTab({
             ) : (
               <ShieldCheck className="h-4 w-4" />
             )}
-            Validar arquivo
+            {t("backup.validateButton")}
           </button>
           {file ? (
             <button
@@ -1744,7 +1730,7 @@ function BackupTab({
               onClick={reset}
               className="text-xs text-zinc-500 underline-offset-2 hover:text-zinc-300 hover:underline"
             >
-              Limpar
+              {t("backup.clear")}
             </button>
           ) : null}
         </div>
@@ -1756,13 +1742,13 @@ function BackupTab({
             <div className="flex items-start gap-2 text-sm text-amber-200">
               <ShieldAlert className="mt-0.5 h-4 w-4 flex-shrink-0" />
               <span>
-                <strong>O restore apaga TODOS os dados atuais</strong> e os substitui pelos do
-                arquivo. Esta operação não pode ser desfeita. Faça um backup antes.
+                <strong>{t("backup.warnStrong")}</strong>
+                {t("backup.warnRest")}
               </span>
             </div>
 
             <label className="block">
-              <span className="text-xs font-medium text-zinc-400">Sua senha (confirmação)</span>
+              <span className="text-xs font-medium text-zinc-400">{t("backup.passwordLabel")}</span>
               <input
                 type="password"
                 value={password}
@@ -1781,8 +1767,8 @@ function BackupTab({
                 className="mt-1"
               />
               <span>
-                Entendo que esta ação <strong>apaga todos os dados</strong> do sistema e os
-                substitui pelos do arquivo. Já fiz um backup antes.
+                {t("backup.acknowledgeStart")} <strong>{t("backup.acknowledgeStrong")}</strong>
+                {t("backup.acknowledgeEnd")}
               </span>
             </label>
 
@@ -1797,25 +1783,23 @@ function BackupTab({
               ) : (
                 <ArchiveRestore className="h-4 w-4" />
               )}
-              Restaurar agora
+              {t("backup.restoreNow")}
             </button>
           </div>
         ) : null}
 
         {lastRestore?.ok && lastRestore.counts ? (
           <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm text-emerald-200">
-            <p className="font-medium">Restore concluído.</p>
+            <p className="font-medium">{t("backup.restoreDone")}</p>
             <p className="mt-1 text-xs text-emerald-200/80">
-              Total restaurado:{" "}
+              {t("backup.totalRestored")}{" "}
               {Object.entries(lastRestore.counts)
                 .filter(([, c]) => c > 0)
                 .map(([k, c]) => `${k}: ${c}`)
-                .join(" · ") || "0 registros"}
+                .join(" · ") || t("backup.zeroRecords")}
             </p>
             {lastRestore.protectedCurrentUser ? (
-              <p className="mt-1 text-xs text-emerald-200/80">
-                Sua conta foi preservada pois não estava no backup.
-              </p>
+              <p className="mt-1 text-xs text-emerald-200/80">{t("backup.accountPreserved")}</p>
             ) : null}
           </div>
         ) : null}
@@ -1823,10 +1807,10 @@ function BackupTab({
 
       <ConfirmDialog
         open={confirmOpen}
-        title="Confirmar restauração"
-        description="Esta ação é IRREVERSÍVEL. Todos os dados atuais serão substituídos pelos do arquivo. Continuar?"
-        confirmLabel={restoring ? "Restaurando…" : "Sim, restaurar"}
-        cancelLabel="Cancelar"
+        title={t("backup.confirm.title")}
+        description={t("backup.confirm.description")}
+        confirmLabel={restoring ? t("backup.confirm.restoring") : t("backup.confirm.confirmLabel")}
+        cancelLabel={t("backup.confirm.cancel")}
         onConfirm={handleRestore}
         onCancel={() => setConfirmOpen(false)}
         tone="danger"
@@ -1837,19 +1821,20 @@ function BackupTab({
 }
 
 function ValidationSummary({ v }: { v: BackupValidationResponse }) {
+  const t = useTranslations("dashboard.settings");
   if (!v.ok) {
     return (
       <div className="rounded-xl border border-rose-500/40 bg-rose-500/5 p-3 text-sm text-rose-200">
-        <p className="font-medium">{v.error ?? "Arquivo inválido"}</p>
+        <p className="font-medium">{v.error ?? t("backup.validation.invalid")}</p>
         {v.issues && v.issues.length > 0 ? (
           <ul className="mt-2 list-disc space-y-0.5 pl-5 text-xs text-rose-200/80">
             {v.issues.slice(0, 8).map((i, idx) => (
               <li key={idx}>
-                <code className="text-rose-300">{i.path || "(raiz)"}</code>: {i.message}
+                <code className="text-rose-300">{i.path || t("backup.validation.root")}</code>: {i.message}
               </li>
             ))}
             {v.issues.length > 8 ? (
-              <li>...e mais {v.issues.length - 8} problemas.</li>
+              <li>{t("backup.validation.moreIssues", { count: v.issues.length - 8 })}</li>
             ) : null}
           </ul>
         ) : null}
@@ -1865,8 +1850,11 @@ function ValidationSummary({ v }: { v: BackupValidationResponse }) {
   return (
     <div className="space-y-2 rounded-xl border border-zinc-800 bg-zinc-950/40 p-3 text-xs text-zinc-300">
       <p className="text-sm text-zinc-100">
-        ✓ Backup v{v.version} válido — {totalRows} registros, exportado em{" "}
-        {v.exportedAt ? formatDateTimeBR(new Date(v.exportedAt)) : "—"}.
+        {t("backup.validation.summary", {
+          version: v.version ?? 0,
+          rows: totalRows,
+          date: v.exportedAt ? formatDateTimeBR(new Date(v.exportedAt)) : "—",
+        })}
       </p>
       <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 sm:grid-cols-3">
         {v.counts
@@ -1881,14 +1869,14 @@ function ValidationSummary({ v }: { v: BackupValidationResponse }) {
       </div>
       {v.meta?.hostname || v.meta?.appVersion ? (
         <p className="text-zinc-500">
-          {v.meta?.hostname ? `host: ${v.meta.hostname}` : ""}
+          {v.meta?.hostname ? t("backup.validation.host", { host: v.meta.hostname }) : ""}
           {v.meta?.hostname && v.meta?.appVersion ? " · " : ""}
-          {v.meta?.appVersion ? `app: v${v.meta.appVersion}` : ""}
+          {v.meta?.appVersion ? t("backup.validation.app", { version: v.meta.appVersion }) : ""}
         </p>
       ) : null}
       {v.checksum ? (
         <p className="text-zinc-500">
-          checksum:{" "}
+          {t("backup.validation.checksum")}{" "}
           <code className="text-zinc-300">{v.checksum.value.slice(0, 16)}…</code>{" "}
           {v.checksumValid ? "✓" : "✗"}
         </p>
@@ -1913,6 +1901,7 @@ function Modal({
   onClose: () => void;
   children: React.ReactNode;
 }) {
+  const t = useTranslations("dashboard.settings");
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center overflow-y-auto bg-black/60 p-4 sm:items-center">
       <div className="my-4 max-h-[calc(100dvh-2rem)] w-full max-w-lg overflow-y-auto rounded-3xl border border-zinc-800 bg-zinc-950 p-6 shadow-2xl">
@@ -1922,7 +1911,7 @@ function Modal({
             type="button"
             onClick={onClose}
             className="rounded-lg p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
-            aria-label="Fechar"
+            aria-label={t("modal.close")}
           >
             ×
           </button>
@@ -1938,6 +1927,7 @@ function WhatsAppTab({
 }: {
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.settings");
   const [status, setStatus] = useState<WhatsAppStatusPayload | null>(null);
   const [busy, setBusy] = useState(false);
   const [testNumber, setTestNumber] = useState("");
@@ -1969,8 +1959,8 @@ function WhatsAppTab({
     setBusy(true);
     try {
       const r = await connectWhatsApp();
-      if (!r.success) toast.error("Falha", r.error);
-      else toast.success("Iniciando conexão. Escaneie o QR Code.");
+      if (!r.success) toast.error(t("toast.failed"), r.error);
+      else toast.success(t("whatsapp.toast.connecting"));
       await refresh();
     } finally {
       setBusy(false);
@@ -1981,8 +1971,8 @@ function WhatsAppTab({
     setBusy(true);
     try {
       const r = await disconnectWhatsAppAction();
-      if (!r.success) toast.error("Falha", r.error);
-      else toast.success("WhatsApp desconectado");
+      if (!r.success) toast.error(t("toast.failed"), r.error);
+      else toast.success(t("whatsapp.toast.disconnected"));
       await refresh();
     } finally {
       setBusy(false);
@@ -1991,7 +1981,7 @@ function WhatsAppTab({
 
   async function handleTest() {
     if (!testNumber) {
-      toast.error("Informe um número");
+      toast.error(t("whatsapp.toast.numberRequired"));
       return;
     }
     setBusy(true);
@@ -1999,8 +1989,8 @@ function WhatsAppTab({
       const fd = new FormData();
       fd.append("phone", testNumber);
       const r = await sendWhatsAppTest(undefined, fd);
-      if (r.success) toast.success("Mensagem de teste enviada");
-      else toast.error("Falha", r.error);
+      if (r.success) toast.success(t("whatsapp.toast.testSent"));
+      else toast.error(t("toast.failed"), r.error);
     } finally {
       setBusy(false);
     }
@@ -2009,24 +1999,23 @@ function WhatsAppTab({
   const state = status?.state ?? "DISCONNECTED";
   const label =
     state === "CONNECTED"
-      ? `Conectado${status?.phoneNumber ? ` (${status.phoneNumber})` : ""}`
+      ? status?.phoneNumber
+        ? t("whatsapp.status.connectedWithPhone", { phone: status.phoneNumber })
+        : t("whatsapp.status.connected")
       : state === "WAITING_QR"
-        ? "Aguardando leitura do QR Code"
+        ? t("whatsapp.status.waitingQr")
         : state === "CONNECTING"
-          ? "Conectando..."
-          : "Desconectado";
+          ? t("whatsapp.status.connecting")
+          : t("whatsapp.status.disconnected");
 
   return (
     <section className="space-y-4 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-2">
           <Smartphone className="h-5 w-5 text-rose-400" />
-          <h2 className="text-lg font-semibold text-zinc-100">WhatsApp</h2>
+          <h2 className="text-lg font-semibold text-zinc-100">{t("whatsapp.title")}</h2>
         </div>
-        <p className="text-sm text-zinc-500">
-          Conecte um número para enviar credenciais, lembretes e redefinições
-          de senha pelo WhatsApp.
-        </p>
+        <p className="text-sm text-zinc-500">{t("whatsapp.subtitle")}</p>
       </div>
 
       <div className="flex items-center gap-3 rounded-xl border border-zinc-800 bg-zinc-950/40 px-4 py-3">
@@ -2047,30 +2036,26 @@ function WhatsAppTab({
 
       {state === "DISCONNECTED" && status?.needsManualAction ? (
         <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
-          Ação necessária: a sessão expirou ou foi desvinculada. Clique em
-          &quot;Conectar&quot; para gerar um novo QR Code.
+          {t("whatsapp.needsManualAction")}
         </div>
       ) : null}
 
       {state === "DISCONNECTED" && !status?.needsManualAction && (status?.attempts ?? 0) > 0 ? (
         <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-200">
-          Tentando reconectar automaticamente · tentativas: {status?.attempts}
+          {t("whatsapp.reconnecting", { attempts: status?.attempts ?? 0 })}
           {status?.lastDisconnectAt
-            ? ` · caiu em ${new Date(status.lastDisconnectAt).toLocaleString("pt-BR", { timeZone: "America/Sao_Paulo" })}`
+            ? ` · ${t("whatsapp.lastDisconnect", { date: new Date(status.lastDisconnectAt).toLocaleString("pt-BR", { timeZone: "America/Sao_Paulo" }) })}`
             : ""}
         </div>
       ) : null}
 
       {state === "WAITING_QR" && status?.qrDataUrl ? (
         <div className="rounded-xl border border-zinc-800 bg-zinc-950/40 p-4">
-          <p className="mb-3 text-sm text-zinc-300">
-            Abra o WhatsApp no celular → Configurações → Aparelhos conectados →
-            Conectar um aparelho. Escaneie:
-          </p>
+          <p className="mb-3 text-sm text-zinc-300">{t("whatsapp.qrInstructions")}</p>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={status.qrDataUrl}
-            alt="QR Code do WhatsApp"
+            alt={t("whatsapp.qrAlt")}
             className="mx-auto h-64 w-64 rounded-lg bg-white p-2"
           />
         </div>
@@ -2085,7 +2070,7 @@ function WhatsAppTab({
             className="inline-flex items-center gap-2 rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-2 text-sm text-rose-200 hover:bg-rose-500/20 disabled:opacity-50"
           >
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <PowerOff className="h-4 w-4" />}
-            Desconectar
+            {t("whatsapp.disconnect")}
           </button>
         ) : (
           <button
@@ -2099,7 +2084,7 @@ function WhatsAppTab({
             ) : (
               <Smartphone className="h-4 w-4" />
             )}
-            {state === "WAITING_QR" ? "Reabrir QR" : "Conectar"}
+            {state === "WAITING_QR" ? t("whatsapp.reopenQr") : t("whatsapp.connect")}
           </button>
         )}
 
@@ -2108,13 +2093,13 @@ function WhatsAppTab({
           onClick={refresh}
           className="inline-flex items-center gap-2 rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-xs text-zinc-300 hover:bg-zinc-800"
         >
-          <RefreshCw className="h-4 w-4" /> Atualizar
+          <RefreshCw className="h-4 w-4" /> {t("whatsapp.refresh")}
         </button>
       </div>
 
       {state === "CONNECTED" ? (
         <div className="rounded-xl border border-zinc-800 bg-zinc-950/40 p-4">
-          <p className="mb-2 text-sm font-medium text-zinc-300">Enviar mensagem de teste</p>
+          <p className="mb-2 text-sm font-medium text-zinc-300">{t("whatsapp.testTitle")}</p>
           <div className="flex flex-col gap-2 sm:flex-row">
             <input
               type="text"
@@ -2130,7 +2115,7 @@ function WhatsAppTab({
               className="inline-flex items-center justify-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
               {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-              Enviar teste
+              {t("whatsapp.sendTest")}
             </button>
           </div>
         </div>

--- a/src/app/dashboard/tasks/page.tsx
+++ b/src/app/dashboard/tasks/page.tsx
@@ -1,9 +1,11 @@
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import TasksClient from "./tasks-client";
 
 export const dynamic = "force-dynamic";
 
 export default async function TasksPage() {
+  const t = await getTranslations("dashboard.tasks");
   const [tasks, vendors, venues] = await Promise.all([
     prisma.task.findMany({
       where: { deletedAt: null },
@@ -28,10 +30,8 @@ export default async function TasksPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Tarefas</h1>
-        <p className="text-sm text-zinc-500">
-          Use o template pronto de 12 meses ou crie tarefas avulsas. Exporta para o calendário.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
       <TasksClient tasks={tasks} vendors={vendors} venues={venues} />
     </div>

--- a/src/app/dashboard/tasks/tasks-client.tsx
+++ b/src/app/dashboard/tasks/tasks-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
 import {
   CheckCircle2,
   ChevronDown,
@@ -44,17 +45,17 @@ type TaskRow = {
 type RefRow = { id: string; name: string };
 
 const STATUS_COLUMNS = [
-  { key: "TODO", label: "A fazer", tone: "bg-zinc-800 text-zinc-200" },
-  { key: "IN_PROGRESS", label: "Em andamento", tone: "bg-sky-500/10 text-sky-300" },
-  { key: "DONE", label: "Concluído", tone: "bg-emerald-500/10 text-emerald-300" },
-  { key: "BLOCKED", label: "Bloqueado", tone: "bg-rose-500/10 text-rose-300" },
+  { key: "TODO", tone: "bg-zinc-800 text-zinc-200" },
+  { key: "IN_PROGRESS", tone: "bg-sky-500/10 text-sky-300" },
+  { key: "DONE", tone: "bg-emerald-500/10 text-emerald-300" },
+  { key: "BLOCKED", tone: "bg-rose-500/10 text-rose-300" },
 ] as const;
 
-const PRIORITY_LABEL: Record<string, { label: string; chip: string }> = {
-  LOW: { label: "Baixa", chip: "bg-zinc-800 text-zinc-400" },
-  MEDIUM: { label: "Média", chip: "bg-zinc-800 text-zinc-200" },
-  HIGH: { label: "Alta", chip: "bg-amber-500/10 text-amber-300" },
-  URGENT: { label: "Urgente", chip: "bg-rose-500/15 text-rose-300" },
+const PRIORITY_CHIP: Record<string, string> = {
+  LOW: "bg-zinc-800 text-zinc-400",
+  MEDIUM: "bg-zinc-800 text-zinc-200",
+  HIGH: "bg-amber-500/10 text-amber-300",
+  URGENT: "bg-rose-500/15 text-rose-300",
 };
 
 type View = "list" | "kanban";
@@ -68,6 +69,8 @@ export default function TasksClient({
   vendors: RefRow[];
   venues: RefRow[];
 }) {
+  const t = useTranslations("dashboard.tasks");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [view, setView] = useState<View>("list");
   const [filter, setFilter] = useState<"all" | "open" | "overdue" | "week">("all");
@@ -81,12 +84,12 @@ export default function TasksClient({
   const filtered = useMemo(() => {
     const now = new Date();
     const weekFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
-    return tasks.filter((t) => {
-      if (filter === "open") return t.status !== "DONE";
+    return tasks.filter((task) => {
+      if (filter === "open") return task.status !== "DONE";
       if (filter === "overdue")
-        return t.status !== "DONE" && t.deadline && new Date(t.deadline) < now;
+        return task.status !== "DONE" && task.deadline && new Date(task.deadline) < now;
       if (filter === "week")
-        return t.status !== "DONE" && t.deadline && new Date(t.deadline) <= weekFromNow;
+        return task.status !== "DONE" && task.deadline && new Date(task.deadline) <= weekFromNow;
       return true;
     });
   }, [tasks, filter]);
@@ -99,9 +102,9 @@ export default function TasksClient({
       try {
         const r = await createTask(undefined, formData);
         if (r.success) {
-          toast.success("Tarefa criada");
+          toast.success(t("toast.created"));
           setCreateOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -114,19 +117,19 @@ export default function TasksClient({
       try {
         const r = await updateTask(undefined, formData);
         if (r.success) {
-          toast.success("Tarefa atualizada");
+          toast.success(t("toast.updated"));
           setEditing(null);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setUpdatingBusy(false);
       }
     });
   }
 
-  function handleStatus(t: TaskRow, status: "TODO" | "IN_PROGRESS" | "DONE" | "BLOCKED") {
+  function handleStatus(task: TaskRow, status: "TODO" | "IN_PROGRESS" | "DONE" | "BLOCKED") {
     startTransition(async () => {
-      const r = await setTaskStatus(t.id, status);
-      if (!r.success) toast.error("Falha", r.error);
+      const r = await setTaskStatus(task.id, status);
+      if (!r.success) toast.error(t("toast.failed"), r.error);
     });
   }
 
@@ -136,9 +139,9 @@ export default function TasksClient({
     startTransition(async () => {
       const r = await deleteTask(id);
       if (r.success) {
-        toast.success("Tarefa removida");
+        toast.success(t("toast.removed"));
         setDeleting(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.failed"), r.error);
     });
   }
 
@@ -148,11 +151,11 @@ export default function TasksClient({
       if (r.success && r.data) {
         toast.success(
           r.data.created === 0
-            ? "Todas as tarefas do template já existem"
-            : `${r.data.created} tarefa(s) criadas`,
+            ? t("toast.templatesAllExist")
+            : t("toast.templatesCreated", { count: r.data.created }),
         );
       } else if (!r.success) {
-        toast.error("Falha", r.error);
+        toast.error(t("toast.failed"), r.error);
       }
     });
   }
@@ -169,10 +172,10 @@ export default function TasksClient({
             }}
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
           >
-            <option value="all">Todas</option>
-            <option value="open">Em aberto</option>
-            <option value="overdue">Atrasadas</option>
-            <option value="week">Próximos 7 dias</option>
+            <option value="all">{t("filter.all")}</option>
+            <option value="open">{t("filter.open")}</option>
+            <option value="overdue">{t("filter.overdue")}</option>
+            <option value="week">{t("filter.week")}</option>
           </select>
           <div className="flex overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950">
             <button
@@ -182,7 +185,7 @@ export default function TasksClient({
                 view === "list" ? "bg-zinc-800 text-zinc-100" : "text-zinc-400 hover:text-zinc-100"
               }`}
             >
-              <ListTodo className="h-4 w-4" /> Lista
+              <ListTodo className="h-4 w-4" /> {t("view.list")}
             </button>
             <button
               type="button"
@@ -191,7 +194,7 @@ export default function TasksClient({
                 view === "kanban" ? "bg-zinc-800 text-zinc-100" : "text-zinc-400 hover:text-zinc-100"
               }`}
             >
-              <KanbanSquare className="h-4 w-4" /> Kanban
+              <KanbanSquare className="h-4 w-4" /> {t("view.kanban")}
             </button>
           </div>
         </div>
@@ -201,21 +204,21 @@ export default function TasksClient({
             download
             className="inline-flex items-center gap-1.5 rounded-xl bg-zinc-800 px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-700"
           >
-            <Download className="h-4 w-4" /> Exportar (.ics)
+            <Download className="h-4 w-4" /> {t("toolbar.exportIcs")}
           </a>
           <button
             type="button"
             onClick={handleLoadTemplates}
             className="inline-flex items-center gap-1.5 rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm font-medium text-rose-200 hover:bg-rose-500/20"
           >
-            <Sparkles className="h-4 w-4" /> Carregar template
+            <Sparkles className="h-4 w-4" /> {t("toolbar.loadTemplate")}
           </button>
           <button
             type="button"
             onClick={() => setCreateOpen(true)}
             className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-lg hover:bg-rose-500"
           >
-            <Plus className="h-4 w-4" /> Nova tarefa
+            <Plus className="h-4 w-4" /> {t("toolbar.newTask")}
           </button>
         </div>
       </div>
@@ -271,8 +274,8 @@ export default function TasksClient({
 
       <ConfirmDialog
         open={!!deleting}
-        title={deleting ? `Excluir "${deleting.title}"?` : "Excluir tarefa?"}
-        confirmLabel="Excluir"
+        title={deleting ? t("delete.titleNamed", { title: deleting.title }) : t("delete.title")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
@@ -292,10 +295,11 @@ function ListView({
   onEdit: (t: TaskRow) => void;
   onDelete: (t: TaskRow) => void;
 }) {
+  const t = useTranslations("dashboard.tasks");
   if (tasks.length === 0) {
     return (
       <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/30 p-8 text-center text-sm text-zinc-500">
-        Nenhuma tarefa neste filtro.
+        {t("list.empty")}
       </div>
     );
   }
@@ -319,9 +323,11 @@ function TaskRowItem({
   onEdit: (t: TaskRow) => void;
   onDelete: (t: TaskRow) => void;
 }) {
+  const t = useTranslations("dashboard.tasks");
+  const tc = useTranslations("common");
   const done = task.status === "DONE";
   const overdue = !done && task.deadline && new Date(task.deadline) < new Date();
-  const priority = PRIORITY_LABEL[task.priority] ?? PRIORITY_LABEL.MEDIUM;
+  const priorityChip = PRIORITY_CHIP[task.priority] ?? PRIORITY_CHIP.MEDIUM;
 
   return (
     <li
@@ -332,7 +338,7 @@ function TaskRowItem({
       <button
         type="button"
         onClick={() => onStatus(task, done ? "TODO" : "DONE")}
-        aria-label={done ? "Reabrir" : "Concluir"}
+        aria-label={done ? t("row.reopen") : t("row.complete")}
         className="shrink-0"
       >
         <CheckCircle2 className={`h-5 w-5 ${done ? "text-emerald-400" : "text-zinc-600"}`} />
@@ -346,18 +352,18 @@ function TaskRowItem({
           {task.responsible ? <span>👤 {task.responsible}</span> : null}
           {task.vendor ? <span>🛒 {task.vendor.name}</span> : null}
           {task.venue ? <span>🏛️ {task.venue.name}</span> : null}
-          {task.templateKey ? <span className="opacity-60">template</span> : null}
+          {task.templateKey ? <span className="opacity-60">{t("row.template")}</span> : null}
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${priority.chip}`}>
-          {priority.label}
+        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${priorityChip}`}>
+          {t(`priority.${task.priority}`)}
         </span>
         <StatusSelect value={task.status} onChange={(v) => onStatus(task, v)} />
         <button
           type="button"
           onClick={() => onEdit(task)}
-          aria-label="Editar"
+          aria-label={tc("actions.edit")}
           className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
         >
           <Pencil className="h-4 w-4" />
@@ -365,7 +371,7 @@ function TaskRowItem({
         <button
           type="button"
           onClick={() => onDelete(task)}
-          aria-label="Excluir"
+          aria-label={tc("actions.delete")}
           className="rounded-lg p-1.5 text-zinc-400 hover:bg-rose-500/10 hover:text-rose-400"
         >
           <Trash2 className="h-4 w-4" />
@@ -382,6 +388,7 @@ function StatusSelect({
   value: string;
   onChange: (v: "TODO" | "IN_PROGRESS" | "DONE" | "BLOCKED") => void;
 }) {
+  const t = useTranslations("dashboard.tasks");
   return (
     <div className="relative">
       <select
@@ -391,7 +398,7 @@ function StatusSelect({
       >
         {STATUS_COLUMNS.map((s) => (
           <option key={s.key} value={s.key}>
-            {s.label}
+            {t(`status.${s.key}`)}
           </option>
         ))}
       </select>
@@ -411,24 +418,25 @@ function KanbanView({
   onEdit: (t: TaskRow) => void;
   onDelete: (t: TaskRow) => void;
 }) {
+  const t = useTranslations("dashboard.tasks");
   return (
     <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
       {STATUS_COLUMNS.map((col) => {
-        const items = tasks.filter((t) => t.status === col.key);
+        const items = tasks.filter((task) => task.status === col.key);
         return (
           <div key={col.key} className="flex flex-col rounded-2xl border border-zinc-800 bg-zinc-900/50 p-3">
             <div className="mb-3 flex items-center justify-between">
               <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] ${col.tone}`}>
-                {col.label}
+                {t(`status.${col.key}`)}
               </span>
               <span className="text-[11px] text-zinc-500">{items.length}</span>
             </div>
             <div className="custom-scrollbar max-h-[60vh] space-y-2 overflow-y-auto pr-1">
               {items.length === 0 ? (
-                <p className="px-1 py-3 text-center text-xs text-zinc-600">Vazio</p>
+                <p className="px-1 py-3 text-center text-xs text-zinc-600">{t("kanban.empty")}</p>
               ) : (
-                items.map((t) => (
-                  <KanbanCard key={t.id} task={t} onStatus={onStatus} onEdit={onEdit} onDelete={onDelete} />
+                items.map((task) => (
+                  <KanbanCard key={task.id} task={task} onStatus={onStatus} onEdit={onEdit} onDelete={onDelete} />
                 ))
               )}
             </div>
@@ -450,9 +458,11 @@ function KanbanCard({
   onEdit: (t: TaskRow) => void;
   onDelete: (t: TaskRow) => void;
 }) {
+  const t = useTranslations("dashboard.tasks");
+  const tc = useTranslations("common");
   const overdue =
     task.status !== "DONE" && task.deadline && new Date(task.deadline) < new Date();
-  const priority = PRIORITY_LABEL[task.priority] ?? PRIORITY_LABEL.MEDIUM;
+  const priorityChip = PRIORITY_CHIP[task.priority] ?? PRIORITY_CHIP.MEDIUM;
   return (
     <div className={`rounded-xl border bg-zinc-950/60 p-3 ${overdue ? "border-rose-500/40" : "border-zinc-800"}`}>
       <p className="text-sm font-medium text-zinc-100">{task.title}</p>
@@ -463,13 +473,13 @@ function KanbanCard({
         {task.responsible ? <span>👤 {task.responsible}</span> : null}
       </div>
       <div className="mt-2 flex items-center justify-between gap-2">
-        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${priority.chip}`}>{priority.label}</span>
+        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${priorityChip}`}>{t(`priority.${task.priority}`)}</span>
         <div className="flex items-center gap-1">
           <StatusSelect value={task.status} onChange={(v) => onStatus(task, v)} />
           <button
             type="button"
             onClick={() => onEdit(task)}
-            aria-label="Editar"
+            aria-label={tc("actions.edit")}
             className="rounded-lg p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
           >
             <Pencil className="h-3.5 w-3.5" />
@@ -477,7 +487,7 @@ function KanbanCard({
           <button
             type="button"
             onClick={() => onDelete(task)}
-            aria-label="Excluir"
+            aria-label={tc("actions.delete")}
             className="rounded-lg p-1 text-zinc-400 hover:bg-rose-500/10 hover:text-rose-400"
           >
             <Trash2 className="h-3.5 w-3.5" />
@@ -505,17 +515,19 @@ function TaskFormModal({
   onClose: () => void;
   formAction: (formData: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.tasks");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-lg rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
         <h2 className="text-lg font-semibold text-white">
-          {mode === "create" ? "Nova tarefa" : "Editar tarefa"}
+          {mode === "create" ? t("form.createTitle") : t("form.editTitle")}
         </h2>
         <form action={formAction} className="mt-4 space-y-3">
           {task ? <input type="hidden" name="id" value={task.id} /> : null}
-          <Field name="title" label="Título" required defaultValue={task?.title ?? ""} />
+          <Field name="title" label={t("form.title")} required defaultValue={task?.title ?? ""} />
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Descrição</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.description")}</label>
             <textarea
               name="description"
               rows={2}
@@ -527,48 +539,48 @@ function TaskFormModal({
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Field
               name="deadline"
-              label="Prazo"
+              label={t("form.deadline")}
               type="date"
               defaultValue={task?.deadline ? toIsoDate(new Date(task.deadline)) : ""}
             />
             <Field
               name="responsible"
-              label="Responsável"
-              placeholder="noivo / noiva / cerimonial"
+              label={t("form.responsible")}
+              placeholder={t("form.responsiblePlaceholder")}
               defaultValue={task?.responsible ?? ""}
             />
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Status</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.status")}</label>
               <select
                 name="status"
                 defaultValue={task?.status ?? "TODO"}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
               >
-                <option value="TODO">A fazer</option>
-                <option value="IN_PROGRESS">Em andamento</option>
-                <option value="DONE">Concluído</option>
-                <option value="BLOCKED">Bloqueado</option>
+                <option value="TODO">{t("status.TODO")}</option>
+                <option value="IN_PROGRESS">{t("status.IN_PROGRESS")}</option>
+                <option value="DONE">{t("status.DONE")}</option>
+                <option value="BLOCKED">{t("status.BLOCKED")}</option>
               </select>
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Prioridade</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.priority")}</label>
               <select
                 name="priority"
                 defaultValue={task?.priority ?? "MEDIUM"}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
               >
-                <option value="LOW">Baixa</option>
-                <option value="MEDIUM">Média</option>
-                <option value="HIGH">Alta</option>
-                <option value="URGENT">Urgente</option>
+                <option value="LOW">{t("priority.LOW")}</option>
+                <option value="MEDIUM">{t("priority.MEDIUM")}</option>
+                <option value="HIGH">{t("priority.HIGH")}</option>
+                <option value="URGENT">{t("priority.URGENT")}</option>
               </select>
             </div>
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Fornecedor (opcional)</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.vendor")} {tc("labels.optional")}</label>
               <select
                 name="vendorId"
                 defaultValue={task?.vendorId ?? ""}
@@ -583,7 +595,7 @@ function TaskFormModal({
               </select>
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Local (opcional)</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.venue")} {tc("labels.optional")}</label>
               <select
                 name="venueId"
                 defaultValue={task?.venueId ?? ""}
@@ -604,14 +616,14 @@ function TaskFormModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/trousseau/page.tsx
+++ b/src/app/dashboard/trousseau/page.tsx
@@ -1,9 +1,11 @@
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import TrousseauClient from "./trousseau-client";
 
 export const dynamic = "force-dynamic";
 
 export default async function TrousseauPage() {
+  const t = await getTranslations("dashboard.trousseau");
   const items = await prisma.trousseauItem.findMany({
     where: { deletedAt: null },
     orderBy: [{ priority: "asc" }, { room: "asc" }, { title: "asc" }],
@@ -12,10 +14,8 @@ export default async function TrousseauPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Enxoval</h1>
-        <p className="text-sm text-zinc-500">
-          Liste o que falta comprar, marque prioridade e acompanhe o orçamento por cômodo.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
       <TrousseauClient items={items} />
     </div>

--- a/src/app/dashboard/trousseau/trousseau-client.tsx
+++ b/src/app/dashboard/trousseau/trousseau-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
 import {
   ExternalLink,
   Gift,
@@ -21,6 +22,21 @@ import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Pagination, usePagination } from "@/components/pagination";
 import { formatCurrency } from "@/lib/format";
 
+type TFn = (key: string) => string;
+
+const ROOM_KEYS = ["KITCHEN", "BATHROOM", "BEDROOM", "LIVING", "LAUNDRY", "ELECTRONICS", "OTHER"] as const;
+const STATUS_KEYS = ["TO_BUY", "BOUGHT", "GIFTED"] as const;
+const PRIORITY_META: Record<string, { chip: string; weight: number }> = {
+  ESSENTIAL: { chip: "bg-rose-500/15 text-rose-300", weight: 1 },
+  NICE_TO_HAVE: { chip: "bg-amber-500/10 text-amber-300", weight: 2 },
+  LUXURY: { chip: "bg-zinc-800 text-zinc-300", weight: 3 },
+};
+const PRIORITY_KEYS = ["ESSENTIAL", "NICE_TO_HAVE", "LUXURY"] as const;
+
+const roomLabel = (t: TFn, k: string) => t(`room.${k}`);
+const priorityLabel = (t: TFn, k: string) => t(`priority.${k}`);
+const statusLabel = (t: TFn, k: string) => t(`status.${k}`);
+
 type Item = {
   id: string;
   title: string;
@@ -34,29 +50,9 @@ type Item = {
   notes: string | null;
 };
 
-const ROOM_LABEL: Record<string, string> = {
-  KITCHEN: "Cozinha",
-  BATHROOM: "Banheiro",
-  BEDROOM: "Quarto",
-  LIVING: "Sala",
-  LAUNDRY: "Lavanderia",
-  ELECTRONICS: "Eletro",
-  OTHER: "Outros",
-};
-
-const PRIORITY_LABEL: Record<string, { label: string; chip: string; weight: number }> = {
-  ESSENTIAL: { label: "Essencial", chip: "bg-rose-500/15 text-rose-300", weight: 1 },
-  NICE_TO_HAVE: { label: "Desejável", chip: "bg-amber-500/10 text-amber-300", weight: 2 },
-  LUXURY: { label: "Luxo", chip: "bg-zinc-800 text-zinc-300", weight: 3 },
-};
-
-const STATUS_LABEL: Record<string, string> = {
-  TO_BUY: "A comprar",
-  BOUGHT: "Comprado",
-  GIFTED: "Ganhei",
-};
-
 export default function TrousseauClient({ items }: { items: Item[] }) {
+  const t = useTranslations("dashboard.trousseau");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<Item | null>(null);
@@ -88,9 +84,9 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
       try {
         const r = await createTrousseauItem(undefined, formData);
         if (r.success) {
-          toast.success("Item adicionado");
+          toast.success(t("toast.created"));
           setOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(tc("common.errorGeneric"), r.error);
       } finally {
         setBusy(false);
       }
@@ -102,9 +98,9 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
       try {
         const r = await updateTrousseauItem(undefined, formData);
         if (r.success) {
-          toast.success("Item atualizado");
+          toast.success(t("toast.updated"));
           setEditing(null);
-        } else toast.error("Falha", r.error);
+        } else toast.error(tc("common.errorGeneric"), r.error);
       } finally {
         setUpdateBusy(false);
       }
@@ -113,7 +109,7 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
   function handleStatus(it: Item, status: "TO_BUY" | "BOUGHT" | "GIFTED") {
     startTransition(async () => {
       const r = await setTrousseauStatus(it.id, status);
-      if (!r.success) toast.error("Falha", r.error);
+      if (!r.success) toast.error(tc("common.errorGeneric"), r.error);
     });
   }
   function handleDelete() {
@@ -122,19 +118,19 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
     startTransition(async () => {
       const r = await deleteTrousseauItem(id);
       if (r.success) {
-        toast.success("Item removido");
+        toast.success(t("toast.deleted"));
         setDeleting(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(tc("common.errorGeneric"), r.error);
     });
   }
 
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
-        <Stat label="Estimado" value={formatCurrency(totals.estTotal)} />
-        <Stat label="Comprado" value={formatCurrency(totals.actualTotal)} accent="emerald" />
-        <Stat label="A comprar" value={String(totals.toBuy)} accent="amber" />
-        <Stat label="Ganhei" value={String(totals.gifted)} accent="emerald" />
+        <Stat label={t("stats.estimated")} value={formatCurrency(totals.estTotal)} />
+        <Stat label={t("stats.bought")} value={formatCurrency(totals.actualTotal)} accent="emerald" />
+        <Stat label={t("stats.toBuy")} value={String(totals.toBuy)} accent="amber" />
+        <Stat label={t("stats.gifted")} value={String(totals.gifted)} accent="emerald" />
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -146,28 +142,29 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
           }}
           className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
         >
-          <option value="ALL">Todos</option>
-          <option value="TO_BUY">A comprar</option>
-          <option value="BOUGHT">Comprado</option>
-          <option value="GIFTED">Ganhei</option>
+          <option value="ALL">{t("filter.all")}</option>
+          <option value="TO_BUY">{t("status.TO_BUY")}</option>
+          <option value="BOUGHT">{t("status.BOUGHT")}</option>
+          <option value="GIFTED">{t("status.GIFTED")}</option>
         </select>
         <button
           type="button"
           onClick={() => setOpen(true)}
           className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500"
         >
-          <Plus className="h-4 w-4" /> Novo item
+          <Plus className="h-4 w-4" /> {t("list.add")}
         </button>
       </div>
 
       {filtered.length === 0 ? (
         <p className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/30 p-8 text-center text-sm text-zinc-500">
-          Nada por aqui ainda.
+          {t("list.empty")}
         </p>
       ) : (
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
           {pageItems.map((it) => {
-            const prio = PRIORITY_LABEL[it.priority] ?? PRIORITY_LABEL.NICE_TO_HAVE;
+            const prioKey = PRIORITY_META[it.priority] ? it.priority : "NICE_TO_HAVE";
+            const prio = PRIORITY_META[prioKey];
             return (
               <article
                 key={it.id}
@@ -182,18 +179,18 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
                         {it.title}
                       </h3>
                       <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${prio.chip}`}>
-                        {prio.label}
+                        {priorityLabel(t, prioKey)}
                       </span>
                     </div>
                     <p className="mt-0.5 text-xs text-zinc-500">
-                      {ROOM_LABEL[it.room] ?? it.room}
+                      {ROOM_KEYS.includes(it.room as (typeof ROOM_KEYS)[number]) ? roomLabel(t, it.room) : it.room}
                       {it.store ? ` · ${it.store}` : ""}
                     </p>
                     <p className="mt-2 text-sm text-zinc-300">
                       {it.estimatedPrice ? formatCurrency(it.estimatedPrice) : "—"}
                       {it.actualPrice ? (
                         <span className="ml-2 text-emerald-300">
-                          (pago: {formatCurrency(it.actualPrice)})
+                          {t("card.paid", { value: formatCurrency(it.actualPrice) })}
                         </span>
                       ) : null}
                     </p>
@@ -204,19 +201,19 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
                         rel="noopener noreferrer"
                         className="mt-1 inline-flex items-center gap-1 text-xs text-rose-300 hover:text-rose-200"
                       >
-                        <ExternalLink className="h-3 w-3" /> Link da loja
+                        <ExternalLink className="h-3 w-3" /> {t("card.storeLink")}
                       </a>
                     ) : null}
                   </div>
                   <div className="flex flex-col items-end gap-1">
                     <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-[10px] uppercase tracking-wider text-zinc-300">
-                      {STATUS_LABEL[it.status]}
+                      {statusLabel(t, it.status)}
                     </span>
                     <div className="flex gap-1">
                       <button
                         type="button"
                         onClick={() => handleStatus(it, it.status === "BOUGHT" ? "TO_BUY" : "BOUGHT")}
-                        aria-label="Alternar comprado"
+                        aria-label={t("card.toggleBought")}
                         className={`rounded-lg p-1.5 ${
                           it.status === "BOUGHT"
                             ? "bg-emerald-500/10 text-emerald-300"
@@ -228,7 +225,7 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
                       <button
                         type="button"
                         onClick={() => handleStatus(it, it.status === "GIFTED" ? "TO_BUY" : "GIFTED")}
-                        aria-label="Ganhei"
+                        aria-label={t("card.toggleGifted")}
                         className={`rounded-lg p-1.5 ${
                           it.status === "GIFTED"
                             ? "bg-emerald-500/10 text-emerald-300"
@@ -240,7 +237,7 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
                       <button
                         type="button"
                         onClick={() => setEditing(it)}
-                        aria-label="Editar"
+                        aria-label={tc("actions.edit")}
                         className="rounded-lg bg-zinc-800/70 p-1.5 text-zinc-300 hover:bg-zinc-700"
                       >
                         <Pencil className="h-3.5 w-3.5" />
@@ -248,7 +245,7 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
                       <button
                         type="button"
                         onClick={() => setDeleting(it)}
-                        aria-label="Excluir"
+                        aria-label={tc("actions.delete")}
                         className="rounded-lg bg-zinc-800/70 p-1.5 text-rose-400 hover:bg-rose-500/20"
                       >
                         <Trash2 className="h-3.5 w-3.5" />
@@ -286,8 +283,8 @@ export default function TrousseauClient({ items }: { items: Item[] }) {
 
       <ConfirmDialog
         open={!!deleting}
-        title="Excluir item?"
-        confirmLabel="Excluir"
+        title={t("confirmDelete.title")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
@@ -327,67 +324,69 @@ function ItemModal({
   onClose: () => void;
   formAction: (formData: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.trousseau");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
         <h2 className="text-lg font-semibold text-white">
-          {mode === "create" ? "Novo item do enxoval" : "Editar item"}
+          {mode === "create" ? t("form.createTitle") : t("form.editTitle")}
         </h2>
         <form action={formAction} className="mt-4 space-y-3">
           {item ? <input type="hidden" name="id" value={item.id} /> : null}
-          <Field name="title" label="Item" required defaultValue={item?.title ?? ""} />
+          <Field name="title" label={t("form.item")} required defaultValue={item?.title ?? ""} />
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Cômodo</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.room")}</label>
               <select
                 name="room"
                 defaultValue={item?.room ?? "OTHER"}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
               >
-                {Object.entries(ROOM_LABEL).map(([k, v]) => (
+                {ROOM_KEYS.map((k) => (
                   <option key={k} value={k}>
-                    {v}
+                    {roomLabel(t, k)}
                   </option>
                 ))}
               </select>
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Prioridade</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.priority")}</label>
               <select
                 name="priority"
                 defaultValue={item?.priority ?? "NICE_TO_HAVE"}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
               >
-                {Object.entries(PRIORITY_LABEL).map(([k, v]) => (
+                {PRIORITY_KEYS.map((k) => (
                   <option key={k} value={k}>
-                    {v.label}
+                    {priorityLabel(t, k)}
                   </option>
                 ))}
               </select>
             </div>
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Field name="estimatedPrice" label="Preço estimado" type="number" step="0.01" defaultValue={item?.estimatedPrice?.toString() ?? ""} />
-            <Field name="actualPrice" label="Preço pago" type="number" step="0.01" defaultValue={item?.actualPrice?.toString() ?? ""} />
+            <Field name="estimatedPrice" label={t("form.estimatedPrice")} type="number" step="0.01" defaultValue={item?.estimatedPrice?.toString() ?? ""} />
+            <Field name="actualPrice" label={t("form.actualPrice")} type="number" step="0.01" defaultValue={item?.actualPrice?.toString() ?? ""} />
           </div>
-          <Field name="store" label="Loja" defaultValue={item?.store ?? ""} />
-          <Field name="link" label="Link" type="url" defaultValue={item?.link ?? ""} />
+          <Field name="store" label={t("form.store")} defaultValue={item?.store ?? ""} />
+          <Field name="link" label={t("form.link")} type="url" defaultValue={item?.link ?? ""} />
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Status</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.status")}</label>
             <select
               name="status"
               defaultValue={item?.status ?? "TO_BUY"}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
             >
-              {Object.entries(STATUS_LABEL).map(([k, v]) => (
+              {STATUS_KEYS.map((k) => (
                 <option key={k} value={k}>
-                  {v}
+                  {statusLabel(t, k)}
                 </option>
               ))}
             </select>
           </div>
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.notes")}</label>
             <textarea
               name="notes"
               rows={2}
@@ -402,14 +401,14 @@ function ItemModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/vendors/[id]/page.tsx
+++ b/src/app/dashboard/vendors/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import { ArrowLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
@@ -10,6 +11,7 @@ export const dynamic = "force-dynamic";
 
 export default async function VendorDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const t = await getTranslations("dashboard.vendors.detail");
   const session = await auth();
   const role = (session?.user as { role?: string } | undefined)?.role;
   const showFinance = canViewSensitiveFinance(role);
@@ -57,7 +59,7 @@ export default async function VendorDetailPage({ params }: { params: Promise<{ i
           className="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-300"
         >
           <ArrowLeft className="h-4 w-4" />
-          <span>Voltar para fornecedores</span>
+          <span>{t("back")}</span>
         </Link>
       </div>
       <VendorDetailClient vendor={sanitized} role={role ?? null} />

--- a/src/app/dashboard/vendors/[id]/vendor-detail-client.tsx
+++ b/src/app/dashboard/vendors/[id]/vendor-detail-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import {
   AlertCircle,
   CheckCircle2,
@@ -117,21 +118,16 @@ type VendorFull = VendorBase & {
   attachments: Attachment[];
 };
 
-const CONTRACT_STATUS_LABEL: Record<string, string> = {
-  DRAFT: "Rascunho",
-  SENT: "Enviado",
-  NEGOTIATING: "Negociando",
-  SIGNED_DIGITAL: "Assinado (digital)",
-  SIGNED_PHYSICAL: "Assinado (físico)",
-  CANCELLED: "Cancelado",
-};
+const CONTRACT_STATUS_KEYS = [
+  "DRAFT",
+  "SENT",
+  "NEGOTIATING",
+  "SIGNED_DIGITAL",
+  "SIGNED_PHYSICAL",
+  "CANCELLED",
+] as const;
 
-const NOTE_KIND_LABEL: Record<string, string> = {
-  NOTE: "Nota",
-  NEGOTIATION_EVENT: "Negociação",
-  MEETING: "Reunião",
-  DECISION: "Decisão",
-};
+const NOTE_KIND_KEYS = ["NOTE", "NEGOTIATION_EVENT", "MEETING", "DECISION"] as const;
 
 export default function VendorDetailClient({
   vendor,
@@ -179,6 +175,7 @@ function Header({
   paidTotal: number;
   balance: number;
 }) {
+  const t = useTranslations("dashboard.vendors.detail");
   return (
     <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
@@ -186,7 +183,7 @@ function Header({
           <span className="text-xs uppercase tracking-wider text-zinc-500">{vendor.category}</span>
           <h1 className="mt-1 text-2xl font-bold text-white">{vendor.name}</h1>
           {vendor.indicatedBy ? (
-            <p className="mt-1 text-xs text-zinc-500">Indicado por: {vendor.indicatedBy}</p>
+            <p className="mt-1 text-xs text-zinc-500">{t("header.indicatedBy", { name: vendor.indicatedBy })}</p>
           ) : null}
           {vendor.tags ? (
             <div className="mt-2 flex flex-wrap gap-1.5">
@@ -225,7 +222,7 @@ function Header({
                   : "bg-amber-500/10 text-amber-400 border-amber-500/20"
             }`}
           >
-            {vendor.status === "CONTRACTED" ? "Contratado" : vendor.status === "FINALIZED" ? "Finalizado" : "Em Negociação"}
+            {vendor.status === "CONTRACTED" ? t("status.contracted") : vendor.status === "FINALIZED" ? t("status.finalized") : t("status.negotiation")}
           </span>
           {vendor.contractLink ? (
             <a
@@ -234,7 +231,7 @@ function Header({
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200"
             >
-              <ExternalLink className="h-3.5 w-3.5" /> Link do contrato
+              <ExternalLink className="h-3.5 w-3.5" /> {t("header.contractLink")}
             </a>
           ) : null}
         </div>
@@ -247,9 +244,9 @@ function Header({
       ) : null}
 
       <div className="mt-6 grid gap-4 sm:grid-cols-3">
-        <Stat label="Orçado" value={budgetTotal} accent="zinc" />
-        <Stat label="Já pago" value={paidTotal} accent="emerald" />
-        <Stat label="Saldo" value={balance} accent={balance > 0 ? "rose" : "emerald"} />
+        <Stat label={t("header.budgeted")} value={budgetTotal} accent="zinc" />
+        <Stat label={t("header.paid")} value={paidTotal} accent="emerald" />
+        <Stat label={t("header.balance")} value={balance} accent={balance > 0 ? "rose" : "emerald"} />
       </div>
     </div>
   );
@@ -283,6 +280,8 @@ function ContactsSection({
   startTransition: React.TransitionStartFunction;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.vendors.detail");
+  const tc = useTranslations("common");
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
@@ -293,9 +292,9 @@ function ContactsSection({
       try {
         const r = await createVendorContact(undefined, formData);
         if (r.success) {
-          toast.success("Contato adicionado");
+          toast.success(t("contacts.added"));
           setOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -308,16 +307,16 @@ function ContactsSection({
     startTransition(async () => {
       const r = await deleteVendorContact(id, vendor.id);
       if (r.success) {
-        toast.success("Contato removido");
+        toast.success(t("contacts.removed"));
         setDeleteId(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.failed"), r.error);
     });
   }
 
   return (
-    <Card title="Contatos" icon={<Users className="h-5 w-5" />} action={() => setOpen(true)}>
+    <Card title={t("contacts.title")} icon={<Users className="h-5 w-5" />} action={() => setOpen(true)}>
       {vendor.contacts.length === 0 ? (
-        <Empty text="Nenhum contato cadastrado." />
+        <Empty text={t("contacts.empty")} />
       ) : (
         <ul className="space-y-2">
           {vendor.contacts.map((c) => (
@@ -327,7 +326,7 @@ function ContactsSection({
                   <span className="font-medium text-zinc-200">{c.name}</span>
                   {c.isPrimary ? (
                     <span className="rounded-full border border-rose-500/30 bg-rose-500/10 px-1.5 py-0.5 text-[10px] text-rose-300">
-                      Principal
+                      {t("contacts.primary")}
                     </span>
                   ) : null}
                 </div>
@@ -350,7 +349,7 @@ function ContactsSection({
                 type="button"
                 onClick={() => setDeleteId(c.id)}
                 className="rounded-lg p-1.5 text-zinc-400 hover:bg-rose-500/10 hover:text-rose-400"
-                aria-label="Excluir contato"
+                aria-label={t("contacts.deleteAria")}
               >
                 <Trash2 className="h-4 w-4" />
               </button>
@@ -362,15 +361,15 @@ function ContactsSection({
       {open ? (
         <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
           <div className="my-4 w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
-            <h2 className="text-lg font-semibold text-white">Novo contato</h2>
+            <h2 className="text-lg font-semibold text-white">{t("contacts.formTitle")}</h2>
             <form action={handleSubmit} className="mt-4 space-y-3">
               <input type="hidden" name="vendorId" value={vendor.id} />
-              <Input name="name" label="Nome" required />
-              <Input name="role" label="Função (ex: gerente, atendimento)" />
-              <Input name="phone" label="Telefone" placeholder="+5511..." />
-              <Input name="email" label="Email" type="email" />
+              <Input name="name" label={t("contacts.name")} required />
+              <Input name="role" label={t("contacts.role")} />
+              <Input name="phone" label={tc("labels.phone")} placeholder="+5511..." />
+              <Input name="email" label={tc("labels.email")} type="email" />
               <label className="flex items-center gap-2 text-sm text-zinc-300">
-                <input type="checkbox" name="isPrimary" className="accent-rose-500" /> Contato principal
+                <input type="checkbox" name="isPrimary" className="accent-rose-500" /> {t("contacts.isPrimary")}
               </label>
               <ModalActions onCancel={() => setOpen(false)} busy={busy} />
             </form>
@@ -380,8 +379,8 @@ function ContactsSection({
 
       <ConfirmDialog
         open={!!deleteId}
-        title="Remover contato?"
-        confirmLabel="Remover"
+        title={t("contacts.removeTitle")}
+        confirmLabel={tc("actions.remove")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleteId(null)}
@@ -399,6 +398,8 @@ function NotesSection({
   startTransition: React.TransitionStartFunction;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.vendors.detail");
+  const tc = useTranslations("common");
   const [busy, setBusy] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
@@ -408,10 +409,10 @@ function NotesSection({
       try {
         const r = await createVendorNote(undefined, formData);
         if (r.success) {
-          toast.success("Nota adicionada");
+          toast.success(t("notes.added"));
           const form = document.getElementById(`note-form-${vendor.id}`) as HTMLFormElement | null;
           form?.reset();
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -424,14 +425,14 @@ function NotesSection({
     startTransition(async () => {
       const r = await deleteVendorNote(id, vendor.id);
       if (r.success) {
-        toast.success("Nota removida");
+        toast.success(t("notes.removed"));
         setDeleteId(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.failed"), r.error);
     });
   }
 
   return (
-    <Card title="Notas e negociação" icon={<MessageSquare className="h-5 w-5" />}>
+    <Card title={t("notes.title")} icon={<MessageSquare className="h-5 w-5" />}>
       <form id={`note-form-${vendor.id}`} action={handleSubmit} className="mb-4 space-y-2">
         <input type="hidden" name="vendorId" value={vendor.id} />
         <div className="flex gap-2">
@@ -440,10 +441,10 @@ function NotesSection({
             defaultValue="NOTE"
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
           >
-            <option value="NOTE">Nota</option>
-            <option value="NEGOTIATION_EVENT">Negociação</option>
-            <option value="MEETING">Reunião</option>
-            <option value="DECISION">Decisão</option>
+            <option value="NOTE">{t("noteKind.NOTE")}</option>
+            <option value="NEGOTIATION_EVENT">{t("noteKind.NEGOTIATION_EVENT")}</option>
+            <option value="MEETING">{t("noteKind.MEETING")}</option>
+            <option value="DECISION">{t("noteKind.DECISION")}</option>
           </select>
         </div>
         <textarea
@@ -451,7 +452,7 @@ function NotesSection({
           rows={2}
           required
           maxLength={4000}
-          placeholder="Anote o que aconteceu, decidiu, combinou..."
+          placeholder={t("notes.bodyPlaceholder")}
           className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
         />
         <button
@@ -460,12 +461,12 @@ function NotesSection({
           className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
         >
           {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-          <span>Adicionar</span>
+          <span>{t("notes.add")}</span>
         </button>
       </form>
 
       {vendor.vendorNotes.length === 0 ? (
-        <Empty text="Sem notas ainda. Use este espaço como histórico de negociação." />
+        <Empty text={t("notes.empty")} />
       ) : (
         <ul className="space-y-2">
           {vendor.vendorNotes.map((n) => (
@@ -474,7 +475,7 @@ function NotesSection({
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="text-[10px] uppercase tracking-wider text-zinc-500">
-                      {NOTE_KIND_LABEL[n.kind] ?? n.kind}
+                      {(NOTE_KIND_KEYS as readonly string[]).includes(n.kind) ? t(`noteKind.${n.kind}`) : n.kind}
                     </span>
                     <span className="text-[11px] text-zinc-500">{formatDateTimeBR(n.createdAt)}</span>
                   </div>
@@ -484,7 +485,7 @@ function NotesSection({
                   type="button"
                   onClick={() => setDeleteId(n.id)}
                   className="rounded-lg p-1.5 text-zinc-500 hover:bg-rose-500/10 hover:text-rose-400"
-                  aria-label="Excluir nota"
+                  aria-label={t("notes.deleteAria")}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                 </button>
@@ -496,8 +497,8 @@ function NotesSection({
 
       <ConfirmDialog
         open={!!deleteId}
-        title="Remover nota?"
-        confirmLabel="Remover"
+        title={t("notes.removeTitle")}
+        confirmLabel={tc("actions.remove")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleteId(null)}
@@ -517,6 +518,8 @@ function ContractsSection({
   startTransition: React.TransitionStartFunction;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.vendors.detail");
+  const tc = useTranslations("common");
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
@@ -530,9 +533,9 @@ function ContractsSection({
       try {
         const r = await createContract(undefined, formData);
         if (r.success) {
-          toast.success("Contrato criado");
+          toast.success(t("contracts.created"));
           setOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -545,16 +548,16 @@ function ContractsSection({
     startTransition(async () => {
       const r = await deleteContract(id, vendor.id);
       if (r.success) {
-        toast.success("Contrato removido");
+        toast.success(t("contracts.removed"));
         setDeleteId(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.failed"), r.error);
     });
   }
 
   return (
-    <Card title="Contratos" icon={<FileText className="h-5 w-5" />} action={() => setOpen(true)}>
+    <Card title={t("contracts.title")} icon={<FileText className="h-5 w-5" />} action={() => setOpen(true)}>
       {vendor.contracts.length === 0 ? (
-        <Empty text="Nenhum contrato registrado. Use para guardar cláusulas-chave e versões." />
+        <Empty text={t("contracts.empty")} />
       ) : (
         <ul className="space-y-3">
           {vendor.contracts.map((c) => (
@@ -565,27 +568,27 @@ function ContractsSection({
                     <h4 className="font-semibold text-zinc-100">{c.title}</h4>
                     <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-[11px] text-zinc-300">v{c.version}</span>
                     <span className="rounded-full border border-zinc-700 bg-zinc-800/60 px-2 py-0.5 text-[11px] text-zinc-300">
-                      {CONTRACT_STATUS_LABEL[c.status] ?? c.status}
+                      {(CONTRACT_STATUS_KEYS as readonly string[]).includes(c.status) ? t(`contractStatus.${c.status}`) : c.status}
                     </span>
                   </div>
                   <div className="mt-2 grid gap-2 sm:grid-cols-3">
-                    {c.totalValue ? <Mini label="Valor" value={formatCurrency(c.totalValue)} /> : null}
-                    {c.signedAt ? <Mini label="Assinado" value={formatDateBR(c.signedAt)} /> : null}
-                    {c.expiresAt ? <Mini label="Vence" value={formatDateBR(c.expiresAt)} /> : null}
+                    {c.totalValue ? <Mini label={t("contracts.value")} value={formatCurrency(c.totalValue)} /> : null}
+                    {c.signedAt ? <Mini label={t("contracts.signed")} value={formatDateBR(c.signedAt)} /> : null}
+                    {c.expiresAt ? <Mini label={t("contracts.expires")} value={formatDateBR(c.expiresAt)} /> : null}
                   </div>
-                  {c.paymentTerms ? <MiniBlock label="Condições de pagamento" body={c.paymentTerms} /> : null}
+                  {c.paymentTerms ? <MiniBlock label={t("contracts.paymentTerms")} body={c.paymentTerms} /> : null}
                   {c.cancellationPolicy ? (
-                    <MiniBlock label="Política de cancelamento" body={c.cancellationPolicy} />
+                    <MiniBlock label={t("contracts.cancellationPolicy")} body={c.cancellationPolicy} />
                   ) : null}
-                  {c.includedItems ? <MiniBlock label="Incluso" body={c.includedItems} /> : null}
-                  {c.excludedItems ? <MiniBlock label="Não incluso" body={c.excludedItems} /> : null}
-                  {c.notes ? <MiniBlock label="Observações" body={c.notes} /> : null}
+                  {c.includedItems ? <MiniBlock label={t("contracts.included")} body={c.includedItems} /> : null}
+                  {c.excludedItems ? <MiniBlock label={t("contracts.excluded")} body={c.excludedItems} /> : null}
+                  {c.notes ? <MiniBlock label={t("contracts.notes")} body={c.notes} /> : null}
                 </div>
                 <button
                   type="button"
                   onClick={() => setDeleteId(c.id)}
                   className="rounded-lg p-1.5 text-zinc-400 hover:bg-rose-500/10 hover:text-rose-400"
-                  aria-label="Excluir contrato"
+                  aria-label={t("contracts.deleteAria")}
                 >
                   <Trash2 className="h-4 w-4" />
                 </button>
@@ -608,9 +611,9 @@ function ContractsSection({
 
       <ConfirmDialog
         open={!!deleteId}
-        title="Excluir contrato?"
-        description="O contrato será removido da listagem mas pode ser recuperado via banco."
-        confirmLabel="Excluir"
+        title={t("contracts.removeTitle")}
+        description={t("contracts.removeDescription")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleteId(null)}
@@ -630,38 +633,40 @@ function ContractForm({
   onClose: () => void;
   onSubmit: (formData: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.vendors.detail");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
       <div className="my-4 w-full max-w-2xl rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
-        <h2 className="text-lg font-semibold text-white">Novo contrato</h2>
+        <h2 className="text-lg font-semibold text-white">{t("contractForm.title")}</h2>
         <form action={onSubmit} className="mt-4 space-y-3">
           <input type="hidden" name="vendorId" value={vendorId} />
-          <Input name="title" label="Título" placeholder="Ex: Contrato Buffet Colonial" required />
+          <Input name="title" label={t("contractForm.titleLabel")} placeholder={t("contractForm.titlePlaceholder")} required />
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Status</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.status")}</label>
               <select
                 name="status"
                 defaultValue="DRAFT"
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
               >
-                {Object.entries(CONTRACT_STATUS_LABEL).map(([k, v]) => (
-                  <option key={k} value={k}>{v}</option>
+                {CONTRACT_STATUS_KEYS.map((k) => (
+                  <option key={k} value={k}>{t(`contractStatus.${k}`)}</option>
                 ))}
               </select>
             </div>
-            <Input name="totalValue" type="number" step="0.01" label="Valor total (R$)" />
+            <Input name="totalValue" type="number" step="0.01" label={t("contractForm.totalValue")} />
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Input name="signedAt" type="date" label="Data de assinatura" />
-            <Input name="expiresAt" type="date" label="Validade / expiração" />
+            <Input name="signedAt" type="date" label={t("contractForm.signedAt")} />
+            <Input name="expiresAt" type="date" label={t("contractForm.expiresAt")} />
           </div>
-          <Textarea name="paymentTerms" label="Condições de pagamento" rows={2} />
-          <Textarea name="cancellationPolicy" label="Política de cancelamento" rows={2} />
-          <Textarea name="includedItems" label="O que está incluso" rows={2} />
-          <Textarea name="excludedItems" label="O que NÃO está incluso" rows={2} />
-          <Textarea name="notes" label="Observações" rows={2} />
-          <ModalActions onCancel={onClose} busy={busy} confirmLabel="Salvar contrato" />
+          <Textarea name="paymentTerms" label={t("contracts.paymentTerms")} rows={2} />
+          <Textarea name="cancellationPolicy" label={t("contracts.cancellationPolicy")} rows={2} />
+          <Textarea name="includedItems" label={t("contractForm.includedItems")} rows={2} />
+          <Textarea name="excludedItems" label={t("contractForm.excludedItems")} rows={2} />
+          <Textarea name="notes" label={t("contracts.notes")} rows={2} />
+          <ModalActions onCancel={onClose} busy={busy} confirmLabel={t("contractForm.save")} />
         </form>
       </div>
     </div>
@@ -677,6 +682,8 @@ function AttachmentsSection({
   startTransition: React.TransitionStartFunction;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.vendors.detail");
+  const tc = useTranslations("common");
   const [busy, setBusy] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
@@ -686,10 +693,10 @@ function AttachmentsSection({
       try {
         const r = await uploadAttachment(undefined, formData);
         if (r.success) {
-          toast.success("Arquivo anexado");
+          toast.success(t("attachments.uploaded"));
           const form = document.getElementById(`upload-form-${vendor.id}`) as HTMLFormElement | null;
           form?.reset();
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
       }
@@ -702,19 +709,19 @@ function AttachmentsSection({
     startTransition(async () => {
       const r = await deleteAttachment(id);
       if (r.success) {
-        toast.success("Anexo removido");
+        toast.success(t("attachments.removed"));
         setDeleteId(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.failed"), r.error);
     });
   }
 
   return (
-    <Card title="Anexos" icon={<Paperclip className="h-5 w-5" />}>
+    <Card title={t("attachments.title")} icon={<Paperclip className="h-5 w-5" />}>
       <form id={`upload-form-${vendor.id}`} action={handleUpload} className="mb-4 grid gap-2 sm:grid-cols-[1fr_auto_auto] sm:items-end">
         <input type="hidden" name="ownerType" value="VENDOR" />
         <input type="hidden" name="ownerId" value={vendor.id} />
         <label className="block">
-          <span className="mb-1 block text-sm font-medium text-zinc-400">Arquivo (PDF/PNG/JPG, até 10MB)</span>
+          <span className="mb-1 block text-sm font-medium text-zinc-400">{t("attachments.fileLabel")}</span>
           <input
             type="file"
             name="file"
@@ -724,19 +731,19 @@ function AttachmentsSection({
           />
         </label>
         <div>
-          <label className="mb-1 block text-sm font-medium text-zinc-400">Tipo</label>
+          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("attachments.kindLabel")}</label>
           <select
             name="kind"
             defaultValue="CONTRACT"
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
           >
-            <option value="CONTRACT">Contrato</option>
-            <option value="PROPOSAL">Proposta</option>
-            <option value="RECEIPT">Comprovante</option>
-            <option value="INVOICE">NF / Boleto</option>
-            <option value="ID_DOC">Documento</option>
-            <option value="PHOTO">Foto</option>
-            <option value="OTHER">Outro</option>
+            <option value="CONTRACT">{t("attachmentKind.CONTRACT")}</option>
+            <option value="PROPOSAL">{t("attachmentKind.PROPOSAL")}</option>
+            <option value="RECEIPT">{t("attachmentKind.RECEIPT")}</option>
+            <option value="INVOICE">{t("attachmentKind.INVOICE")}</option>
+            <option value="ID_DOC">{t("attachmentKind.ID_DOC")}</option>
+            <option value="PHOTO">{t("attachmentKind.PHOTO")}</option>
+            <option value="OTHER">{t("attachmentKind.OTHER")}</option>
           </select>
         </div>
         <button
@@ -745,12 +752,12 @@ function AttachmentsSection({
           className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
         >
           {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
-          <span>Enviar</span>
+          <span>{t("attachments.send")}</span>
         </button>
       </form>
 
       {vendor.attachments.length === 0 ? (
-        <Empty text="Nenhum arquivo anexado." />
+        <Empty text={t("attachments.empty")} />
       ) : (
         <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           {vendor.attachments.map((a) => (
@@ -778,7 +785,7 @@ function AttachmentsSection({
                 type="button"
                 onClick={() => setDeleteId(a.id)}
                 className="rounded-lg p-1.5 text-zinc-500 hover:bg-rose-500/10 hover:text-rose-400"
-                aria-label="Excluir anexo"
+                aria-label={t("attachments.deleteAria")}
               >
                 <Trash2 className="h-4 w-4" />
               </button>
@@ -789,8 +796,8 @@ function AttachmentsSection({
 
       <ConfirmDialog
         open={!!deleteId}
-        title="Excluir anexo?"
-        confirmLabel="Excluir"
+        title={t("attachments.removeTitle")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleteId(null)}
@@ -800,10 +807,11 @@ function AttachmentsSection({
 }
 
 function PaymentsSection({ vendor }: { vendor: VendorFull }) {
+  const t = useTranslations("dashboard.vendors.detail");
   return (
-    <Card title="Pagamentos" icon={<CheckCircle2 className="h-5 w-5" />}>
+    <Card title={t("payments.title")} icon={<CheckCircle2 className="h-5 w-5" />}>
       {vendor.payments.length === 0 ? (
-        <Empty text="Nenhum pagamento. Use a aba Pagamentos para adicionar." />
+        <Empty text={t("payments.empty")} />
       ) : (
         <ul className="divide-y divide-zinc-800/60">
           {vendor.payments.map((p) => (
@@ -828,7 +836,7 @@ function PaymentsSection({ vendor }: { vendor: VendorFull }) {
                       : "bg-amber-500/10 text-amber-400 border-amber-500/20"
                   }`}
                 >
-                  {p.status === "PAID" ? "Pago" : "Pendente"}
+                  {p.status === "PAID" ? t("payments.paid") : t("payments.pending")}
                 </span>
               </div>
             </li>
@@ -840,7 +848,7 @@ function PaymentsSection({ vendor }: { vendor: VendorFull }) {
           href="/dashboard/payments"
           className="inline-flex items-center gap-1 text-xs text-rose-300 hover:text-rose-200"
         >
-          Gerenciar pagamentos →
+          {t("payments.manage")}
         </Link>
       </div>
     </Card>
@@ -858,6 +866,7 @@ function Card({
   action?: () => void;
   children: React.ReactNode;
 }) {
+  const tc = useTranslations("common");
   return (
     <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
       <div className="mb-4 flex items-center justify-between">
@@ -871,7 +880,7 @@ function Card({
             onClick={action}
             className="inline-flex items-center gap-1 rounded-lg bg-zinc-800/70 px-2 py-1 text-xs font-medium text-zinc-200 hover:bg-zinc-700"
           >
-            <Plus className="h-3.5 w-3.5" /> Adicionar
+            <Plus className="h-3.5 w-3.5" /> {tc("actions.add")}
           </button>
         ) : null}
       </div>
@@ -962,12 +971,14 @@ function Textarea({
 function ModalActions({
   onCancel,
   busy,
-  confirmLabel = "Salvar",
+  confirmLabel,
 }: {
   onCancel: () => void;
   busy: boolean;
   confirmLabel?: string;
 }) {
+  const tc = useTranslations("common");
+  const label = confirmLabel ?? tc("actions.save");
   return (
     <div className="flex gap-2 pt-2">
       <button
@@ -975,14 +986,14 @@ function ModalActions({
         onClick={onCancel}
         className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
       >
-        Cancelar
+        {tc("actions.cancel")}
       </button>
       <button
         type="submit"
         disabled={busy}
         className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
       >
-        {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : confirmLabel}
+        {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : label}
       </button>
     </div>
   );
@@ -1005,6 +1016,7 @@ function ContractFileBlock({
   startTransition: React.TransitionStartFunction;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.vendors.detail");
   const [busy, setBusy] = useState(false);
   const [confirmReplace, setConfirmReplace] = useState<FormData | null>(null);
   const [showHistory, setShowHistory] = useState(false);
@@ -1018,7 +1030,7 @@ function ContractFileBlock({
   if (!canView) {
     return (
       <div className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/30 p-3 text-xs text-zinc-500">
-        Documento do contrato disponível, mas seu perfil não tem permissão para visualizá-lo.
+        {t("contractFile.noViewPermission")}
       </div>
     );
   }
@@ -1030,11 +1042,11 @@ function ContractFileBlock({
         const r = await replaceContractFile(undefined, fd);
         if (r.success) {
           if (current) {
-            toast.success("Contrato atualizado", `Nova versão v${contract.version + 1}`);
+            toast.success(t("contractFile.updated"), t("contractFile.newVersionToast", { version: contract.version + 1 }));
           } else {
-            toast.success("PDF do contrato enviado", `Mantido como v${contract.version}`);
+            toast.success(t("contractFile.pdfSent"), t("contractFile.keptVersionToast", { version: contract.version }));
           }
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.failed"), r.error);
       } finally {
         setBusy(false);
         setConfirmReplace(null);
@@ -1065,8 +1077,8 @@ function ContractFileBlock({
     startTransition(async () => {
       try {
         const r = await signContract(undefined, fd);
-        if (r.success) toast.success("Contrato assinado");
-        else toast.error("Falha", r.error);
+        if (r.success) toast.success(t("contractFile.signed"));
+        else toast.error(t("toast.failed"), r.error);
       } finally {
         setSigning(false);
       }
@@ -1076,7 +1088,7 @@ function ContractFileBlock({
   return (
     <div className="mt-4 rounded-xl border border-zinc-800 bg-zinc-950/40 p-4">
       <div className="flex flex-wrap items-center gap-2">
-        <h5 className="text-sm font-semibold text-zinc-200">Arquivo do contrato</h5>
+        <h5 className="text-sm font-semibold text-zinc-200">{t("contractFile.title")}</h5>
         {current ? (
           <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-[10px] text-zinc-300">
             v{current.version}
@@ -1093,14 +1105,14 @@ function ContractFileBlock({
             aria-label={current.filename}
           >
             <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-4 text-center text-xs text-zinc-400">
-              <p>O navegador não conseguiu exibir o PDF inline.</p>
+              <p>{t("contractFile.inlineFallback")}</p>
               <a
                 href={`/api/files/${current.id}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-medium text-rose-300 hover:text-rose-200"
               >
-                Abrir o contrato em nova aba
+                {t("contractFile.openNewTab")}
               </a>
             </div>
           </object>
@@ -1111,8 +1123,8 @@ function ContractFileBlock({
               {current.sha256Full ? ` · ${current.sha256Full.slice(0, 10)}…` : ""}
             </span>
             <span>
-              enviado em {formatDateBR(new Date(current.createdAt))}{" "}
-              {current.uploadedBy ? `por ${current.uploadedBy.name ?? current.uploadedBy.email}` : ""}
+              {t("contractFile.uploadedAt", { date: formatDateBR(new Date(current.createdAt)) })}{" "}
+              {current.uploadedBy ? t("contractFile.uploadedBy", { name: current.uploadedBy.name ?? current.uploadedBy.email }) : ""}
             </span>
           </div>
           <a
@@ -1121,11 +1133,11 @@ function ContractFileBlock({
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1 text-xs font-medium text-rose-300 hover:text-rose-200"
           >
-            Baixar PDF
+            {t("contractFile.downloadPdf")}
           </a>
         </div>
       ) : (
-        <p className="mt-3 text-xs text-zinc-500">Nenhum PDF anexado a este contrato ainda.</p>
+        <p className="mt-3 text-xs text-zinc-500">{t("contractFile.noPdfYet")}</p>
       )}
 
       {canUpload ? (
@@ -1137,7 +1149,7 @@ function ContractFileBlock({
           <input type="hidden" name="vendorId" value={vendorId} />
           <div>
             <label className="mb-1 block text-xs text-zinc-400">
-              {current ? "Substituir contrato (vira v" + (contract.version + 1) + ")" : "Enviar PDF do contrato"}
+              {current ? t("contractFile.replaceLabel", { version: contract.version + 1 }) : t("contractFile.uploadLabel")}
             </label>
             <input
               type="file"
@@ -1146,28 +1158,28 @@ function ContractFileBlock({
               required
               className="block w-full text-xs text-zinc-300 file:mr-3 file:rounded-lg file:border-0 file:bg-zinc-800 file:px-3 file:py-1.5 file:text-xs file:text-zinc-200 hover:file:bg-zinc-700"
             />
-            <p className="mt-1 text-[10px] text-zinc-500">Apenas PDF, até 8 MB.</p>
+            <p className="mt-1 text-[10px] text-zinc-500">{t("contractFile.onlyPdf")}</p>
           </div>
           <button
             type="submit"
             disabled={busy}
             className="rounded-xl bg-rose-600 px-4 py-2 text-xs font-medium text-white hover:bg-rose-500 disabled:opacity-50"
           >
-            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Enviar"}
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : t("contractFile.send")}
           </button>
         </form>
       ) : null}
 
       {canSign && !isSigned ? (
         <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/40 p-3">
-          <span className="text-xs text-zinc-400">Marcar como assinado:</span>
+          <span className="text-xs text-zinc-400">{t("contractFile.markSigned")}</span>
           <button
             type="button"
             disabled={signing}
             onClick={() => handleSign("DIGITAL")}
             className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-300 hover:bg-emerald-500/20 disabled:opacity-50"
           >
-            Assinatura digital
+            {t("contractFile.signDigital")}
           </button>
           <button
             type="button"
@@ -1175,7 +1187,7 @@ function ContractFileBlock({
             onClick={() => handleSign("PHYSICAL")}
             className="rounded-lg border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs text-violet-300 hover:bg-violet-500/20 disabled:opacity-50"
           >
-            Assinatura física
+            {t("contractFile.signPhysical")}
           </button>
         </div>
       ) : null}
@@ -1187,7 +1199,9 @@ function ContractFileBlock({
             onClick={() => setShowHistory((v) => !v)}
             className="text-xs text-zinc-400 hover:text-zinc-200"
           >
-            {showHistory ? "Esconder" : "Ver"} histórico ({history.length} versão{history.length > 1 ? "ões" : ""})
+            {showHistory
+              ? t("contractFile.historyHide", { count: history.length })
+              : t("contractFile.historyShow", { count: history.length })}
           </button>
           {showHistory ? (
             <ul className="mt-2 space-y-1">
@@ -1206,7 +1220,7 @@ function ContractFileBlock({
                     rel="noopener noreferrer"
                     className="text-rose-300 hover:text-rose-200"
                   >
-                    Baixar
+                    {t("contractFile.download")}
                   </a>
                 </li>
               ))}
@@ -1217,9 +1231,9 @@ function ContractFileBlock({
 
       <ConfirmDialog
         open={!!confirmReplace}
-        title={`Criar nova versão v${contract.version + 1}?`}
-        description="A versão atual será arquivada (mantida no histórico por 30 dias). Tem certeza?"
-        confirmLabel="Sim, substituir"
+        title={t("contractFile.newVersionTitle", { version: contract.version + 1 })}
+        description={t("contractFile.newVersionDescription")}
+        confirmLabel={t("contractFile.confirmReplace")}
         tone="danger"
         onConfirm={confirmDoReplace}
         onCancel={() => setConfirmReplace(null)}

--- a/src/app/dashboard/vendors/compare/page.tsx
+++ b/src/app/dashboard/vendors/compare/page.tsx
@@ -1,16 +1,11 @@
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import { ArrowLeft } from "lucide-react";
 import { prisma } from "@/lib/prisma";
 import { resolveCategoryLabel } from "@/lib/categories";
 import { formatCurrency, formatDateBR } from "@/lib/format";
 
 export const dynamic = "force-dynamic";
-
-const STATUS_LABEL: Record<string, string> = {
-  NEGOTIATION: "Em Negociação",
-  CONTRACTED: "Contratado",
-  FINALIZED: "Finalizado",
-};
 
 type SearchParams = { ids?: string };
 
@@ -19,6 +14,12 @@ export default async function ComparePage({
 }: {
   searchParams: Promise<SearchParams>;
 }) {
+  const t = await getTranslations("dashboard.vendors.compare");
+  const STATUS_LABEL: Record<string, string> = {
+    NEGOTIATION: t("status.negotiation"),
+    CONTRACTED: t("status.contracted"),
+    FINALIZED: t("status.finalized"),
+  };
   const params = await searchParams;
   const ids = (params.ids ?? "")
     .split(",")
@@ -75,16 +76,16 @@ export default async function ComparePage({
           href="/dashboard/vendors"
           className="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-300"
         >
-          <ArrowLeft className="h-4 w-4" /> Voltar para fornecedores
+          <ArrowLeft className="h-4 w-4" /> {t("back")}
         </Link>
       </div>
 
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Comparar propostas</h1>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("title")}</h1>
         <p className="text-sm text-zinc-500">
           {computed.length === 0
-            ? "Marque 2 a 4 fornecedores na lista e clique em \"Comparar\"."
-            : `Comparando ${computed.length} fornecedor(es).`}
+            ? t("hint")
+            : t("comparing", { count: computed.length })}
         </p>
       </div>
 
@@ -96,7 +97,7 @@ export default async function ComparePage({
             <thead>
               <tr>
                 <th className="sticky left-0 z-10 w-44 bg-zinc-900/80 px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500">
-                  Critério
+                  {t("criterion")}
                 </th>
                 {computed.map(({ vendor }) => (
                   <th key={vendor.id} className="min-w-[220px] px-4 py-3 text-left">
@@ -114,19 +115,19 @@ export default async function ComparePage({
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-800/60">
-              <Row label="Status">
+              <Row label={t("row.status")}>
                 {computed.map(({ vendor }) => (
                   <Cell key={vendor.id}>{STATUS_LABEL[vendor.status] ?? vendor.status}</Cell>
                 ))}
               </Row>
-              <Row label="Rating">
+              <Row label={t("row.rating")}>
                 {computed.map(({ vendor }) => (
                   <Cell key={vendor.id} highlight={!!vendor.rating && vendor.rating === maxRating}>
                     {vendor.rating ? `${vendor.rating} ★` : "—"}
                   </Cell>
                 ))}
               </Row>
-              <Row label="Valor total">
+              <Row label={t("row.totalValue")}>
                 {computed.map((c) => (
                   <Cell
                     key={c.vendor.id}
@@ -137,26 +138,26 @@ export default async function ComparePage({
                   </Cell>
                 ))}
               </Row>
-              <Row label="Já pago">
+              <Row label={t("row.paid")}>
                 {computed.map((c) => (
                   <Cell key={c.vendor.id} accent="emerald">
                     {formatCurrency(c.paid)}
                   </Cell>
                 ))}
               </Row>
-              <Row label="Saldo">
+              <Row label={t("row.balance")}>
                 {computed.map((c) => (
                   <Cell key={c.vendor.id} accent={c.balance > 0 ? "rose" : "emerald"}>
                     {formatCurrency(c.balance)}
                   </Cell>
                 ))}
               </Row>
-              <Row label="Indicado por">
+              <Row label={t("row.indicatedBy")}>
                 {computed.map(({ vendor }) => (
                   <Cell key={vendor.id}>{vendor.indicatedBy ?? "—"}</Cell>
                 ))}
               </Row>
-              <Row label="Tags">
+              <Row label={t("row.tags")}>
                 {computed.map(({ vendor }) => (
                   <Cell key={vendor.id}>
                     {vendor.tags ? (
@@ -180,14 +181,14 @@ export default async function ComparePage({
                   </Cell>
                 ))}
               </Row>
-              <Row label="Contatos / Contratos / Anexos">
+              <Row label={t("row.counts")}>
                 {computed.map(({ vendor }) => (
                   <Cell key={vendor.id}>
                     {vendor.contacts.length} / {vendor.contracts.length} / {vendor.attachments.length}
                   </Cell>
                 ))}
               </Row>
-              <Row label="Notas">
+              <Row label={t("row.notes")}>
                 {computed.map(({ vendor }) => (
                   <Cell key={vendor.id}>
                     {vendor.notes ? (
@@ -198,7 +199,7 @@ export default async function ComparePage({
                   </Cell>
                 ))}
               </Row>
-              <Row label="Última interação">
+              <Row label={t("row.lastInteraction")}>
                 {computed.map(({ vendor }) => {
                   const last = vendor.vendorNotes[0];
                   return (
@@ -215,7 +216,7 @@ export default async function ComparePage({
                   );
                 })}
               </Row>
-              <Row label="Link contrato">
+              <Row label={t("row.contractLink")}>
                 {computed.map(({ vendor }) =>
                   vendor.contractLink ? (
                     <Cell key={vendor.id}>
@@ -225,7 +226,7 @@ export default async function ComparePage({
                         rel="noopener noreferrer"
                         className="text-rose-300 hover:text-rose-200"
                       >
-                        Abrir →
+                        {t("open")}
                       </a>
                     </Cell>
                   ) : (
@@ -239,7 +240,7 @@ export default async function ComparePage({
       )}
 
       <p className="text-xs text-zinc-600">
-        💡 Cor verde no preço marca o mais barato; ⭐ no rating marca o melhor avaliado.
+        {t("legend")}
       </p>
     </div>
   );
@@ -281,18 +282,19 @@ function Cell({
   );
 }
 
-function EmptyState() {
+async function EmptyState() {
+  const t = await getTranslations("dashboard.vendors.compare");
   return (
     <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/30 p-10 text-center">
-      <p className="text-zinc-300">Nenhum fornecedor selecionado.</p>
+      <p className="text-zinc-300">{t("empty.title")}</p>
       <p className="mt-2 text-sm text-zinc-500">
-        Volte para a lista, marque os checkboxes dos fornecedores que quer comparar e clique em &quot;Comparar&quot;.
+        {t("empty.description")}
       </p>
       <Link
         href="/dashboard/vendors"
         className="mt-4 inline-flex items-center gap-1 text-sm text-rose-300 hover:text-rose-200"
       >
-        Ir para fornecedores →
+        {t("empty.cta")}
       </Link>
     </div>
   );

--- a/src/app/dashboard/vendors/page.tsx
+++ b/src/app/dashboard/vendors/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { CATEGORIES } from "@/lib/categories";
@@ -8,6 +9,7 @@ export const dynamic = "force-dynamic";
 
 
 export default async function VendorsPage() {
+  const t = await getTranslations("dashboard.vendors");
   const session = await auth();
   const role = (session?.user as { role?: string } | undefined)?.role;
   const showFinance = canViewSensitiveFinance(role);
@@ -25,7 +27,7 @@ export default async function VendorsPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight text-white">Fornecedores</h1>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
       </div>
       <VendorsClient vendors={vendors} categories={[...CATEGORIES]} />
     </div>

--- a/src/app/dashboard/vendors/vendors-client.tsx
+++ b/src/app/dashboard/vendors/vendors-client.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { GitCompare, Plus, Loader2, Pencil, Trash2, Search, Star } from "lucide-react";
 import {
   createVendor,
@@ -23,12 +24,6 @@ type Props = {
   categories: CategoryDef[];
 };
 
-const STATUS_LABEL: Record<VendorStatus, string> = {
-  NEGOTIATION: "Em Negociação",
-  CONTRACTED: "Contratado",
-  FINALIZED: "Finalizado",
-};
-
 const STATUS_CHIP: Record<VendorStatus, string> = {
   NEGOTIATION: "bg-amber-500/10 text-amber-400 border-amber-500/20",
   CONTRACTED: "bg-emerald-500/10 text-emerald-400 border-emerald-500/20",
@@ -36,7 +31,14 @@ const STATUS_CHIP: Record<VendorStatus, string> = {
 };
 
 export default function VendorsClient({ vendors, categories }: Props) {
+  const t = useTranslations("dashboard.vendors");
+  const tc = useTranslations("common");
   const toast = useToast();
+  const STATUS_LABEL: Record<VendorStatus, string> = {
+    NEGOTIATION: t("status.negotiation"),
+    CONTRACTED: t("status.contracted"),
+    FINALIZED: t("status.finalized"),
+  };
   const [isCreateOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<VendorRow | null>(null);
   const [deleting, setDeleting] = useState<VendorRow | null>(null);
@@ -67,10 +69,10 @@ export default function VendorsClient({ vendors, categories }: Props) {
       try {
         const r = await createVendor(undefined, formData);
         if (r.success) {
-          toast.success("Fornecedor criado");
+          toast.success(t("toast.created"));
           setCreateOpen(false);
         } else {
-          toast.error("Falha ao criar", r.error);
+          toast.error(t("toast.createFailed"), r.error);
         }
       } finally {
         setCreating(false);
@@ -84,10 +86,10 @@ export default function VendorsClient({ vendors, categories }: Props) {
       try {
         const r = await updateVendor(undefined, formData);
         if (r.success) {
-          toast.success("Fornecedor atualizado");
+          toast.success(t("toast.updated"));
           setEditing(null);
         } else {
-          toast.error("Falha ao atualizar", r.error);
+          toast.error(t("toast.updateFailed"), r.error);
         }
       } finally {
         setUpdating(false);
@@ -113,13 +115,13 @@ export default function VendorsClient({ vendors, categories }: Props) {
 
     if (newStatus === "CONTRACTED" && !hasActual) {
       const raw = window.prompt(
-        `Qual o valor REAL contratado com ${vendor.name}? (apenas números, ex: 12500.00)`,
+        t("statusPrompt.message", { name: vendor.name }),
         String(item?.estimatedValue ?? ""),
       );
       if (raw === null) return;
       const n = Number(raw.replace(",", "."));
       if (!Number.isFinite(n) || n < 0) {
-        toast.error("Valor inválido");
+        toast.error(t("statusPrompt.invalidValue"));
         return;
       }
       actual = n;
@@ -127,8 +129,8 @@ export default function VendorsClient({ vendors, categories }: Props) {
 
     startTransition(async () => {
       const r = await updateVendorStatus(vendor.id, newStatus, actual);
-      if (r.success) toast.success("Status atualizado");
-      else toast.error("Falha", r.error);
+      if (r.success) toast.success(t("toast.statusUpdated"));
+      else toast.error(t("toast.failed"), r.error);
     });
   }
 
@@ -138,10 +140,10 @@ export default function VendorsClient({ vendors, categories }: Props) {
     startTransition(async () => {
       const r = await deleteVendor(target.id);
       if (r.success) {
-        toast.success("Fornecedor excluído");
+        toast.success(t("toast.deleted"));
         setDeleting(null);
       } else {
-        toast.error("Falha ao excluir", r.error);
+        toast.error(t("toast.deleteFailed"), r.error);
       }
     });
   }
@@ -159,7 +161,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
                 setSearch(e.target.value);
                 setPage(1);
               }}
-              placeholder="Buscar fornecedor..."
+              placeholder={t("list.searchPlaceholder")}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
             />
           </div>
@@ -171,10 +173,10 @@ export default function VendorsClient({ vendors, categories }: Props) {
             }}
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
           >
-            <option value="ALL">Todos os status</option>
-            <option value="NEGOTIATION">Em Negociação</option>
-            <option value="CONTRACTED">Contratado</option>
-            <option value="FINALIZED">Finalizado</option>
+            <option value="ALL">{t("filter.allStatus")}</option>
+            <option value="NEGOTIATION">{t("status.negotiation")}</option>
+            <option value="CONTRACTED">{t("status.contracted")}</option>
+            <option value="FINALIZED">{t("status.finalized")}</option>
           </select>
         </div>
         <div className="flex items-center gap-2">
@@ -184,11 +186,11 @@ export default function VendorsClient({ vendors, categories }: Props) {
                 href={compareHref}
                 className="flex items-center gap-1.5 rounded-xl bg-zinc-800 px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-700"
               >
-                <GitCompare className="h-4 w-4" /> Comparar ({selected.size})
+                <GitCompare className="h-4 w-4" /> {t("compareButton.label", { count: selected.size })}
               </Link>
             ) : (
               <span className="rounded-xl bg-zinc-800/50 px-3 py-2 text-xs text-zinc-400">
-                Selecione mais 1 para comparar
+                {t("compareButton.selectMore")}
               </span>
             )
           ) : null}
@@ -197,7 +199,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
             className="flex items-center justify-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-lg transition-colors hover:bg-rose-500"
           >
             <Plus className="h-4 w-4" />
-            <span>Novo Fornecedor</span>
+            <span>{t("list.new")}</span>
           </button>
         </div>
       </div>
@@ -207,19 +209,19 @@ export default function VendorsClient({ vendors, categories }: Props) {
           <table className="w-full text-left text-sm text-zinc-400">
             <thead className="border-b border-zinc-800 bg-zinc-900/80 text-xs uppercase text-zinc-500">
               <tr>
-                <th className="px-4 py-4 font-medium" aria-label="Selecionar"></th>
-                <th className="px-6 py-4 font-medium">Nome</th>
-                <th className="px-6 py-4 font-medium">Categoria</th>
-                <th className="px-6 py-4 font-medium">Status</th>
-                <th className="px-6 py-4 font-medium">Valor</th>
-                <th className="px-6 py-4 text-right font-medium">Ações</th>
+                <th className="px-4 py-4 font-medium" aria-label={t("table.select")}></th>
+                <th className="px-6 py-4 font-medium">{tc("labels.name")}</th>
+                <th className="px-6 py-4 font-medium">{t("table.category")}</th>
+                <th className="px-6 py-4 font-medium">{tc("labels.status")}</th>
+                <th className="px-6 py-4 font-medium">{tc("labels.amount")}</th>
+                <th className="px-6 py-4 text-right font-medium">{tc("labels.actions")}</th>
               </tr>
             </thead>
             <tbody>
               {filtered.length === 0 ? (
                 <tr>
                   <td colSpan={6} className="px-6 py-8 text-center text-zinc-500">
-                    {vendors.length === 0 ? "Nenhum fornecedor cadastrado." : "Nenhum resultado para o filtro."}
+                    {vendors.length === 0 ? t("list.empty") : t("list.noResults")}
                   </td>
                 </tr>
               ) : (
@@ -239,7 +241,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
                           checked={isSelected}
                           onChange={() => toggleSelected(vendor.id)}
                           disabled={!isSelected && selected.size >= 4}
-                          aria-label={`Selecionar ${vendor.name}`}
+                          aria-label={t("table.selectVendor", { name: vendor.name })}
                           className="h-4 w-4 accent-rose-500"
                         />
                       </td>
@@ -282,21 +284,21 @@ export default function VendorsClient({ vendors, categories }: Props) {
                           disabled={isPendingTransition}
                           className={`rounded-full border px-2.5 py-1 text-xs font-medium outline-none ${STATUS_CHIP[status]}`}
                         >
-                          <option value="NEGOTIATION">Em Negociação</option>
-                          <option value="CONTRACTED">Contratado</option>
-                          <option value="FINALIZED">Finalizado</option>
+                          <option value="NEGOTIATION">{t("status.negotiation")}</option>
+                          <option value="CONTRACTED">{t("status.contracted")}</option>
+                          <option value="FINALIZED">{t("status.finalized")}</option>
                         </select>
                       </td>
                       <td className="px-6 py-4">
                         <span className="font-medium text-zinc-300">{formatCurrency(value)}</span>
-                        <span className="ml-2 text-xs text-zinc-600">({isReal ? "Real" : "Estimado"})</span>
+                        <span className="ml-2 text-xs text-zinc-600">({isReal ? t("value.real") : t("value.estimated")})</span>
                       </td>
                       <td className="px-6 py-4 text-right">
                         <div className="flex items-center justify-end gap-2">
                           <button
                             type="button"
                             onClick={() => setEditing(vendor)}
-                            aria-label="Editar"
+                            aria-label={tc("actions.edit")}
                             className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
                           >
                             <Pencil className="h-4 w-4" />
@@ -304,7 +306,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
                           <button
                             type="button"
                             onClick={() => setDeleting(vendor)}
-                            aria-label="Excluir"
+                            aria-label={tc("actions.delete")}
                             className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-rose-500/10 hover:text-rose-400"
                           >
                             <Trash2 className="h-4 w-4" />
@@ -323,7 +325,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
       <div className="space-y-3 md:hidden">
         {filtered.length === 0 ? (
           <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-8 text-center text-sm text-zinc-500">
-            {vendors.length === 0 ? "Nenhum fornecedor cadastrado." : "Nenhum resultado para o filtro."}
+            {vendors.length === 0 ? t("list.empty") : t("list.noResults")}
           </div>
         ) : (
           pageItems.map((vendor) => {
@@ -348,7 +350,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
                         checked={isSelected}
                         onChange={() => toggleSelected(vendor.id)}
                         disabled={!isSelected && selected.size >= 4}
-                        aria-label={`Selecionar ${vendor.name}`}
+                        aria-label={t("table.selectVendor", { name: vendor.name })}
                         className="h-4 w-4 accent-rose-500"
                       />
                       <span
@@ -365,7 +367,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
                     </Link>
                     <div className="mt-2 text-sm text-zinc-300">
                       {formatCurrency(value)}{" "}
-                      <span className="text-xs text-zinc-500">({isReal ? "Real" : "Estimado"})</span>
+                      <span className="text-xs text-zinc-500">({isReal ? t("value.real") : t("value.estimated")})</span>
                     </div>
                   </div>
                   <div className="flex flex-col items-end gap-2">
@@ -377,7 +379,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
                         type="button"
                         onClick={() => setEditing(vendor)}
                         className="rounded-lg bg-zinc-800/60 p-1.5 text-zinc-300"
-                        aria-label="Editar"
+                        aria-label={tc("actions.edit")}
                       >
                         <Pencil className="h-3.5 w-3.5" />
                       </button>
@@ -385,7 +387,7 @@ export default function VendorsClient({ vendors, categories }: Props) {
                         type="button"
                         onClick={() => setDeleting(vendor)}
                         className="rounded-lg bg-zinc-800/60 p-1.5 text-rose-400"
-                        aria-label="Excluir"
+                        aria-label={tc("actions.delete")}
                       >
                         <Trash2 className="h-3.5 w-3.5" />
                       </button>
@@ -398,9 +400,9 @@ export default function VendorsClient({ vendors, categories }: Props) {
                   disabled={isPendingTransition}
                   className="mt-3 w-full rounded-lg border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-200 outline-none"
                 >
-                  <option value="NEGOTIATION">Em Negociação</option>
-                  <option value="CONTRACTED">Contratado</option>
-                  <option value="FINALIZED">Finalizado</option>
+                  <option value="NEGOTIATION">{t("status.negotiation")}</option>
+                  <option value="CONTRACTED">{t("status.contracted")}</option>
+                  <option value="FINALIZED">{t("status.finalized")}</option>
                 </select>
               </div>
             );
@@ -440,11 +442,9 @@ export default function VendorsClient({ vendors, categories }: Props) {
 
       <ConfirmDialog
         open={!!deleting}
-        title={deleting ? `Excluir ${deleting.name}?` : "Excluir fornecedor?"}
-        description={
-          "Essa ação fará exclusão lógica do fornecedor, seus orçamentos e pagamentos associados.\nVocê não verá mais esses registros nas listagens."
-        }
-        confirmLabel="Excluir"
+        title={deleting ? t("delete.titleNamed", { name: deleting.name }) : t("delete.title")}
+        description={t("delete.description")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         busy={isPendingTransition}
         onConfirm={handleDelete}
@@ -469,6 +469,8 @@ function VendorFormModal({
   formAction: (formData: FormData) => void;
   onClose: () => void;
 }) {
+  const t = useTranslations("dashboard.vendors");
+  const tc = useTranslations("common");
   const budget = vendor?.budgetItems[0];
   const defaultEstimated = budget?.estimatedValue ?? 0;
   const defaultActual = budget?.actualValue ?? "";
@@ -483,13 +485,13 @@ function VendorFormModal({
       <div className="my-4 w-full max-w-lg rounded-2xl border border-zinc-800 bg-zinc-900 shadow-2xl">
         <form action={formAction} className="space-y-4 p-6">
           <h2 className="text-xl font-bold text-white">
-            {mode === "create" ? "Novo Fornecedor" : `Editar ${vendor?.name ?? ""}`}
+            {mode === "create" ? t("form.createTitle") : t("form.editTitle", { name: vendor?.name ?? "" })}
           </h2>
 
           {mode === "edit" && vendor ? <input type="hidden" name="id" value={vendor.id} /> : null}
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Nome</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.name")}</label>
             <input
               type="text"
               name="name"
@@ -497,20 +499,20 @@ function VendorFormModal({
               maxLength={120}
               defaultValue={vendor?.name ?? ""}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
-              placeholder="Ex: Buffet Colonial"
+              placeholder={t("form.namePlaceholder")}
             />
           </div>
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Categoria</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.category")}</label>
               <select
                 name="categoryKey"
                 value={categoryKey}
                 onChange={(e) => setCategoryKey(e.target.value)}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
               >
-                <option value="">— escolher —</option>
+                <option value="">{t("form.categoryChoose")}</option>
                 {categories.map((c) => (
                   <option key={c.key} value={c.key}>
                     {c.label}
@@ -519,7 +521,7 @@ function VendorFormModal({
               </select>
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium text-zinc-400">Rótulo livre</label>
+              <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.freeLabel")}</label>
               <input
                 type="text"
                 name="category"
@@ -528,7 +530,7 @@ function VendorFormModal({
                 defaultValue={categoryLabel}
                 key={categoryKey}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
-                placeholder="Ex: Alimentação"
+                placeholder={t("form.freeLabelPlaceholder")}
               />
             </div>
           </div>
@@ -536,7 +538,7 @@ function VendorFormModal({
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
               <label className="mb-1 block text-sm font-medium text-zinc-400">
-                Valor {mode === "create" ? "estimado" : "estimado"} (R$)
+                {t("form.estimatedValue")}
               </label>
               <input
                 type="number"
@@ -545,39 +547,39 @@ function VendorFormModal({
                 required={mode === "create"}
                 defaultValue={defaultEstimated ? String(defaultEstimated) : ""}
                 className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
-                placeholder="Ex: 15000.00"
+                placeholder={t("form.estimatedValuePlaceholder")}
               />
             </div>
             {mode === "edit" ? (
               <div>
-                <label className="mb-1 block text-sm font-medium text-zinc-400">Valor real (R$)</label>
+                <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.actualValue")}</label>
                 <input
                   type="number"
                   step="0.01"
                   name="actualValue"
                   defaultValue={defaultActual ? String(defaultActual) : ""}
                   className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
-                  placeholder="Vazio = ainda não fechado"
+                  placeholder={t("form.actualValuePlaceholder")}
                 />
               </div>
             ) : null}
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Status</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{tc("labels.status")}</label>
             <select
               name="status"
               defaultValue={vendor?.status ?? "NEGOTIATION"}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
             >
-              <option value="NEGOTIATION">Em Negociação</option>
-              <option value="CONTRACTED">Contratado</option>
-              <option value="FINALIZED">Finalizado</option>
+              <option value="NEGOTIATION">{t("status.negotiation")}</option>
+              <option value="CONTRACTED">{t("status.contracted")}</option>
+              <option value="FINALIZED">{t("status.finalized")}</option>
             </select>
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Link do contrato (opcional)</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.contractLink")}</label>
             <input
               type="url"
               name="contractLink"
@@ -588,14 +590,14 @@ function VendorFormModal({
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">Notas</label>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("form.notes")}</label>
             <textarea
               name="notes"
               rows={3}
               maxLength={2000}
               defaultValue={vendor?.notes ?? ""}
               className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-zinc-200 outline-none focus:border-rose-500/50"
-              placeholder="Observações, contatos, condições..."
+              placeholder={t("form.notesPlaceholder")}
             />
           </div>
 
@@ -605,14 +607,14 @@ function VendorFormModal({
               onClick={onClose}
               className="flex-1 rounded-xl bg-zinc-800 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700"
             >
-              Cancelar
+              {tc("actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={isBusy}
               className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2.5 text-sm font-medium text-white transition-colors hover:bg-rose-500 disabled:opacity-50"
             >
-              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : mode === "create" ? "Salvar" : "Salvar alterações"}
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : mode === "create" ? tc("actions.save") : t("form.saveChanges")}
             </button>
           </div>
         </form>

--- a/src/app/dashboard/venues/[id]/page.tsx
+++ b/src/app/dashboard/venues/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import { ArrowLeft } from "lucide-react";
 import { prisma } from "@/lib/prisma";
 import VenueDetailClient from "./venue-detail-client";
@@ -8,6 +9,7 @@ export const dynamic = "force-dynamic";
 
 export default async function VenueDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const t = await getTranslations("dashboard.venues");
   const venue = await prisma.venue.findFirst({
     where: { id, deletedAt: null },
     include: {
@@ -20,7 +22,7 @@ export default async function VenueDetailPage({ params }: { params: Promise<{ id
   return (
     <div className="space-y-6">
       <Link href="/dashboard/venues" className="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-300">
-        <ArrowLeft className="h-4 w-4" /> Voltar para locais
+        <ArrowLeft className="h-4 w-4" /> {t("detail.back")}
       </Link>
       <VenueDetailClient venue={venue} />
     </div>

--- a/src/app/dashboard/venues/[id]/venue-detail-client.tsx
+++ b/src/app/dashboard/venues/[id]/venue-detail-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import {
   CheckCircle2,
   Circle,
@@ -69,6 +70,8 @@ type VenueFull = {
 };
 
 export default function VenueDetailClient({ venue }: { venue: VenueFull }) {
+  const t = useTranslations("dashboard.venues");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -81,9 +84,9 @@ export default function VenueDetailClient({ venue }: { venue: VenueFull }) {
       try {
         const r = await updateVenue(undefined, formData);
         if (r.success) {
-          toast.success("Atualizado");
+          toast.success(t("toast.updated"));
           setEditing(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.fail"), r.error);
       } finally {
         setBusy(false);
       }
@@ -94,9 +97,9 @@ export default function VenueDetailClient({ venue }: { venue: VenueFull }) {
     startTransition(async () => {
       const r = await deleteVenue(venue.id);
       if (r.success) {
-        toast.success("Local removido");
+        toast.success(t("toast.removed"));
         window.location.href = "/dashboard/venues";
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.fail"), r.error);
     });
   }
 
@@ -120,7 +123,7 @@ export default function VenueDetailClient({ venue }: { venue: VenueFull }) {
             ) : null}
             {venue.contactName || venue.contactPhone ? (
               <p className="mt-1 text-sm text-zinc-400">
-                Contato: {venue.contactName ?? "—"}
+                {t("detail.contactLabel")} {venue.contactName ?? "—"}
                 {venue.contactPhone ? (
                   <>
                     {" · "}
@@ -143,7 +146,7 @@ export default function VenueDetailClient({ venue }: { venue: VenueFull }) {
                 rel="noopener noreferrer"
                 className="mt-1 inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200"
               >
-                <ExternalLink className="h-3.5 w-3.5" /> Abrir no Maps
+                <ExternalLink className="h-3.5 w-3.5" /> {t("detail.openMaps")}
               </a>
             ) : null}
           </div>
@@ -153,61 +156,63 @@ export default function VenueDetailClient({ venue }: { venue: VenueFull }) {
               onClick={() => setEditing(!editing)}
               className="rounded-xl bg-zinc-800 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-700"
             >
-              {editing ? "Fechar edição" : "Editar"}
+              {editing ? t("detail.closeEdit") : tc("actions.edit")}
             </button>
             <button
               type="button"
               onClick={() => setDeleting(true)}
               className="rounded-xl bg-rose-500/10 px-3 py-2 text-sm font-medium text-rose-300 hover:bg-rose-500/20"
             >
-              Excluir local
+              {t("detail.deleteVenue")}
             </button>
           </div>
         </div>
 
         <div className="mt-6 grid gap-4 sm:grid-cols-3">
-          <Stat label="Sentados">{venue.capacitySeated ?? "—"}</Stat>
-          <Stat label="Em pé">{venue.capacityStanding ?? "—"}</Stat>
-          <Stat label="Locação">{venue.baseRate ? formatCurrency(venue.baseRate) : "—"}</Stat>
+          <Stat label={t("fields.seated")}>{venue.capacitySeated ?? "—"}</Stat>
+          <Stat label={t("fields.standing")}>{venue.capacityStanding ?? "—"}</Stat>
+          <Stat label={t("fields.rate")}>{venue.baseRate ? formatCurrency(venue.baseRate) : "—"}</Stat>
         </div>
 
         {venue.visitedAt ? (
-          <p className="mt-4 text-xs text-zinc-500">Visitado em {formatDateBR(venue.visitedAt)}</p>
+          <p className="mt-4 text-xs text-zinc-500">
+            {t("list.visitedOn", { date: formatDateBR(venue.visitedAt) })}
+          </p>
         ) : null}
       </div>
 
       {editing ? (
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
-          <h2 className="text-lg font-semibold text-white">Editar local</h2>
+          <h2 className="text-lg font-semibold text-white">{t("editForm.title")}</h2>
           <form action={handleUpdate} className="mt-4 grid gap-3 sm:grid-cols-2">
             <input type="hidden" name="id" value={venue.id} />
-            <Input name="name" label="Nome" defaultValue={venue.name} required />
-            <Input name="address" label="Endereço" defaultValue={venue.address ?? ""} />
-            <Input name="mapsUrl" label="Link Maps" defaultValue={venue.mapsUrl ?? ""} />
+            <Input name="name" label={t("fields.name")} defaultValue={venue.name} required />
+            <Input name="address" label={t("fields.address")} defaultValue={venue.address ?? ""} />
+            <Input name="mapsUrl" label={t("editForm.mapsUrl")} defaultValue={venue.mapsUrl ?? ""} />
             <Input
               name="baseRate"
-              label="Locação (R$)"
+              label={t("editForm.baseRate")}
               type="number"
               step="0.01"
               defaultValue={venue.baseRate?.toString() ?? ""}
             />
             <Input
               name="capacitySeated"
-              label="Sentados"
+              label={t("fields.seated")}
               type="number"
               defaultValue={venue.capacitySeated?.toString() ?? ""}
             />
             <Input
               name="capacityStanding"
-              label="Em pé"
+              label={t("fields.standing")}
               type="number"
               defaultValue={venue.capacityStanding?.toString() ?? ""}
             />
-            <Input name="contactName" label="Contato" defaultValue={venue.contactName ?? ""} />
-            <Input name="contactPhone" label="Telefone" defaultValue={venue.contactPhone ?? ""} />
+            <Input name="contactName" label={t("editForm.contactName")} defaultValue={venue.contactName ?? ""} />
+            <Input name="contactPhone" label={t("editForm.contactPhone")} defaultValue={venue.contactPhone ?? ""} />
             <Input
               name="visitedAt"
-              label="Visitado em"
+              label={t("editForm.visitedAt")}
               type="date"
               defaultValue={venue.visitedAt ? toIsoDate(new Date(venue.visitedAt)) : ""}
             />
@@ -218,25 +223,25 @@ export default function VenueDetailClient({ venue }: { venue: VenueFull }) {
                 defaultChecked={venue.isShortlisted}
                 className="accent-rose-500"
               />
-              <label className="text-sm text-zinc-300">Favorito</label>
+              <label className="text-sm text-zinc-300">{t("editForm.favorite")}</label>
             </div>
-            <Textarea name="pros" label="Prós" defaultValue={venue.pros ?? ""} className="sm:col-span-2" />
-            <Textarea name="cons" label="Contras" defaultValue={venue.cons ?? ""} className="sm:col-span-2" />
+            <Textarea name="pros" label={t("fields.pros")} defaultValue={venue.pros ?? ""} className="sm:col-span-2" />
+            <Textarea name="cons" label={t("fields.cons")} defaultValue={venue.cons ?? ""} className="sm:col-span-2" />
             <Textarea
               name="restrictions"
-              label="Restrições"
+              label={t("fields.restrictions")}
               defaultValue={venue.restrictions ?? ""}
               className="sm:col-span-2"
             />
             <Textarea
               name="pricingNotes"
-              label="Notas de preço"
+              label={t("editForm.pricingNotes")}
               defaultValue={venue.pricingNotes ?? ""}
               className="sm:col-span-2"
             />
             <Textarea
               name="notes"
-              label="Observações gerais"
+              label={t("fields.notes")}
               defaultValue={venue.notes ?? ""}
               className="sm:col-span-2"
             />
@@ -247,31 +252,31 @@ export default function VenueDetailClient({ venue }: { venue: VenueFull }) {
                 className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
               >
                 {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-                Salvar
+                {tc("actions.save")}
               </button>
             </div>
           </form>
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          <ProsConsBlock title="Prós" body={venue.pros} accent="emerald" />
-          <ProsConsBlock title="Contras" body={venue.cons} accent="rose" />
+          <ProsConsBlock title={t("fields.pros")} body={venue.pros} accent="emerald" />
+          <ProsConsBlock title={t("fields.cons")} body={venue.cons} accent="rose" />
           {venue.restrictions ? (
-            <NotesCard title="Restrições" body={venue.restrictions} />
+            <NotesCard title={t("fields.restrictions")} body={venue.restrictions} />
           ) : null}
           {venue.pricingNotes ? (
-            <NotesCard title="Observações de preço" body={venue.pricingNotes} />
+            <NotesCard title={t("fields.pricingNotes")} body={venue.pricingNotes} />
           ) : null}
-          {venue.notes ? <NotesCard title="Observações gerais" body={venue.notes} /> : null}
+          {venue.notes ? <NotesCard title={t("fields.notes")} body={venue.notes} /> : null}
         </div>
       )}
 
       <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
         <div className="mb-4 flex items-center justify-between">
           <div>
-            <h3 className="text-lg font-semibold text-zinc-100">Checklist da visita</h3>
+            <h3 className="text-lg font-semibold text-zinc-100">{t("checklist.title")}</h3>
             <p className="text-xs text-zinc-500">
-              {checklistDone}/{venue.checklistItems.length} respondidos
+              {t("checklist.answered", { done: checklistDone, total: venue.checklistItems.length })}
             </p>
           </div>
         </div>
@@ -287,9 +292,9 @@ export default function VenueDetailClient({ venue }: { venue: VenueFull }) {
 
       <ConfirmDialog
         open={deleting}
-        title={`Excluir ${venue.name}?`}
-        description="O local e o checklist serão marcados como excluídos."
-        confirmLabel="Excluir"
+        title={t("delete.confirmTitle", { name: venue.name })}
+        description={t("delete.confirmDescriptionDetail")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(false)}
@@ -307,13 +312,14 @@ function ChecklistRow({
   startTransition: React.TransitionStartFunction;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.venues");
   const [value, setValue] = useState(item.value ?? "");
   const [checked, setChecked] = useState(item.checked);
 
   function persist(nextChecked: boolean, nextValue: string) {
     startTransition(async () => {
       const r = await toggleChecklistItem(item.id, nextChecked, nextValue);
-      if (!r.success) toast.error("Falha", r.error);
+      if (!r.success) toast.error(t("toast.fail"), r.error);
     });
   }
 
@@ -327,7 +333,7 @@ function ChecklistRow({
   function onDelete() {
     startTransition(async () => {
       const r = await deleteChecklistItem(item.id);
-      if (!r.success) toast.error("Falha", r.error);
+      if (!r.success) toast.error(t("toast.fail"), r.error);
     });
   }
 
@@ -352,13 +358,13 @@ function ChecklistRow({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onBlur={onBlurValue}
-        placeholder="Anote a resposta"
+        placeholder={t("checklist.answerPlaceholder")}
         className="sm:w-64 w-full rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-1.5 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
       />
       <button
         type="button"
         onClick={onDelete}
-        aria-label="Excluir item"
+        aria-label={t("checklist.deleteItemAria")}
         className="self-end rounded-lg p-1.5 text-zinc-500 hover:bg-rose-500/10 hover:text-rose-400 sm:self-auto"
       >
         <Trash2 className="h-4 w-4" />
@@ -376,6 +382,8 @@ function AddChecklistForm({
   startTransition: React.TransitionStartFunction;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.venues");
+  const tc = useTranslations("common");
   const [busy, setBusy] = useState(false);
 
   function handleSubmit(formData: FormData) {
@@ -386,7 +394,7 @@ function AddChecklistForm({
         if (r.success) {
           const form = document.getElementById(`checklist-add-${venueId}`) as HTMLFormElement | null;
           form?.reset();
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.fail"), r.error);
       } finally {
         setBusy(false);
       }
@@ -401,7 +409,7 @@ function AddChecklistForm({
         name="label"
         required
         maxLength={200}
-        placeholder="Nova pergunta para o checklist..."
+        placeholder={t("checklist.addPlaceholder")}
         className="flex-1 rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
       />
       <button
@@ -410,7 +418,7 @@ function AddChecklistForm({
         className="inline-flex items-center gap-1 rounded-xl bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
       >
         {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-        <span>Adicionar</span>
+        <span>{tc("actions.add")}</span>
       </button>
     </form>
   );
@@ -425,6 +433,8 @@ function AttachmentsCard({
   startTransition: React.TransitionStartFunction;
   toast: ReturnType<typeof useToast>;
 }) {
+  const t = useTranslations("dashboard.venues");
+  const tcCommon = useTranslations("common");
   const [busy, setBusy] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
@@ -436,7 +446,7 @@ function AttachmentsCard({
         if (r.success) {
           const form = document.getElementById(`venue-upload-${venue.id}`) as HTMLFormElement | null;
           form?.reset();
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.fail"), r.error);
       } finally {
         setBusy(false);
       }
@@ -449,9 +459,9 @@ function AttachmentsCard({
     startTransition(async () => {
       const r = await deleteAttachment(id);
       if (r.success) {
-        toast.success("Anexo removido");
+        toast.success(t("attachments.removed"));
         setDeleteId(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.fail"), r.error);
     });
   }
 
@@ -459,7 +469,7 @@ function AttachmentsCard({
     <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
       <div className="mb-4 flex items-center gap-2 text-zinc-100">
         <Paperclip className="h-5 w-5" />
-        <h3 className="text-lg font-semibold">Anexos</h3>
+        <h3 className="text-lg font-semibold">{t("attachments.title")}</h3>
       </div>
       <form
         id={`venue-upload-${venue.id}`}
@@ -469,7 +479,7 @@ function AttachmentsCard({
         <input type="hidden" name="ownerType" value="VENUE" />
         <input type="hidden" name="ownerId" value={venue.id} />
         <label className="block">
-          <span className="mb-1 block text-sm font-medium text-zinc-400">Arquivo</span>
+          <span className="mb-1 block text-sm font-medium text-zinc-400">{t("attachments.file")}</span>
           <input
             type="file"
             name="file"
@@ -479,16 +489,16 @@ function AttachmentsCard({
           />
         </label>
         <div>
-          <label className="mb-1 block text-sm font-medium text-zinc-400">Tipo</label>
+          <label className="mb-1 block text-sm font-medium text-zinc-400">{t("attachments.kind")}</label>
           <select
             name="kind"
             defaultValue="PHOTO"
             className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
           >
-            <option value="PHOTO">Foto da visita</option>
-            <option value="CONTRACT">Contrato</option>
-            <option value="PROPOSAL">Proposta</option>
-            <option value="OTHER">Outro</option>
+            <option value="PHOTO">{t("attachments.kinds.PHOTO")}</option>
+            <option value="CONTRACT">{t("attachments.kinds.CONTRACT")}</option>
+            <option value="PROPOSAL">{t("attachments.kinds.PROPOSAL")}</option>
+            <option value="OTHER">{t("attachments.kinds.OTHER")}</option>
           </select>
         </div>
         <button
@@ -497,12 +507,12 @@ function AttachmentsCard({
           className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
         >
           {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
-          <span>Enviar</span>
+          <span>{t("attachments.upload")}</span>
         </button>
       </form>
 
       {venue.attachments.length === 0 ? (
-        <p className="text-sm text-zinc-500">Sem anexos ainda.</p>
+        <p className="text-sm text-zinc-500">{t("attachments.empty")}</p>
       ) : (
         <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           {venue.attachments.map((a) => (
@@ -526,14 +536,14 @@ function AttachmentsCard({
                   {a.filename}
                 </Link>
                 <p className="text-[11px] text-zinc-500">
-                  {a.kind} · {(a.size / 1024).toFixed(1)} KB · {formatDateBR(a.createdAt)}
+                  {attachmentKindLabel(t, a.kind)} · {(a.size / 1024).toFixed(1)} KB · {formatDateBR(a.createdAt)}
                 </p>
               </div>
               <button
                 type="button"
                 onClick={() => setDeleteId(a.id)}
                 className="rounded-lg p-1.5 text-zinc-500 hover:bg-rose-500/10 hover:text-rose-400"
-                aria-label="Excluir anexo"
+                aria-label={t("attachments.deleteAria")}
               >
                 <Trash2 className="h-4 w-4" />
               </button>
@@ -544,14 +554,19 @@ function AttachmentsCard({
 
       <ConfirmDialog
         open={!!deleteId}
-        title="Excluir anexo?"
-        confirmLabel="Excluir"
+        title={t("attachments.deleteTitle")}
+        confirmLabel={tcCommon("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleteId(null)}
       />
     </div>
   );
+}
+
+function attachmentKindLabel(t: ReturnType<typeof useTranslations>, kind: string): string {
+  const known = ["PHOTO", "CONTRACT", "PROPOSAL", "OTHER"];
+  return known.includes(kind) ? t(`attachments.kinds.${kind}`) : kind;
 }
 
 function Stat({ label, children }: { label: string; children: React.ReactNode }) {

--- a/src/app/dashboard/venues/page.tsx
+++ b/src/app/dashboard/venues/page.tsx
@@ -1,9 +1,11 @@
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
 import VenuesClient from "./venues-client";
 
 export const dynamic = "force-dynamic";
 
 export default async function VenuesPage() {
+  const t = await getTranslations("dashboard.venues");
   const venues = await prisma.venue.findMany({
     where: { deletedAt: null },
     include: {
@@ -34,10 +36,8 @@ export default async function VenuesPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-white">Locais / Venues</h1>
-        <p className="text-sm text-zinc-500">
-          Compare candidatos, anote pros e contras e mantenha o checklist da visita.
-        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
+        <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
       <VenuesClient venues={decorated} />
     </div>

--- a/src/app/dashboard/venues/venues-client.tsx
+++ b/src/app/dashboard/venues/venues-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { Loader2, MapPin, Plus, Star, Trash2 } from "lucide-react";
 import { createVenue, deleteVenue } from "@/app/actions/venueActions";
 import { useToast } from "@/components/toast";
@@ -23,6 +24,8 @@ type VenueRow = {
 };
 
 export default function VenuesClient({ venues }: { venues: VenueRow[] }) {
+  const t = useTranslations("dashboard.venues");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -35,9 +38,9 @@ export default function VenuesClient({ venues }: { venues: VenueRow[] }) {
       try {
         const r = await createVenue(undefined, formData);
         if (r.success) {
-          toast.success("Local criado");
+          toast.success(t("toast.created"));
           setOpen(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.fail"), r.error);
       } finally {
         setBusy(false);
       }
@@ -50,9 +53,9 @@ export default function VenuesClient({ venues }: { venues: VenueRow[] }) {
     startTransition(async () => {
       const r = await deleteVenue(target.id);
       if (r.success) {
-        toast.success("Local removido");
+        toast.success(t("toast.removed"));
         setDeleting(null);
-      } else toast.error("Falha", r.error);
+      } else toast.error(t("toast.fail"), r.error);
     });
   }
 
@@ -64,13 +67,13 @@ export default function VenuesClient({ venues }: { venues: VenueRow[] }) {
           className="flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white shadow-lg transition-colors hover:bg-rose-500"
         >
           <Plus className="h-4 w-4" />
-          <span>Novo local</span>
+          <span>{t("list.new")}</span>
         </button>
       </div>
 
       {venues.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/30 p-8 text-center text-sm text-zinc-500">
-          Nenhum local cadastrado ainda. Adicione candidatos para comparar lado a lado.
+          {t("list.empty")}
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -94,13 +97,13 @@ export default function VenuesClient({ venues }: { venues: VenueRow[] }) {
                   {v.isShortlisted ? (
                     <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] text-amber-300">
                       <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
-                      Favorito
+                      {t("list.favorite")}
                     </span>
                   ) : null}
                   <button
                     type="button"
                     onClick={() => setDeleting(v)}
-                    aria-label="Excluir local"
+                    aria-label={t("list.deleteAria")}
                     className="rounded-lg p-1.5 text-zinc-500 hover:bg-rose-500/10 hover:text-rose-400"
                   >
                     <Trash2 className="h-4 w-4" />
@@ -109,17 +112,19 @@ export default function VenuesClient({ venues }: { venues: VenueRow[] }) {
               </div>
 
               <div className="mt-4 grid grid-cols-3 gap-2 text-xs">
-                <Mini label="Sentados">{v.capacitySeated ?? "—"}</Mini>
-                <Mini label="Em pé">{v.capacityStanding ?? "—"}</Mini>
-                <Mini label="Locação">{v.baseRate ? formatCurrency(v.baseRate) : "—"}</Mini>
+                <Mini label={t("fields.seated")}>{v.capacitySeated ?? "—"}</Mini>
+                <Mini label={t("fields.standing")}>{v.capacityStanding ?? "—"}</Mini>
+                <Mini label={t("fields.rate")}>{v.baseRate ? formatCurrency(v.baseRate) : "—"}</Mini>
               </div>
 
               <div className="mt-3 flex items-center justify-between text-xs text-zinc-500">
-                <span>
-                  Checklist {v.checklistDone}/{v.checklistTotal}
-                </span>
-                <span>{v.attachmentCount} anexo(s)</span>
-                {v.visitedAt ? <span>Visitado em {formatDateBR(v.visitedAt)}</span> : <span>Sem visita</span>}
+                <span>{t("list.checklistCount", { done: v.checklistDone, total: v.checklistTotal })}</span>
+                <span>{t("list.attachments", { count: v.attachmentCount })}</span>
+                {v.visitedAt ? (
+                  <span>{t("list.visitedOn", { date: formatDateBR(v.visitedAt) })}</span>
+                ) : (
+                  <span>{t("list.noVisit")}</span>
+                )}
               </div>
             </article>
           ))}
@@ -129,35 +134,35 @@ export default function VenuesClient({ venues }: { venues: VenueRow[] }) {
       {open ? (
         <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
           <div className="my-4 w-full max-w-xl rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
-            <h2 className="text-lg font-semibold text-white">Novo local</h2>
+            <h2 className="text-lg font-semibold text-white">{t("list.new")}</h2>
             <form action={handleSubmit} className="mt-4 space-y-3">
-              <Input name="name" label="Nome" required placeholder="Ex: Vila dos Lagos" />
-              <Input name="address" label="Endereço" />
+              <Input name="name" label={t("fields.name")} required placeholder={t("form.namePlaceholder")} />
+              <Input name="address" label={t("fields.address")} />
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <Input name="mapsUrl" label="Link Google Maps / Waze" type="url" />
-                <Input name="baseRate" label="Valor locação (R$)" type="number" step="0.01" />
+                <Input name="mapsUrl" label={t("fields.mapsUrl")} type="url" />
+                <Input name="baseRate" label={t("fields.baseRate")} type="number" step="0.01" />
               </div>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <Input name="capacitySeated" label="Capacidade sentados" type="number" />
-                <Input name="capacityStanding" label="Capacidade em pé" type="number" />
+                <Input name="capacitySeated" label={t("fields.capacitySeated")} type="number" />
+                <Input name="capacityStanding" label={t("fields.capacityStanding")} type="number" />
               </div>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <Input name="contactName" label="Contato (nome)" />
-                <Input name="contactPhone" label="Contato (telefone)" />
+                <Input name="contactName" label={t("fields.contactName")} />
+                <Input name="contactPhone" label={t("fields.contactPhone")} />
               </div>
-              <Input name="visitedAt" label="Data da visita" type="date" />
-              <Textarea name="pros" label="Prós" rows={2} />
-              <Textarea name="cons" label="Contras" rows={2} />
-              <Textarea name="restrictions" label="Restrições" rows={2} />
-              <Textarea name="pricingNotes" label="Observações de preço" rows={2} />
-              <Textarea name="notes" label="Observações gerais" rows={2} />
+              <Input name="visitedAt" label={t("fields.visitedAt")} type="date" />
+              <Textarea name="pros" label={t("fields.pros")} rows={2} />
+              <Textarea name="cons" label={t("fields.cons")} rows={2} />
+              <Textarea name="restrictions" label={t("fields.restrictions")} rows={2} />
+              <Textarea name="pricingNotes" label={t("fields.pricingNotes")} rows={2} />
+              <Textarea name="notes" label={t("fields.notes")} rows={2} />
               <label className="flex items-center gap-2 text-sm text-zinc-300">
                 <input type="checkbox" name="isShortlisted" className="accent-rose-500" />
-                Marcar como favorito
+                {t("form.markFavorite")}
               </label>
               <label className="flex items-center gap-2 text-sm text-zinc-300">
                 <input type="checkbox" name="seedChecklist" defaultChecked className="accent-rose-500" />
-                Criar checklist padrão de visita (20 perguntas)
+                {t("form.seedChecklist")}
               </label>
               <div className="flex gap-2 pt-2">
                 <button
@@ -165,14 +170,14 @@ export default function VenuesClient({ venues }: { venues: VenueRow[] }) {
                   onClick={() => setOpen(false)}
                   className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
                 >
-                  Cancelar
+                  {tc("actions.cancel")}
                 </button>
                 <button
                   type="submit"
                   disabled={busy}
                   className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
                 >
-                  {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Salvar"}
+                  {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : tc("actions.save")}
                 </button>
               </div>
             </form>
@@ -182,9 +187,9 @@ export default function VenuesClient({ venues }: { venues: VenueRow[] }) {
 
       <ConfirmDialog
         open={!!deleting}
-        title={deleting ? `Excluir ${deleting.name}?` : "Excluir local?"}
-        description="O local e o checklist serão removidos das listagens."
-        confirmLabel="Excluir"
+        title={deleting ? t("delete.confirmTitle", { name: deleting.name }) : t("delete.confirmTitleFallback")}
+        description={t("delete.confirmDescription")}
+        confirmLabel={tc("actions.delete")}
         tone="danger"
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}

--- a/src/app/dashboard/wedding-day/seating/_components/GuestChip.tsx
+++ b/src/app/dashboard/wedding-day/seating/_components/GuestChip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useDraggable } from "@dnd-kit/core";
+import { useTranslations } from "next-intl";
 import { Crown, Baby, User } from "lucide-react";
 
 export type GuestChipData = {
@@ -14,6 +15,7 @@ export type GuestChipData = {
 };
 
 export function GuestChip({ guest, compact = false }: { guest: GuestChipData; compact?: boolean }) {
+  const t = useTranslations("dashboard.weddingDay.seating");
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `guest:${guest.id}`,
     data: { type: "guest", guestId: guest.id, plusOnes: guest.plusOnesConfirmed },
@@ -28,7 +30,7 @@ export function GuestChip({ guest, compact = false }: { guest: GuestChipData; co
       {...attributes}
       {...listeners}
       type="button"
-      aria-label={`Arrastar ${guest.name}`}
+      aria-label={t("chip.dragAria", { name: guest.name })}
       className={`flex w-full items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800/60 px-2.5 py-1.5 text-left text-xs text-zinc-100 hover:border-rose-500/40 hover:bg-zinc-800 ${
         isDragging ? "opacity-40" : ""
       } ${compact ? "py-1" : ""}`}

--- a/src/app/dashboard/wedding-day/seating/_components/TableCard.tsx
+++ b/src/app/dashboard/wedding-day/seating/_components/TableCard.tsx
@@ -3,6 +3,7 @@
 import { useDroppable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { useTranslations } from "next-intl";
 import { Circle, GripVertical, RectangleVertical, Square, Trash2, Edit3 } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -27,6 +28,7 @@ export function TableCard({
   onEdit?: () => void;
   onDelete?: () => void;
 }) {
+  const t = useTranslations("dashboard.weddingDay.seating");
   const {
     setNodeRef: setSortableRef,
     setActivatorNodeRef,
@@ -73,7 +75,7 @@ export function TableCard({
             ref={setActivatorNodeRef}
             {...attributes}
             {...listeners}
-            aria-label="Reordenar mesa"
+            aria-label={t("card.reorderAria")}
             className="flex-none cursor-grab touch-none rounded p-0.5 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 active:cursor-grabbing"
           >
             <GripVertical className="h-4 w-4" />
@@ -97,7 +99,7 @@ export function TableCard({
             <button
               type="button"
               onClick={onEdit}
-              aria-label="Editar mesa"
+              aria-label={t("card.editAria")}
               className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
             >
               <Edit3 className="h-3.5 w-3.5" />
@@ -107,7 +109,7 @@ export function TableCard({
             <button
               type="button"
               onClick={onDelete}
-              aria-label="Excluir mesa"
+              aria-label={t("card.deleteAria")}
               className="rounded p-1 text-zinc-400 hover:bg-rose-500/20 hover:text-rose-400"
             >
               <Trash2 className="h-3.5 w-3.5" />

--- a/src/app/dashboard/wedding-day/seating/seating-client.tsx
+++ b/src/app/dashboard/wedding-day/seating/seating-client.tsx
@@ -18,6 +18,7 @@ import {
 import { SortableContext, arrayMove, rectSortingStrategy } from "@dnd-kit/sortable";
 import { GripVertical, Plus, Users, Info } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import {
@@ -74,6 +75,8 @@ const seatingCollision: CollisionDetection = (args) => {
 };
 
 export default function SeatingClient({ initialTables, initialGuests }: Props) {
+  const t = useTranslations("dashboard.weddingDay.seating");
+  const tc = useTranslations("common");
   const router = useRouter();
   const toast = useToast();
   const [, startTransition] = useTransition();
@@ -133,9 +136,9 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
     setTables(reordered);
 
     startTransition(async () => {
-      const res = await reorderSeatingTables(reordered.map((t) => t.id));
+      const res = await reorderSeatingTables(reordered.map((tbl) => tbl.id));
       if (!res.success) {
-        toast.error("Falha", res.error);
+        toast.error(t("toast.error"), res.error);
         setTables(previous);
       } else {
         router.refresh();
@@ -175,8 +178,8 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
       const needed = 1 + (guest.plusOnesConfirmed ?? 0);
       if (seatsUsed + needed > table.capacity) {
         toast.error(
-          "Mesa cheia",
-          `Capacidade ${table.capacity}, ocupados ${seatsUsed}, necessário ${needed}`,
+          t("toast.tableFull"),
+          t("toast.tableFullDetail", { capacity: table.capacity, used: seatsUsed, needed }),
         );
         return;
       }
@@ -188,7 +191,7 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
     startTransition(async () => {
       const res = await assignGuestToTable(guestId, targetTableId);
       if (!res.success) {
-        toast.error("Falha", res.error);
+        toast.error(t("toast.error"), res.error);
         setGuests((cur) => cur.map((g) => (g.id === guestId ? { ...g, tableId: previousTableId } : g)));
       } else {
         router.refresh();
@@ -201,10 +204,10 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
     const res = await createSeatingTable(undefined, formData);
     setBusy(false);
     if (!res.success) {
-      toast.error("Erro", res.error);
+      toast.error(t("toast.errorTitle"), res.error);
       return;
     }
-    toast.success("Mesa criada");
+    toast.success(t("toast.created"));
     setShowCreate(false);
     router.refresh();
   }
@@ -216,10 +219,10 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
     const res = await updateSeatingTable(undefined, formData);
     setBusy(false);
     if (!res.success) {
-      toast.error("Erro", res.error);
+      toast.error(t("toast.errorTitle"), res.error);
       return;
     }
-    toast.success("Mesa atualizada");
+    toast.success(t("toast.updated"));
     setEditing(null);
     router.refresh();
   }
@@ -230,10 +233,10 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
     const res = await deleteSeatingTable(confirmDelete.id);
     setBusy(false);
     if (!res.success) {
-      toast.error("Erro", res.error);
+      toast.error(t("toast.errorTitle"), res.error);
       return;
     }
-    toast.success("Mesa excluída");
+    toast.success(t("toast.deleted"));
     setConfirmDelete(null);
     router.refresh();
   }
@@ -248,9 +251,9 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
       <div className="space-y-4 p-4 md:p-6">
         <header className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h1 className="text-xl font-semibold text-zinc-100 md:text-2xl">Mapa de assentos</h1>
+            <h1 className="text-xl font-semibold text-zinc-100 md:text-2xl">{t("title")}</h1>
             <p className="text-sm text-zinc-400">
-              Arraste convidados confirmados para as mesas. Capacidade considera +1.
+              {t("subtitle")}
             </p>
           </div>
           <button
@@ -259,14 +262,14 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
             className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500"
           >
             <Plus className="h-4 w-4" />
-            Nova mesa
+            {t("newTable")}
           </button>
         </header>
 
         <div className="grid grid-cols-1 gap-2 rounded-2xl border border-zinc-800 bg-zinc-900/40 p-3 sm:grid-cols-3">
-          <Stat label="Mesas" value={tables.length} />
-          <Stat label="Assentos totais" value={totalSeats} />
-          <Stat label="Convidados alocados" value={totalAllocated} suffix={`/${guests.reduce((s, g) => s + 1 + g.plusOnesConfirmed, 0)}`} />
+          <Stat label={t("stats.tables")} value={tables.length} />
+          <Stat label={t("stats.totalSeats")} value={totalSeats} />
+          <Stat label={t("stats.allocatedGuests")} value={totalAllocated} suffix={`/${guests.reduce((s, g) => s + 1 + g.plusOnesConfirmed, 0)}`} />
         </div>
 
         <div className="flex flex-col gap-4 lg:flex-row">
@@ -276,28 +279,28 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
             <div className="mb-3 flex items-center gap-2 text-xs text-zinc-400">
               <Info className="h-3.5 w-3.5" />
               {tables.length === 0
-                ? "Crie a primeira mesa para começar."
-                : "Solte um convidado numa mesa para alocar; arraste pela alça para reordenar."}
+                ? t("hint.empty")
+                : t("hint.help")}
             </div>
             <SortableContext items={tables.map((t) => t.id)} strategy={rectSortingStrategy}>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                {tables.map((t) => {
-                  const tableGuests = guests.filter((g) => g.tableId === t.id);
-                  const seatsUsed = computeSeatsUsed(guests, t.id);
+                {tables.map((tbl) => {
+                  const tableGuests = guests.filter((g) => g.tableId === tbl.id);
+                  const seatsUsed = computeSeatsUsed(guests, tbl.id);
                   return (
                     <TableCard
-                      key={t.id}
-                      id={t.id}
-                      name={t.name}
-                      capacity={t.capacity}
-                      shape={t.shape as "ROUND" | "RECT" | "SQUARE"}
+                      key={tbl.id}
+                      id={tbl.id}
+                      name={tbl.name}
+                      capacity={tbl.capacity}
+                      shape={tbl.shape as "ROUND" | "RECT" | "SQUARE"}
                       seatsUsed={seatsUsed}
-                      onEdit={() => setEditing(t)}
-                      onDelete={() => setConfirmDelete(t)}
+                      onEdit={() => setEditing(tbl)}
+                      onDelete={() => setConfirmDelete(tbl)}
                     >
                       {tableGuests.length === 0 ? (
                         <p className="rounded-lg border border-dashed border-zinc-700 px-2 py-3 text-center text-[11px] text-zinc-500">
-                          Solte convidados aqui
+                          {t("table.dropGuests")}
                         </p>
                       ) : (
                         tableGuests.map((g) => <GuestChip key={g.id} guest={g} compact />)
@@ -312,7 +315,7 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
 
         {showCreate ? (
           <TableForm
-            title="Nova mesa"
+            title={t("form.createTitle")}
             busy={busy}
             onCancel={() => setShowCreate(false)}
             onSubmit={handleCreate}
@@ -321,7 +324,7 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
 
         {editing ? (
           <TableForm
-            title="Editar mesa"
+            title={t("form.editTitle")}
             initial={{ name: editing.name, capacity: editing.capacity, shape: editing.shape, notes: editing.notes }}
             busy={busy}
             onCancel={() => setEditing(null)}
@@ -331,14 +334,14 @@ export default function SeatingClient({ initialTables, initialGuests }: Props) {
 
         <ConfirmDialog
           open={confirmDelete !== null}
-          title="Excluir mesa?"
+          title={t("delete.title")}
           description={
             confirmDelete
-              ? `A mesa "${confirmDelete.name}" será removida e os convidados ficarão sem alocação.`
+              ? t("delete.description", { name: confirmDelete.name })
               : ""
           }
           tone="danger"
-          confirmLabel="Excluir"
+          confirmLabel={tc("actions.delete")}
           busy={busy}
           onConfirm={handleDelete}
           onCancel={() => setConfirmDelete(null)}
@@ -378,6 +381,7 @@ function Stat({ label, value, suffix }: { label: string; value: number; suffix?:
 }
 
 function GuestPool({ guests }: { guests: GuestChipData[] }) {
+  const t = useTranslations("dashboard.weddingDay.seating");
   const { setNodeRef, isOver } = useDroppable({
     id: "pool",
     data: { type: "pool" },
@@ -391,7 +395,7 @@ function GuestPool({ guests }: { guests: GuestChipData[] }) {
     >
       <header className="mb-3 flex items-center gap-2">
         <Users className="h-4 w-4 text-zinc-400" />
-        <h2 className="text-sm font-medium text-zinc-100">Pool de convidados</h2>
+        <h2 className="text-sm font-medium text-zinc-100">{t("pool.title")}</h2>
         <span className="ml-auto rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] text-zinc-400">
           {guests.length}
         </span>
@@ -399,7 +403,7 @@ function GuestPool({ guests }: { guests: GuestChipData[] }) {
       <div className="space-y-1.5 max-h-[60vh] overflow-y-auto pr-1">
         {guests.length === 0 ? (
           <p className="rounded-lg border border-dashed border-zinc-700 px-3 py-6 text-center text-xs text-zinc-500">
-            Todos os confirmados estão alocados. Solte aqui para desalocar.
+            {t("pool.empty")}
           </p>
         ) : (
           guests.map((g) => <GuestChip key={g.id} guest={g} />)
@@ -422,6 +426,8 @@ function TableForm({
   onCancel: () => void;
   onSubmit: (fd: FormData) => void;
 }) {
+  const t = useTranslations("dashboard.weddingDay.seating");
+  const tc = useTranslations("common");
   return (
     <div className="fixed inset-0 z-[80] flex items-start justify-center overflow-y-auto bg-black/60 p-4 backdrop-blur-sm sm:items-center">
       <form
@@ -429,7 +435,7 @@ function TableForm({
         className="my-4 w-full max-w-md space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900 p-5 shadow-2xl"
       >
         <h2 className="text-base font-semibold text-zinc-100">{title}</h2>
-        <Field label="Nome">
+        <Field label={tc("labels.name")}>
           <input
             name="name"
             defaultValue={initial?.name ?? ""}
@@ -439,7 +445,7 @@ function TableForm({
           />
         </Field>
         <div className="grid grid-cols-2 gap-3">
-          <Field label="Capacidade">
+          <Field label={t("form.capacity")}>
             <input
               type="number"
               name="capacity"
@@ -450,19 +456,19 @@ function TableForm({
               className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 focus:border-rose-500 focus:outline-none"
             />
           </Field>
-          <Field label="Formato">
+          <Field label={t("form.shape")}>
             <select
               name="shape"
               defaultValue={initial?.shape ?? "ROUND"}
               className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 focus:border-rose-500 focus:outline-none"
             >
-              <option value="ROUND">Redonda</option>
-              <option value="RECT">Retangular</option>
-              <option value="SQUARE">Quadrada</option>
+              <option value="ROUND">{t("shape.round")}</option>
+              <option value="RECT">{t("shape.rect")}</option>
+              <option value="SQUARE">{t("shape.square")}</option>
             </select>
           </Field>
         </div>
-        <Field label="Observações">
+        <Field label={tc("labels.notes")}>
           <textarea
             name="notes"
             defaultValue={initial?.notes ?? ""}
@@ -478,14 +484,14 @@ function TableForm({
             disabled={busy}
             className="rounded-lg px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
           >
-            Cancelar
+            {tc("actions.cancel")}
           </button>
           <button
             type="submit"
             disabled={busy}
             className="rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-60"
           >
-            {busy ? "Salvando..." : "Salvar"}
+            {busy ? t("form.saving") : tc("actions.save")}
           </button>
         </div>
       </form>

--- a/src/app/dashboard/wedding-day/wedding-day-client.tsx
+++ b/src/app/dashboard/wedding-day/wedding-day-client.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import {
   AlertTriangle,
   Armchair,
@@ -84,6 +85,8 @@ export default function WeddingDayClient({
   guestStats,
   guests,
 }: Props) {
+  const t = useTranslations("dashboard.weddingDay");
+  const tc = useTranslations("common");
   const toast = useToast();
   const [editingSettings, setEditingSettings] = useState(false);
   const [search, setSearch] = useState("");
@@ -109,9 +112,9 @@ export default function WeddingDayClient({
       try {
         const r = await updateWeddingDay(undefined, formData);
         if (r.success) {
-          toast.success("Salvo");
+          toast.success(t("toast.saved"));
           setEditingSettings(false);
-        } else toast.error("Falha", r.error);
+        } else toast.error(t("toast.error"), r.error);
       } finally {
         setBusy(false);
       }
@@ -121,7 +124,7 @@ export default function WeddingDayClient({
   function handleCheckin(g: Guest) {
     startTransition(async () => {
       const r = await toggleCheckin(g.id, !g.checkedInAt);
-      if (!r.success) toast.error("Falha", r.error);
+      if (!r.success) toast.error(t("toast.error"), r.error);
     });
   }
 
@@ -132,25 +135,25 @@ export default function WeddingDayClient({
           <div>
             <div className="flex items-center gap-2 text-rose-200">
               <CalendarHeart className="h-5 w-5" />
-              <span className="text-xs uppercase tracking-wider">Modo Dia do Casamento</span>
+              <span className="text-xs uppercase tracking-wider">{t("header.mode")}</span>
             </div>
             <h1 className="mt-1 text-3xl font-bold text-white">
-              {coupleNames ?? "O grande dia"}
+              {coupleNames ?? t("header.fallbackTitle")}
             </h1>
             <p className="mt-1 text-sm text-zinc-300">{formatDateBR(eventDate)}</p>
           </div>
           <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-5 py-3 text-center">
-            <p className="text-xs uppercase tracking-wider text-rose-200">Contagem regressiva</p>
-            <p className="text-3xl font-bold text-rose-100">{daysToEvent} dia{daysToEvent === 1 ? "" : "s"}</p>
+            <p className="text-xs uppercase tracking-wider text-rose-200">{t("header.countdown")}</p>
+            <p className="text-3xl font-bold text-rose-100">{t("header.daysLeft", { count: daysToEvent })}</p>
           </div>
         </div>
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Stat label="Confirmados" value={`${confirmed}/${total}`} accent="emerald" />
-        <Stat label="Total de cabeças" value={String(totalSeats)} />
-        <Stat label="Chegaram" value={`${checkedIn}/${totalSeats}`} accent={checkedIn > 0 ? "emerald" : "amber"} />
-        <Stat label="Tarefas do dia" value={String(tasksToday.length)} accent="amber" />
+        <Stat label={t("stats.confirmed")} value={`${confirmed}/${total}`} accent="emerald" />
+        <Stat label={t("stats.totalHeads")} value={String(totalSeats)} />
+        <Stat label={t("stats.arrived")} value={`${checkedIn}/${totalSeats}`} accent={checkedIn > 0 ? "emerald" : "amber"} />
+        <Stat label={t("stats.tasksToday")} value={String(tasksToday.length)} accent="amber" />
       </div>
 
       <Link
@@ -161,61 +164,61 @@ export default function WeddingDayClient({
           <Armchair className="h-5 w-5" />
         </span>
         <div className="min-w-0">
-          <h3 className="font-semibold text-zinc-100">Mapa de assentos</h3>
+          <h3 className="font-semibold text-zinc-100">{t("seatingLink.title")}</h3>
           <p className="text-sm text-zinc-400">
-            Organize as mesas e arraste os convidados confirmados para os lugares.
+            {t("seatingLink.description")}
           </p>
         </div>
         <ChevronRight className="ml-auto h-5 w-5 flex-none text-zinc-500" />
       </Link>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <Card title="Cronograma do dia" icon={<CalendarHeart className="h-5 w-5" />}>
+        <Card title={t("schedule.title")} icon={<CalendarHeart className="h-5 w-5" />}>
           <pre className="whitespace-pre-wrap font-sans text-sm text-zinc-200">
-            {settings?.daySchedule || "Nenhum cronograma adicionado. Use o botão abaixo para registrar (ex.: 07:00 cabeleireiro, 14:00 chegada do buffet...)."}
+            {settings?.daySchedule || t("schedule.empty")}
           </pre>
         </Card>
 
-        <Card title="Plano B chuva / contingências" icon={<CloudRain className="h-5 w-5" />}>
+        <Card title={t("rainPlan.title")} icon={<CloudRain className="h-5 w-5" />}>
           <pre className="whitespace-pre-wrap font-sans text-sm text-zinc-200">
-            {settings?.rainPlanB || "Sem plano B documentado."}
+            {settings?.rainPlanB || t("rainPlan.empty")}
           </pre>
         </Card>
       </div>
 
-      <Card title="Observações especiais" icon={<AlertTriangle className="h-5 w-5" />}>
+      <Card title={t("notes.title")} icon={<AlertTriangle className="h-5 w-5" />}>
         <pre className="whitespace-pre-wrap font-sans text-sm text-zinc-200">
-          {settings?.daySpecialNotes || "Sem observações."}
+          {settings?.daySpecialNotes || t("notes.empty")}
         </pre>
         <button
           type="button"
           onClick={() => setEditingSettings((v) => !v)}
           className="mt-3 inline-flex items-center gap-1 rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-100 hover:bg-zinc-700"
         >
-          {editingSettings ? "Fechar edição" : "Editar cronograma / plano B / observações"}
+          {editingSettings ? t("notes.closeEdit") : t("notes.openEdit")}
         </button>
 
         {editingSettings ? (
           <form action={handleUpdateSettings} className="mt-4 space-y-3">
             <FormTextarea
-              label="Cronograma do dia"
+              label={t("schedule.title")}
               name="daySchedule"
               defaultValue={settings?.daySchedule ?? ""}
               rows={6}
-              placeholder={`Ex:\n07:00 — cabeleireiro chega\n11:00 — fotógrafo making of\n16:30 — cerimônia\n...`}
+              placeholder={t("schedule.placeholder")}
             />
             <FormTextarea
-              label="Plano B chuva / contingências"
+              label={t("rainPlan.title")}
               name="rainPlanB"
               defaultValue={settings?.rainPlanB ?? ""}
               rows={3}
             />
             <FormTextarea
-              label="Observações especiais"
+              label={t("notes.title")}
               name="daySpecialNotes"
               defaultValue={settings?.daySpecialNotes ?? ""}
               rows={3}
-              placeholder="Música primeira dança, valsa, surpresa, sabores do bolo..."
+              placeholder={t("notes.placeholder")}
             />
             <button
               type="submit"
@@ -223,15 +226,15 @@ export default function WeddingDayClient({
               className="inline-flex items-center gap-2 rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
             >
               {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-              <span>Salvar</span>
+              <span>{tc("actions.save")}</span>
             </button>
           </form>
         ) : null}
       </Card>
 
-      <Card title="Contatos críticos" icon={<Phone className="h-5 w-5" />}>
+      <Card title={t("contacts.title")} icon={<Phone className="h-5 w-5" />}>
         {criticalVendors.length === 0 ? (
-          <p className="text-sm text-zinc-500">Sem fornecedores contratados.</p>
+          <p className="text-sm text-zinc-500">{t("contacts.empty")}</p>
         ) : (
           <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             {criticalVendors.map((v) => (
@@ -258,7 +261,7 @@ export default function WeddingDayClient({
                     href={`/dashboard/vendors/${v.id}`}
                     className="mt-1 inline-flex items-center gap-1 text-xs text-rose-400 hover:text-rose-300"
                   >
-                    <Phone className="h-3 w-3" /> Cadastrar contato
+                    <Phone className="h-3 w-3" /> {t("contacts.addContact")}
                   </Link>
                 )}
               </li>
@@ -267,9 +270,9 @@ export default function WeddingDayClient({
         )}
       </Card>
 
-      <Card title="Tarefas do dia" icon={<CheckCircle2 className="h-5 w-5" />}>
+      <Card title={t("tasks.title")} icon={<CheckCircle2 className="h-5 w-5" />}>
         {tasksToday.length === 0 ? (
-          <p className="text-sm text-zinc-500">Nenhuma tarefa marcada para hoje.</p>
+          <p className="text-sm text-zinc-500">{t("tasks.empty")}</p>
         ) : (
           <ul className="space-y-2">
             {tasksToday.map((t) => (
@@ -293,7 +296,7 @@ export default function WeddingDayClient({
       </Card>
 
       {paymentsToday.length > 0 ? (
-        <Card title="Pagamentos do dia">
+        <Card title={t("payments.title")}>
           <ul className="space-y-2">
             {paymentsToday.map((p) => (
               <li
@@ -311,19 +314,19 @@ export default function WeddingDayClient({
         </Card>
       ) : null}
 
-      <Card title="Check-in rápido">
+      <Card title={t("checkin.title")}>
         <div className="relative mb-3">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500" />
           <input
             type="search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder="Buscar convidado..."
+            placeholder={t("checkin.searchPlaceholder")}
             className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
           />
         </div>
         {filteredGuests.length === 0 ? (
-          <p className="text-sm text-zinc-500">Nenhum convidado.</p>
+          <p className="text-sm text-zinc-500">{t("checkin.empty")}</p>
         ) : (
           <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             {filteredGuests.map((g) => (
@@ -331,7 +334,7 @@ export default function WeddingDayClient({
                 <div>
                   <p className="font-medium text-zinc-100">{g.name}</p>
                   <p className="text-[11px] text-zinc-500">
-                    {g.isChild ? "Criança · " : ""}
+                    {g.isChild ? t("checkin.childPrefix") : ""}
                     {g.plusOnesConfirmed > 0 ? `+${g.plusOnesConfirmed}` : ""}
                   </p>
                 </div>
@@ -344,7 +347,7 @@ export default function WeddingDayClient({
                       : "border-zinc-700 bg-zinc-800 text-zinc-300 hover:bg-zinc-700"
                   }`}
                 >
-                  {g.checkedInAt ? "Chegou" : "Marcar"}
+                  {g.checkedInAt ? t("checkin.arrived") : t("checkin.mark")}
                 </button>
               </li>
             ))}

--- a/src/messages/en/actions.json
+++ b/src/messages/en/actions.json
@@ -1,4 +1,31 @@
 {
+  "asset": {
+    "notFound": "Contribution not found",
+    "errorCreate": "Failed to create contribution",
+    "errorUpdate": "Failed to update contribution",
+    "errorDelete": "Failed to delete contribution"
+  },
+  "attachment": {
+    "notFound": "Attachment not found",
+    "vendorNotFound": "Vendor not found",
+    "contractNotFound": "Contract not found",
+    "venueNotFound": "Venue not found",
+    "noPermission": "No permission",
+    "noPermissionEdit": "No permission to edit",
+    "noPermissionKind": "No permission for this attachment type",
+    "noPermissionView": "No permission for this attachment",
+    "onlyAdminCoupleRemoveContract": "Only the admin, groom or bride can remove contracts.",
+    "rateLimitUser": "Too many uploads in a row. Try again in 1 minute.",
+    "rateLimitIp": "Upload limit exceeded.",
+    "invalidTarget": "Invalid target",
+    "fileRequired": "File required",
+    "errorUpload": "Error uploading file",
+    "errorDelete": "Error deleting attachment"
+  },
+  "auth": {
+    "invalidCredentials": "Invalid credentials.",
+    "loginGenericError": "Something went wrong while signing in."
+  },
   "common": {
     "unauthorized": "Not authorized",
     "forbidden": "Access denied",
@@ -6,9 +33,96 @@
     "notFound": "Not found",
     "generic": "Something went wrong. Please try again."
   },
-  "auth": {
-    "invalidCredentials": "Invalid credentials.",
-    "loginGenericError": "Something went wrong while signing in."
+  "contract": {
+    "notFound": "Contract not found",
+    "noPermissionSign": "No permission to sign",
+    "noPermissionUpload": "No permission to upload contract",
+    "rateLimitUser": "Too many uploads in a row. Try again in 1 minute.",
+    "rateLimitIp": "Upload limit exceeded.",
+    "invalidTarget": "Invalid target",
+    "fileRequired": "File required",
+    "errorCreate": "Error creating contract",
+    "errorUpdate": "Error updating contract",
+    "errorDelete": "Error deleting contract",
+    "errorSign": "Error recording signature",
+    "errorUpload": "Error uploading contract"
+  },
+  "gift": {
+    "notFound": "Gift not found",
+    "errorCreating": "Error recording gift",
+    "errorUpdating": "Error updating gift",
+    "errorUpdatingShort": "Error updating",
+    "errorDeleting": "Error deleting gift",
+    "errorMarkingPix": "Error marking Pix as received",
+    "pixAlreadyReceived": "Pix already marked as received",
+    "assetTitle": "Pix from {giver}{honeymoon}",
+    "assetGuestFallback": "guest",
+    "assetHoneymoonSuffix": " (honeymoon contribution)",
+    "assetNotes": "Generated from gift #{id}"
+  },
+  "goal": {
+    "notFound": "Goal not found",
+    "errorCreate": "Error creating goal",
+    "errorUpdate": "Error updating goal",
+    "errorDelete": "Error deleting goal"
+  },
+  "guest": {
+    "errorCreating": "Failed to create guest",
+    "notFound": "Guest not found",
+    "errorUpdating": "Failed to update guest",
+    "errorDeleting": "Failed to delete guest",
+    "errorCheckin": "Failed to record attendance",
+    "noLinesFound": "No lines found",
+    "errorImporting": "Failed to import",
+    "tooManyAttempts": "Too many attempts. Try again in a few minutes.",
+    "inviteNotFound": "Invitation not found",
+    "linkExpired": "Link expired. Request a new invitation.",
+    "errorRsvp": "Failed to record response",
+    "tooManyUploads": "Too many uploads in a row. Wait 1 minute.",
+    "uploadLimitExceeded": "Upload limit exceeded.",
+    "fileRequired": "File required",
+    "unknownSource": "Unknown source",
+    "unsupportedFormat": "Unsupported format. Use .xlsx (Wedy) or .csv (export from this system).",
+    "unrecognizedFormat": "Could not identify the format. Supported: Wedy (.xlsx) or CSV exported by this system.",
+    "noValidRows": "No valid rows found in the spreadsheet.",
+    "rowLimit": "Limit of {max} rows per import.",
+    "errorProcessingFile": "Failed to process file",
+    "importSessionExpired": "Import session expired. Resend the file.",
+    "errorCommittingImport": "Failed to save import"
+  },
+  "guestGroup": {
+    "errorCreating": "Failed to create group",
+    "notFound": "Group not found",
+    "errorUpdating": "Failed to update group",
+    "invalidId": "Invalid ID",
+    "errorDeleting": "Failed to delete group",
+    "errorUpdatingMembers": "Failed to update members",
+    "tooManyAttempts": "Too many attempts. Try again in a few minutes.",
+    "groupInviteNotFound": "Group invitation not found",
+    "linkExpired": "Link expired. Request a new invitation.",
+    "guestOutsideGroup": "Invalid response (guest outside the group)",
+    "errorRsvp": "Failed to record responses"
+  },
+  "honeymoon": {
+    "itemNotFound": "Item not found",
+    "errorSaving": "Error saving",
+    "errorAdding": "Error adding",
+    "errorUpdating": "Error updating",
+    "errorDeleting": "Error deleting"
+  },
+  "income": {
+    "notFound": "Income not found",
+    "errorCreate": "Error creating income",
+    "errorUpdate": "Error updating income",
+    "errorMarkReceived": "Error marking as received",
+    "errorDelete": "Error deleting income"
+  },
+  "onboarding": {
+    "coupleNameRequired": "Enter the couple's name",
+    "invalidDate": "Invalid date",
+    "errorCouple": "Error saving couple data",
+    "errorBudget": "Error saving budget",
+    "errorFinish": "Error finishing onboarding"
   },
   "passwordReset": {
     "invalidEmail": "Invalid email",
@@ -19,12 +133,18 @@
     "userNotFoundOrInactive": "User not found or inactive",
     "errorResetting": "Error resetting password"
   },
-  "onboarding": {
-    "coupleNameRequired": "Enter the couple's name",
-    "invalidDate": "Invalid date",
-    "errorCouple": "Error saving couple data",
-    "errorBudget": "Error saving budget",
-    "errorFinish": "Error finishing onboarding"
+  "payment": {
+    "vendorNotFound": "Vendor not found",
+    "notFound": "Payment not found",
+    "notFoundOrPaid": "Payment not found or already paid",
+    "cannotUndo": "This payment cannot be reverted",
+    "errorCreate": "Error creating payment",
+    "errorUpdate": "Error updating payment",
+    "errorMarkPaid": "Error settling payment",
+    "errorUndo": "Error reverting payment",
+    "errorDelete": "Error deleting payment",
+    "errorSplit": "Error creating split payments",
+    "errorInstallments": "Error generating installments"
   },
   "profile": {
     "invalidLocale": "Invalid language",
@@ -34,5 +154,109 @@
     "wrongPassword": "Current password is incorrect",
     "emailTaken": "A user with this email already exists",
     "emailUpdated": "Email updated. Use it on your next login."
+  },
+  "seatingTable": {
+    "errorCreate": "Failed to create table",
+    "tableNotFound": "Table not found",
+    "errorUpdate": "Failed to update table",
+    "invalidId": "Invalid ID",
+    "errorDelete": "Failed to delete table",
+    "invalidOrder": "Invalid order",
+    "errorReorder": "Failed to reorder tables",
+    "invalidCoords": "Invalid coordinates",
+    "errorMove": "Failed to move table",
+    "invalidGuestId": "Invalid guest ID",
+    "invalidTableId": "Invalid table ID",
+    "guestNotFound": "Guest not found",
+    "tableFull": "Table \"{name}\" doesn't have enough seats (capacity {capacity}, occupied {used}, required {needed})",
+    "errorAssign": "Failed to assign guest"
+  },
+  "security": {
+    "errorGenerating": "Error generating 2FA setup",
+    "invalidCode": "Invalid code",
+    "invalidTotp": "Invalid TOTP code",
+    "errorEnabling": "Error enabling 2FA",
+    "codeRequired": "Code required",
+    "notActive": "2FA is not active",
+    "errorDisabling": "Error disabling 2FA"
+  },
+  "settings": {
+    "errorSaving": "Error saving settings",
+    "errorSavingPix": "Error saving Pix settings"
+  },
+  "task": {
+    "notFound": "Task not found",
+    "errorCreate": "Failed to create task",
+    "errorUpdate": "Failed to update task",
+    "errorStatus": "Failed to update status",
+    "errorDelete": "Failed to delete task",
+    "errorTemplates": "Failed to load template",
+    "eventDateRequired": "Set the event date in Settings to use the templates."
+  },
+  "trousseau": {
+    "notFound": "Item not found",
+    "errorAdding": "Failed to add",
+    "errorUpdating": "Failed to update",
+    "errorUpdatingStatus": "Failed to update status",
+    "errorDeleting": "Failed to delete"
+  },
+  "user": {
+    "noPermission": "No permission",
+    "invalidSession": "Invalid session",
+    "emailTaken": "A user with this email already exists",
+    "passwordTooShort": "Password must be at least {min} characters",
+    "passwordTooLong": "Password too long",
+    "errorCreating": "Error creating user",
+    "notFound": "User not found",
+    "cannotChangeOwnRole": "You can't change your own role",
+    "cannotDeactivateSelf": "You can't deactivate yourself",
+    "keepOneAdmin": "Keep at least one active administrator",
+    "errorUpdating": "Error updating user",
+    "errorResettingPassword": "Error resetting password",
+    "invalidId": "Invalid ID",
+    "errorResetting2FA": "Error resetting 2FA",
+    "cannotArchiveSelf": "You can't archive yourself",
+    "errorArchiving": "Error archiving user",
+    "errorRestoring": "Error restoring user",
+    "newPasswordMustDiffer": "The new password must be different from the current one",
+    "wrongCurrentPassword": "Current password is incorrect",
+    "errorChangingPassword": "Error changing password",
+    "errorUpdatingProfile": "Error updating profile",
+    "securityPolicyAdminOnly": "Only administrators can change the security policy",
+    "errorSavingSecurityPolicy": "Error saving security policy"
+  },
+  "vendor": {
+    "errorCreate": "Error creating vendor",
+    "errorUpdate": "Error updating vendor",
+    "errorStatus": "Error updating status",
+    "errorDelete": "Error deleting vendor"
+  },
+  "vendorContact": {
+    "notFound": "Contact not found",
+    "errorCreate": "Error adding contact",
+    "errorUpdate": "Error updating contact",
+    "errorDelete": "Error deleting contact"
+  },
+  "vendorNote": {
+    "notFound": "Note not found",
+    "errorCreate": "Error adding note",
+    "errorDelete": "Error deleting note"
+  },
+  "venue": {
+    "errorCreate": "Failed to create venue",
+    "notFound": "Venue not found",
+    "errorUpdate": "Failed to update venue",
+    "errorDelete": "Failed to delete venue",
+    "errorAddItem": "Failed to add item",
+    "errorUpdateItem": "Failed to update item",
+    "itemNotFound": "Item not found",
+    "errorDeleteItem": "Failed to delete item"
+  },
+  "weddingDay": {
+    "errorSaving": "Failed to save"
+  },
+  "whatsapp": {
+    "adminOnly": "Administrators only",
+    "testMessageBody": "*Wedding Finance*\n\nTest message sent successfully. Your WhatsApp integration is working. ✅"
   }
 }

--- a/src/messages/en/dashboard.json
+++ b/src/messages/en/dashboard.json
@@ -1,1 +1,2033 @@
-{}
+{
+  "assets": {
+    "page": {
+      "title": "Cash (Money Saved)"
+    },
+    "list": {
+      "searchPlaceholder": "Search contribution...",
+      "total": "Total: {value}",
+      "new": "New Contribution",
+      "empty": "No contributions recorded yet.",
+      "noResults": "No results for this filter."
+    },
+    "table": {
+      "date": "Date",
+      "source": "Source",
+      "amount": "Amount",
+      "actions": "Actions"
+    },
+    "delete": {
+      "title": "Delete contribution?"
+    },
+    "toast": {
+      "created": "Contribution recorded",
+      "updated": "Contribution updated",
+      "deleted": "Contribution deleted",
+      "failTitle": "Failed"
+    },
+    "form": {
+      "titleCreate": "New contribution",
+      "titleEdit": "Edit contribution",
+      "titleLabel": "Title / Source",
+      "titlePlaceholder": "e.g. March salary",
+      "amountLabel": "Amount",
+      "dateLabel": "Date",
+      "goalLabel": "Link to a goal (optional)",
+      "goalNone": "— no goal —",
+      "notesLabel": "Notes"
+    }
+  },
+  "gifts": {
+    "page": {
+      "title": "Gifts received",
+      "subtitle": "Record what you received (cash or item), from whom, and mark when the thank-you has been sent."
+    },
+    "stats": {
+      "cashTotal": "Total in cash",
+      "itemsReceived": "Items received",
+      "pendingThank": "Awaiting thank-you"
+    },
+    "filter": {
+      "all": "All",
+      "pendingThank": "Awaiting thank-you"
+    },
+    "list": {
+      "empty": "No gifts recorded."
+    },
+    "anonymous": "Anonymous",
+    "type": {
+      "cash": "Cash",
+      "item": "Item"
+    },
+    "badge": {
+      "thanked": "Thanked",
+      "honeymoon": "honeymoon",
+      "pixReceived": "Pix received"
+    },
+    "actions": {
+      "new": "New gift",
+      "generatePix": "Generate Pix QR",
+      "toggleThank": "Toggle thank-you",
+      "markThanked": "Mark as thanked",
+      "unmarkThanked": "Unmark thanked"
+    },
+    "delete": {
+      "title": "Delete gift?"
+    },
+    "form": {
+      "titleCreate": "New gift",
+      "titleEdit": "Edit gift",
+      "type": "Type",
+      "guest": "Guest (optional)",
+      "giverName": "Giver's name (if no guest)",
+      "amount": "Amount",
+      "description": "Description",
+      "receivedAt": "Received on",
+      "honeymoonShare": "Honeymoon contribution (show dedicated Pix QR)",
+      "notes": "Notes"
+    },
+    "toast": {
+      "created": "Gift recorded",
+      "updated": "Gift updated",
+      "removed": "Gift removed",
+      "thanked": "Marked as thanked",
+      "unthanked": "Unmarked",
+      "failed": "Failed"
+    },
+    "pix": {
+      "back": "Back",
+      "title": "Pix QR Code",
+      "qrAlt": "Pix QR Code",
+      "errorGenerating": "Error generating QR Code",
+      "errorPrefix": "Error generating Pix:",
+      "field": {
+        "key": "Pix key",
+        "holder": "recipient name",
+        "city": "city"
+      },
+      "incomplete": {
+        "title": "Incomplete Pix configuration",
+        "intro": "To generate the QR Code, configure:",
+        "goToSettings": "Go to Settings"
+      },
+      "summary": {
+        "title": "Summary",
+        "gift": "Gift",
+        "value": "Amount",
+        "freeValue": "no amount (open)",
+        "status": "Pix status",
+        "receivedOn": "Received on",
+        "awaiting": "Awaiting confirmation"
+      },
+      "copyPaste": {
+        "title": "Pix copy and paste",
+        "copyButton": "Copy code"
+      },
+      "confirm": {
+        "title": "Confirm receipt",
+        "hint": "After verifying the payment in your account, mark it as received.",
+        "addToAsset": "Add amount to cash (Asset)",
+        "saving": "Saving...",
+        "markReceived": "Mark as received"
+      },
+      "toast": {
+        "copied": "Code copied",
+        "marked": "Pix marked as received",
+        "error": "Error",
+        "copyFailed": "Could not copy"
+      }
+    }
+  },
+  "goals": {
+    "page": {
+      "title": "Savings goals",
+      "subtitle": "Define how much to save by when. Contributions (cash) can be linked to a goal."
+    },
+    "list": {
+      "new": "New goal",
+      "empty": "No goals yet. Create one to track your savings progress toward the target date."
+    },
+    "card": {
+      "inactive": "inactive",
+      "target": "Target: {date}",
+      "pctReached": "{pct}% reached",
+      "contributions": "{count, plural, one {# contribution} other {# contributions}}",
+      "remaining": "Remaining",
+      "perMonth": "Per month"
+    },
+    "form": {
+      "createTitle": "New goal",
+      "editTitle": "Edit goal",
+      "name": "Name",
+      "targetAmount": "Target amount (R$)",
+      "targetDate": "Target date",
+      "imageUrl": "Inspiration image URL (optional)",
+      "imageUrlPlaceholder": "https://example.com/image.jpg",
+      "isActive": "Active goal",
+      "notes": "Notes"
+    },
+    "delete": {
+      "title": "Delete goal?",
+      "description": "Linked contributions still exist, but they lose the link."
+    },
+    "toast": {
+      "created": "Goal created",
+      "updated": "Goal updated",
+      "removed": "Goal removed",
+      "failed": "Failed"
+    }
+  },
+  "guests": {
+    "page": {
+      "title": "Guests",
+      "subtitle": "Manage the list, send unique RSVP links and track confirmations."
+    },
+    "stats": {
+      "list": "List",
+      "guests": "guests",
+      "confirmed": "Confirmed",
+      "heads": "{count, plural, one {# head} other {# heads}}",
+      "pending": "Pending",
+      "declined": "Declined"
+    },
+    "filters": {
+      "searchPlaceholder": "Search...",
+      "all": "All",
+      "confirmed": "Confirmed",
+      "pending": "Pending",
+      "padrinhos": "Groomsmen & bridesmaids",
+      "children": "Children",
+      "checkedIn": "Already arrived"
+    },
+    "actions": {
+      "groups": "Groups",
+      "csv": "CSV",
+      "importList": "Import list",
+      "newGuest": "New guest"
+    },
+    "table": {
+      "name": "Name",
+      "group": "Group",
+      "rsvp": "RSVP",
+      "plusOne": "+1",
+      "table": "Table",
+      "attendance": "Attendance",
+      "actions": "Actions",
+      "empty": "Empty list.",
+      "noResults": "No results."
+    },
+    "tags": {
+      "padrinhoShort": "G",
+      "child": "Child",
+      "vip": "VIP"
+    },
+    "attendance": {
+      "arrived": "Arrived",
+      "mark": "Mark"
+    },
+    "rowActions": {
+      "copyRsvp": "Copy RSVP link"
+    },
+    "rsvp": {
+      "notInvited": "Not invited",
+      "invited": "Invited",
+      "confirmed": "Confirmed",
+      "declined": "Declined",
+      "maybe": "Maybe"
+    },
+    "delete": {
+      "confirmTitle": "Delete {name}?",
+      "confirmTitleGeneric": "Delete?"
+    },
+    "toast": {
+      "created": "Guest created",
+      "updated": "Guest updated",
+      "removed": "Guest removed",
+      "checkinReverted": "Check-in reverted",
+      "checkinDone": "Attendance recorded",
+      "linkCopied": "Link copied",
+      "copyFailed": "Failed to copy"
+    },
+    "csv": {
+      "name": "Name",
+      "phone": "Phone",
+      "email": "Email",
+      "side": "Side",
+      "group": "Group",
+      "status": "Status",
+      "plusOnesConfirmed": "+1 confirmed",
+      "table": "Table",
+      "dietary": "Dietary",
+      "city": "City",
+      "padrinho": "Groomsman",
+      "vip": "VIP",
+      "child": "Child",
+      "yes": "yes",
+      "fileName": "guests"
+    },
+    "form": {
+      "createTitle": "New guest",
+      "editTitle": "Edit {name}",
+      "name": "Name",
+      "phone": "Phone",
+      "email": "Email",
+      "side": "Side",
+      "groupName": "Group (e.g. his family)",
+      "city": "City",
+      "rsvpStatus": "RSVP status",
+      "plusOnesAllowed": "Companions allowed",
+      "tableNumber": "Table / section",
+      "dietary": "Dietary restrictions",
+      "isChild": "Child",
+      "isVIP": "VIP",
+      "isPadrinho": "Groomsman / bridesmaid",
+      "notes": "Notes"
+    },
+    "side": {
+      "groom": "Groom",
+      "bride": "Bride",
+      "both": "Both"
+    },
+    "groups": {
+      "backToGuests": "Back to guests",
+      "title": "Groups / Families",
+      "subtitle": "Create groups to generate a single RSVP link per family.",
+      "newGroup": "New group",
+      "empty": "No groups yet.",
+      "card": {
+        "contact": "Contact: {name}",
+        "people": "{count, plural, one {# person} other {# people}}",
+        "yes": "{count} yes",
+        "pending": "{count} pending",
+        "no": "{count} no",
+        "copyLink": "Copy link",
+        "members": "Members"
+      },
+      "form": {
+        "createTitle": "New group",
+        "editTitle": "Edit group",
+        "name": "Group name",
+        "contactName": "Contact (optional)",
+        "email": "Email",
+        "phone": "Phone",
+        "notes": "Notes",
+        "saving": "Saving..."
+      },
+      "members": {
+        "title": "Members of {name}",
+        "subtitle": "Select the guests who belong to this group.",
+        "searchPlaceholder": "Search guest...",
+        "noneAvailable": "No guests available.",
+        "selectedCount": "{count, plural, one {# selected} other {# selected}}"
+      },
+      "toast": {
+        "linkCopied": "Link copied",
+        "copyFailed": "Could not copy",
+        "created": "Group created",
+        "updated": "Group updated",
+        "deleted": "Group deleted",
+        "membersUpdated": "Members updated"
+      },
+      "delete": {
+        "title": "Delete group?",
+        "description": "The group \"{name}\" will be removed. The guests will not be deleted."
+      }
+    },
+    "import": {
+      "backToGuests": "Back to guests",
+      "title": "Import guest list",
+      "subtitle": "Upload the file exported from another system (currently: {sources}). You'll see a preview before confirming.",
+      "toast": {
+        "selectFile": "Select an .xlsx file",
+        "unexpectedResponse": "Unexpected server response",
+        "importFailed": "Import failed"
+      },
+      "upload": {
+        "fileLabel": "File (.xlsx or .csv)",
+        "fileHint": "Maximum size: 5 MB. Up to 2000 rows per import. Wedy exports as .xlsx; this system exports as .csv (CSV button at /dashboard/guests).",
+        "sourceLabel": "Source",
+        "autoDetect": "Detect automatically",
+        "preferPaste": "Prefer to paste raw text?",
+        "analyze": "Analyze file"
+      },
+      "preview": {
+        "rowsInFile": "Rows in file",
+        "new": "New",
+        "existingSameGroup": "Already exist (same group)",
+        "divergent": "Divergent",
+        "detectedSource": "Detected source",
+        "fileValid": "valid file, headers recognized.",
+        "detectedGroups": "Detected groups ({count})",
+        "noGroups": "No groups in the spreadsheet.",
+        "peopleCount": "{count, plural, one {# person} other {# people}}",
+        "pin": "PIN {pin}",
+        "detectedTags": "Detected tags ({count})",
+        "noTags": "No tags.",
+        "tagsNote": "New tags will be created. Tags named \"Padrinhos\", \"Madrinha\", etc. also set the guest's groomsman flag.",
+        "sampleTitle": "Sample (up to {count} rows)",
+        "filterAll": "All",
+        "filterNew": "New",
+        "filterExisting": "Already exist",
+        "filterDivergent": "Divergent",
+        "confirmImport": "Confirm import"
+      },
+      "mode": {
+        "heading": "How to handle duplicates",
+        "CREATE_NEW_ONLY": {
+          "label": "Skip rows that already exist in the same group",
+          "description": "Safest. Creates only new guests; nothing is changed."
+        },
+        "UPSERT_BY_NAME": {
+          "label": "Update data of those who already exist in the same group",
+          "description": "Overwrites phone, email, status and tags of guests that already exist. Creates the new ones."
+        },
+        "CREATE_ALL_DUPLICATES": {
+          "label": "Create everything, even if it already exists",
+          "description": "Use when there are namesakes in different families that should not be merged."
+        }
+      },
+      "done": {
+        "title": "Import complete",
+        "created": "<b>{count}</b> guest(s) created.",
+        "updated": "<b>{count}</b> guest(s) updated.",
+        "skipped": "<b>{count}</b> row(s) skipped.",
+        "groupsCreated": "<b>{count}</b> group(s) created.",
+        "tagsCreated": "<b>{count}</b> tag(s) created.",
+        "viewList": "View guest list",
+        "importAnother": "Import another"
+      },
+      "table": {
+        "noRowsForFilter": "No rows for this filter.",
+        "status": "Status",
+        "name": "Name",
+        "group": "Group",
+        "rsvp": "RSVP",
+        "phone": "Phone",
+        "email": "Email",
+        "tags": "Tags",
+        "child": "Child",
+        "pin": "PIN",
+        "statusNew": "New",
+        "statusDuplicateSame": "Already exists (same group)",
+        "statusDuplicateDiff": "Already exists, data differs",
+        "rawStatusHint": "Original status \"{raw}\" not recognized; treated as Invited.",
+        "childYes": "Yes",
+        "childYesAge": "Yes ({age})"
+      },
+      "paste": {
+        "title": "Paste raw text",
+        "instructions": "Paste lines in the format <code>Name,Phone,Email,Side,Group</code> (one line per guest). Phone, email, side and group are optional. Side accepts NOIVO/NOIVA/AMBOS. When the <strong>Group</strong> column is filled in, new groups are created automatically (and existing ones reused, matching by name) — guests from the same family share a single RSVP link.",
+        "contentLabel": "Content",
+        "placeholder": "Maria Silva,+5511999990000,maria@example.com,NOIVA,Family\nJoão Souza\nAna,,ana@example.com,,His work",
+        "separatorLabel": "Separator",
+        "sepAuto": "Detect automatically",
+        "sepComma": ", (comma)",
+        "sepSemicolon": "; (semicolon)",
+        "sepTab": "Tab",
+        "submit": "Import",
+        "toast": {
+          "importedTitle": "{count} imported",
+          "skippedLines": "{count, plural, one {# line skipped} other {# lines skipped}}",
+          "groupsSuffix": ", {count, plural, one {# group created} other {# groups created}}"
+        }
+      }
+    }
+  },
+  "home": {
+    "header": {
+      "title": "Overview",
+      "weddingOn": "Wedding on {date}",
+      "configurePrompt": "Set up your event to get started"
+    },
+    "onboarding": {
+      "title": "Shall we set up your wedding?",
+      "body": "In under 2 minutes you'll set the date, the couple's names, and how notifications work. Click here to start the wizard."
+    },
+    "quitAlert": {
+      "title": "Payoff Alert!",
+      "body": "{days, plural, one {# day left and there's still an outstanding balance of {balance}.} other {# days left and there's still an outstanding balance of {balance}.}}",
+      "pendingValues": "pending amounts"
+    },
+    "kpi": {
+      "totalBudget": {
+        "title": "Total Budget",
+        "hint": "Contingency: {value}"
+      },
+      "totalPaid": {
+        "title": "Total Paid",
+        "hint": "{pct}% of budget"
+      },
+      "remainingBalance": {
+        "title": "Outstanding Balance"
+      },
+      "cashCoverage": {
+        "title": "Cash Coverage",
+        "hintPct": "{pct}% of outstanding balance",
+        "hintPaid": "Balance settled"
+      },
+      "vendors": {
+        "title": "Vendors",
+        "hint": "{pct}% contracted"
+      },
+      "tasks": {
+        "title": "Tasks",
+        "hintOverdue": "{count, plural, one {# overdue} other {# overdue}}",
+        "hintUpToDate": "All caught up"
+      },
+      "guests": {
+        "title": "Guests",
+        "hint": "{total} total · {confirmed} confirmed"
+      },
+      "daysToEvent": {
+        "title": "Days until the event"
+      },
+      "budgetSummary": {
+        "title": "Budget Summary",
+        "hint": "Contracted: {contracted} · Paid: {paid}"
+      }
+    },
+    "risks": {
+      "title": "Warning signs"
+    },
+    "funnel": {
+      "title": "Vendor Funnel",
+      "empty": "No vendors registered.",
+      "negotiating": "Negotiating",
+      "contracted": "Contracted",
+      "finalized": "Finalized"
+    },
+    "budgetDistribution": {
+      "title": "Budget Distribution"
+    },
+    "upcomingPayments": {
+      "title": "Upcoming Payments",
+      "empty": "No payments in the next 30 days.",
+      "dueLabel": "Due: {date}"
+    },
+    "charts": {
+      "noData": "Not enough data for the chart"
+    },
+    "rsvp": {
+      "title": "RSVPs",
+      "empty": "No guests registered yet.",
+      "respondedConfirming": "{confirmed} of {total} have confirmed",
+      "confirmed": "{count, plural, one {# confirmed} other {# confirmed}}",
+      "maybe": "{count, plural, one {# maybe} other {# maybe}}",
+      "declined": "{count, plural, one {# declined} other {# declined}}",
+      "pending": "{count, plural, one {# pending} other {# pending}}",
+      "plusOnes": "{count, plural, one {+# plus-one confirmed} other {+# plus-ones confirmed}}",
+      "totalGuests": "{count, plural, one {# guest in total} other {# guests in total}}"
+    },
+    "gifts": {
+      "title": "Gifts received",
+      "empty": "No gifts recorded yet.",
+      "breakdown": "{cash} in cash · {items} in items",
+      "thankedLabel": "Thanked:",
+      "thankedCount": "{thanked} of {total}"
+    },
+    "upcomingTasks": {
+      "title": "Upcoming Tasks",
+      "empty": "No pending tasks.",
+      "noDeadline": "No due date",
+      "priority": {
+        "urgent": "URGENT",
+        "high": "HIGH",
+        "medium": "MEDIUM",
+        "low": "LOW"
+      }
+    },
+    "countdown": {
+      "past": "Event has passed",
+      "today": "Today's the day!",
+      "remaining": "{days, plural, one {# day left} other {# days left}}"
+    },
+    "install": {
+      "dismiss": "Dismiss",
+      "title": "Install as an app",
+      "iosBody": "Add Wedding Finance Planner directly to your iPhone's home screen for a full-screen experience just like a native app:",
+      "iosTap": "Tap",
+      "iosShare": "Share",
+      "iosAddToHome": "Add to Home Screen",
+      "androidBody": "Add the Wedding Finance Planner app to your home screen to keep track of your finances and tasks with quick access and notifications.",
+      "installButton": "Install App"
+    }
+  },
+  "honeymoon": {
+    "page": {
+      "title": "Honeymoon",
+      "subtitle": "Itinerary, bookings, documents and budget for the post-wedding trip."
+    },
+    "info": {
+      "destination": "Destination",
+      "notDecided": "Not decided yet",
+      "budget": "Budget",
+      "committed": "Committed",
+      "editTrip": "Edit trip details",
+      "departure": "Departure",
+      "return": "Return"
+    },
+    "currency": {
+      "brl": "Real (BRL)",
+      "usd": "Dollar (USD)",
+      "eur": "Euro (EUR)"
+    },
+    "list": {
+      "empty": "Nothing added yet. Start with flights and hotels."
+    },
+    "actions": {
+      "newItem": "New item"
+    },
+    "kind": {
+      "FLIGHT": "Flight",
+      "HOTEL": "Accommodation",
+      "TRANSFER": "Transfer",
+      "ACTIVITY": "Activity",
+      "DOCUMENT": "Document",
+      "BAGGAGE": "Baggage",
+      "OTHER": "Other"
+    },
+    "status": {
+      "PLANNED": "Planned",
+      "BOOKED": "Booked",
+      "CONFIRMED": "Confirmed",
+      "PAID": "Paid",
+      "CANCELLED": "Cancelled"
+    },
+    "form": {
+      "titleCreate": "New item",
+      "titleEdit": "Edit item",
+      "kind": "Type",
+      "title": "Title",
+      "vendor": "Airline / vendor",
+      "start": "Start",
+      "end": "End",
+      "amount": "Amount",
+      "confirmationNumber": "Confirmation number"
+    },
+    "delete": {
+      "confirmTitle": "Delete item?"
+    },
+    "toast": {
+      "updated": "Updated",
+      "itemAdded": "Item added",
+      "itemUpdated": "Item updated",
+      "itemRemoved": "Item removed",
+      "failed": "Failed"
+    }
+  },
+  "income": {
+    "page": {
+      "title": "Income & earnings",
+      "subtitle": "Recurring income, bonuses, cash gifts and pre-wedding sales."
+    },
+    "summary": {
+      "total": "Total estimated",
+      "expected": "To receive",
+      "received": "Received"
+    },
+    "actions": {
+      "new": "New income",
+      "received": "Received it"
+    },
+    "table": {
+      "title": "Title",
+      "source": "Source",
+      "amount": "Amount",
+      "expectedDate": "Expected date",
+      "status": "Status",
+      "actions": "Actions",
+      "empty": "No income recorded."
+    },
+    "row": {
+      "givenBy": "from {name}"
+    },
+    "frequency": {
+      "ONE_TIME": "One-time",
+      "MONTHLY": "Monthly"
+    },
+    "source": {
+      "SALARY": "Salary",
+      "BONUS": "Bonus / 13th salary",
+      "GIFT": "Cash gift",
+      "FREELANCE": "Freelance",
+      "SALE": "Sale",
+      "RESTITUTION": "Tax refund",
+      "OTHER": "Other"
+    },
+    "status": {
+      "EXPECTED": "Expected",
+      "RECEIVED": "Received",
+      "CANCELLED": "Cancelled"
+    },
+    "form": {
+      "titleCreate": "New income",
+      "titleEdit": "Edit income",
+      "title": "Title",
+      "source": "Source",
+      "amount": "Amount",
+      "expectedDate": "Expected date",
+      "frequency": "Frequency",
+      "status": "Status",
+      "givenByName": "Given by (gift)",
+      "notes": "Notes"
+    },
+    "confirmDelete": {
+      "title": "Delete income?"
+    },
+    "toast": {
+      "created": "Income recorded",
+      "updated": "Income updated",
+      "marked": "Marked as received",
+      "deleted": "Income removed",
+      "fail": "Failed"
+    }
+  },
+  "insights": {
+    "header": {
+      "title": "Financial insights",
+      "subtitle": "Projection, project health and per-category budget creep detector."
+    },
+    "noData": "No data yet.",
+    "health": {
+      "label": "Health Score",
+      "statusGood": "Healthy project.",
+      "statusWarn": "A few points need attention.",
+      "statusBad": "Needs urgent adjustments."
+    },
+    "cashflow": {
+      "title": "Projected cash flow",
+      "worstBalance": "Worst balance: {value}",
+      "description": "Cumulative balance up to the event, considering existing contributions + expected income − pending payments."
+    },
+    "monthlyFlow": {
+      "title": "Inflows and outflows by month",
+      "description": "Green bars = income. Red bars = payments. Red background zone = projected negative balance."
+    },
+    "sCurve": {
+      "title": "S-Curve — Planned vs Actual",
+      "hint": "Band = configured contingency"
+    },
+    "burndown": {
+      "title": "Task Burndown",
+      "hint": "Ideal vs actual up to the event date"
+    },
+    "waterfall": {
+      "title": "Variation by Category",
+      "hint": "Green = saved · Pink = over budget"
+    },
+    "whatIf": {
+      "title": "Can I sign this contract now?",
+      "description": "Simulate adding a future payment and see the impact on cash flow up to {date}.",
+      "amountLabel": "Amount ($)",
+      "dateLabel": "Expected date",
+      "fillPrompt": "Enter amount and date",
+      "balanceAt": "Balance in {month}",
+      "worstBalance": "Worst balance until the event",
+      "finalBalance": "Final balance at the event",
+      "canAfford": "You can afford it",
+      "exceedsCash": "Overdraws your cash"
+    },
+    "creep": {
+      "title": "Variation by category",
+      "description": "Compares estimated vs contracted in each category. Items with an increase > 10% need attention.",
+      "allWithinBudget": "No category is above the estimate.",
+      "estimated": "Estimated: {value}",
+      "contracted": "Contracted: {value}"
+    },
+    "heatmap": {
+      "title": "Pending payment concentration",
+      "description": "Until {date} ({days, plural, one {# day} other {# days}}). The more intense, the more concentrated the day.",
+      "cellTitle": "{date} · {value} ({count, plural, one {# payment} other {# payments}})"
+    },
+    "chartLegend": {
+      "ending": "Ending balance",
+      "income": "Income",
+      "outflow": "Payments"
+    }
+  },
+  "payments": {
+    "title": "Payments",
+    "view": {
+      "list": "List",
+      "calendar": "Calendar"
+    },
+    "actions": {
+      "new": "New Payment",
+      "generateInstallments": "Generate Installments",
+      "markPaid": "Mark Paid",
+      "revert": "Revert"
+    },
+    "filter": {
+      "allStatus": "All statuses"
+    },
+    "list": {
+      "searchPlaceholder": "Search by vendor...",
+      "empty": "No payments registered.",
+      "noResults": "No results for this filter."
+    },
+    "table": {
+      "dueDate": "Due Date",
+      "vendor": "Vendor",
+      "method": "Method",
+      "installment": "Installment"
+    },
+    "card": {
+      "dueOn": "Due on {date}"
+    },
+    "method": {
+      "PIX": "PIX",
+      "BOLETO": "Bank Slip",
+      "CREDIT": "Credit Card",
+      "TRANSFER": "Transfer",
+      "CASH": "Cash"
+    },
+    "amount": {
+      "adjustedTooltip": "Base {base} + late fee {lateFee} + interest {interest} ({days} day(s) overdue)"
+    },
+    "form": {
+      "createTitle": "New Payment",
+      "editTitle": "Edit payment",
+      "splitToggle": "Deposit + Balance",
+      "vendor": "Vendor",
+      "selectPlaceholder": "Select...",
+      "amount": "Amount (R$)",
+      "dueDate": "Due Date",
+      "method": "Method",
+      "status": "Status",
+      "installments": "Installments",
+      "installmentNumberPlaceholder": "e.g. 1",
+      "installmentNumberLabel": "Current installment number",
+      "installmentOf": "of",
+      "totalInstallmentsPlaceholder": "e.g. 12",
+      "totalInstallmentsLabel": "Total installments",
+      "installmentsHint": "Leave blank for a one-time payment.",
+      "notes": "Notes",
+      "optionalShort": "optional",
+      "lateFee": "Late fee (%)",
+      "lateFeePlaceholder": "e.g. 2",
+      "interest": "Interest %/month",
+      "interestPlaceholder": "e.g. 1"
+    },
+    "split": {
+      "depositTitle": "1. Deposit (paid today)",
+      "balanceTitle": "2. Final balance (pending)",
+      "balanceMethod": "Balance method"
+    },
+    "delete": {
+      "title": "Delete payment?",
+      "description": "Payment of {amount} to {vendor}.\nThis will soft-delete the record and remove it from the lists."
+    },
+    "installmentsModal": {
+      "title": "Generate installments",
+      "description": "Creates N pending payments at a fixed interval. Useful for installment contracts.",
+      "totalAmount": "Total amount (R$)",
+      "count": "No. of installments",
+      "eachInstallment": "Each installment:",
+      "firstDate": "First date",
+      "intervalDays": "Interval (days)",
+      "lateFee": "Late fee (%) optional",
+      "interest": "Interest %/month optional",
+      "generating": "Generating...",
+      "generateButton": "Generate {count, plural, one {# installment} other {# installments}}"
+    },
+    "toast": {
+      "created": "Payment created",
+      "splitCreated": "Deposit and balance recorded",
+      "createFailed": "Failed to create",
+      "updated": "Payment updated",
+      "updateFailed": "Failed to update",
+      "markedPaid": "Payment settled",
+      "reverted": "Payment reverted",
+      "genericFailed": "Failed",
+      "deleted": "Payment deleted",
+      "deleteFailed": "Failed to delete",
+      "installmentsGenerated": "Installments generated"
+    },
+    "calendar": {
+      "annualView": "Annual View",
+      "yearTitle": "Financial Calendar for {year}",
+      "monthTitle": "{month} {year}",
+      "prevYear": "Previous year",
+      "nextYear": "Next year",
+      "prevMonth": "Previous month",
+      "nextMonth": "Next month",
+      "noScheduled": "No scheduled expenses",
+      "paymentCount": "{count, plural, one {# payment} other {# payments}}",
+      "totalPlanned": "Total Planned:",
+      "paidWithCount": "Paid ({count}):",
+      "pendingWithCount": "Pending ({count}):",
+      "progress": "PROGRESS",
+      "percentPaid": "{percent}% paid",
+      "moreOthers": "+{count} more",
+      "allExpensesOf": "All Expenses for {month}",
+      "expensesOfDay": "Expenses for {month} {day}",
+      "viewAllMonth": "View all for the month",
+      "noExpenses": "No expenses recorded for this period.",
+      "month": {
+        "0": "January",
+        "1": "February",
+        "2": "March",
+        "3": "April",
+        "4": "May",
+        "5": "June",
+        "6": "July",
+        "7": "August",
+        "8": "September",
+        "9": "October",
+        "10": "November",
+        "11": "December"
+      }
+    }
+  },
+  "reports": {
+    "hub": {
+      "title": "Reports",
+      "subtitle": "Detailed analytical views by area. The BI charts inside /dashboard/insights also appear here as shortcuts.",
+      "inInsights": "In Insights",
+      "items": {
+        "scurve": {
+          "title": "S-Curve — Planned vs Actual",
+          "description": "Compares planned payments against actual ones over time, with a contingency band."
+        },
+        "vendorFunnel": {
+          "title": "Vendor Funnel",
+          "description": "Track how many are in negotiation, contracted, and finalized."
+        },
+        "risk": {
+          "title": "Risk Radar",
+          "description": "Red flags consolidated in a single panel."
+        },
+        "guests": {
+          "title": "Guests & RSVP",
+          "description": "Response rate, plus-ones, VIPs, and distribution by group and city."
+        },
+        "gifts": {
+          "title": "Gifts",
+          "description": "CASH × ITEM, pending thank-yous, top givers, and the honeymoon fund."
+        },
+        "burndown": {
+          "title": "Task Burndown",
+          "description": "Compare the ideal vs actual pace of tasks completed up to the event date."
+        },
+        "honeymoon": {
+          "title": "Honeymoon",
+          "description": "Status by stage and funding from gifts via PIX."
+        },
+        "trousseau": {
+          "title": "Trousseau",
+          "description": "Progress by room and essentials still pending."
+        },
+        "waterfall": {
+          "title": "Variance by Category",
+          "description": "Waterfall showing where the budget overran and by how much."
+        },
+        "activity": {
+          "title": "Activity Timeline",
+          "description": "Latest relevant changes recorded in the audit log."
+        }
+      }
+    },
+    "activity": {
+      "back": "Back to reports",
+      "title": "Activity Timeline",
+      "subtitle": "Last 100 changes recorded in the system. Filter by entity below.",
+      "filterAll": "All",
+      "empty": "No audit records yet.",
+      "systemActor": "System",
+      "action": {
+        "CREATE": "created",
+        "UPDATE": "updated",
+        "DELETE": "removed",
+        "RESTORE": "restored",
+        "MARK_PAID": "marked as paid",
+        "UNDO_PAID": "undid payment",
+        "STATUS_CHANGE": "changed status",
+        "UPLOAD": "uploaded",
+        "DOWNLOAD": "downloaded",
+        "REPLACE": "replaced",
+        "SIGN": "signed",
+        "ARCHIVE": "archived",
+        "RESET_PASSWORD": "reset password",
+        "RESET_2FA": "removed 2FA",
+        "CHANGE_OWN_PASSWORD": "changed their own password",
+        "LOGIN": "logged in",
+        "BULK_CREATE": "bulk-created",
+        "ASSIGN_TABLE": "assigned a table",
+        "UNASSIGN_TABLE": "unassigned a table",
+        "RSVP_GROUP_RESPOND": "responded to a group RSVP",
+        "MARK_PIX_RECEIVED": "marked PIX received",
+        "ONBOARDING_COUPLE": "completed the couple step",
+        "ONBOARDING_BUDGET": "completed the budget step",
+        "ONBOARDING_FINISH": "finished onboarding"
+      },
+      "entity": {
+        "Vendor": "vendor",
+        "Payment": "payment",
+        "BudgetItem": "budget item",
+        "Asset": "asset",
+        "EventSettings": "event settings",
+        "User": "user",
+        "SecuritySettings": "security settings",
+        "SeatingTable": "table",
+        "Guest": "guest",
+        "GuestGroup": "guest group",
+        "Gift": "gift",
+        "Contract": "contract",
+        "Attachment": "attachment"
+      }
+    },
+    "gifts": {
+      "back": "Back to reports",
+      "title": "Gifts",
+      "subtitle": "Analysis of gifts received: cash vs items, pending thank-yous, the honeymoon fund, and top givers.",
+      "type": {
+        "cash": "Cash",
+        "item": "Items"
+      },
+      "tiles": {
+        "count": "Gifts",
+        "totalCash": "Total cash",
+        "cashCount": "In cash",
+        "thanked": "Thanked",
+        "thankedSub": "{count} of {total}",
+        "honeymoon": "Honeymoon (PIX)",
+        "contributions": "{count, plural, one {# contribution} other {# contributions}}",
+        "contributionsShort": "contributions"
+      },
+      "distribution": {
+        "title": "Distribution (CASH × ITEM)",
+        "giftCount": "{count, plural, one {# gift} other {# gifts}}"
+      },
+      "cumulative": {
+        "title": "Cumulative intake",
+        "empty": "No receipt data.",
+        "legendAmount": "Cumulative ($)",
+        "legendCount": "Quantity"
+      },
+      "topGivers": {
+        "title": "Top givers",
+        "empty": "No gifts recorded.",
+        "giftCount": "{count, plural, one {# gift} other {# gifts}}"
+      }
+    },
+    "guests": {
+      "back": "Back to reports",
+      "title": "Guests & RSVP",
+      "subtitle": "Response rate, plus-ones, VIPs, groomsmen, and distribution by group/city.",
+      "status": {
+        "confirmed": "Confirmed",
+        "maybe": "Maybe",
+        "pending": "Pending",
+        "declined": "Declined"
+      },
+      "tiles": {
+        "invited": "Guests",
+        "confirmed": "Confirmed",
+        "plusOnes": "+ Plus-ones",
+        "children": "Children"
+      },
+      "rsvp": {
+        "title": "RSVP status",
+        "peopleCount": "{count, plural, one {# person} other {# people}}",
+        "effectiveLabel": "Effective total (with +1s):"
+      },
+      "byGroup": {
+        "title": "By group",
+        "empty": "No guest groups registered."
+      },
+      "vips": {
+        "title": "VIPs & Groomsmen",
+        "vipsConfirmed": "VIPs confirmed",
+        "padrinhosConfirmed": "Groomsmen confirmed"
+      },
+      "cities": {
+        "title": "Top cities",
+        "empty": "No city provided."
+      }
+    },
+    "honeymoon": {
+      "back": "Back to reports",
+      "title": "Honeymoon",
+      "subtitle": "Status by stage (PLANNED → PAID), by item type, and coverage from the gift fund via PIX.",
+      "noPermission": {
+        "title": "No permission",
+        "body": "This report exposes financial figures. Request access from an administrator."
+      },
+      "status": {
+        "paid": "Paid",
+        "confirmed": "Confirmed",
+        "booked": "Booked",
+        "planned": "Planned",
+        "cancelled": "Cancelled"
+      },
+      "kind": {
+        "FLIGHT": "Flights",
+        "HOTEL": "Lodging",
+        "TRANSFER": "Transfer",
+        "ACTIVITY": "Activities",
+        "DOCUMENT": "Documents",
+        "BAGGAGE": "Baggage",
+        "OTHER": "Other"
+      },
+      "tiles": {
+        "items": "Items",
+        "booked": "Booked",
+        "paid": "Paid",
+        "fundedFromGifts": "Received via PIX (fund)"
+      },
+      "coverage": {
+        "title": "Coverage from fund",
+        "sublabel": "contributions via PIX",
+        "empty": "Set a total honeymoon budget to see coverage."
+      },
+      "byKind": {
+        "title": "By item type",
+        "empty": "No items added to the honeymoon yet."
+      },
+      "foreignCurrency": {
+        "title": "Amounts in foreign currencies",
+        "body": "The totals above show values in BRL. Items in other currencies:"
+      }
+    },
+    "risk": {
+      "back": "Back to reports",
+      "title": "Risk Radar",
+      "subtitle": "Consolidated signals that deserve attention: liquidity, contracts on time, overdue tasks, and vendors that exceeded the estimated budget.",
+      "empty": "No red flags right now. Good work.",
+      "tiles": {
+        "critical": "Critical",
+        "warning": "Warning",
+        "ok": "Ok"
+      }
+    },
+    "trousseau": {
+      "back": "Back to reports",
+      "title": "Trousseau",
+      "subtitle": "Progress by room and essential items still pending.",
+      "status": {
+        "gifted": "Received",
+        "bought": "Bought",
+        "toBuy": "To buy"
+      },
+      "room": {
+        "KITCHEN": "Kitchen",
+        "BATHROOM": "Bathroom",
+        "BEDROOM": "Bedroom",
+        "LIVING": "Living room",
+        "LAUNDRY": "Laundry",
+        "ELECTRONICS": "Electronics",
+        "OTHER": "Other"
+      },
+      "tiles": {
+        "items": "Items",
+        "completion": "Completion",
+        "estimated": "Estimated",
+        "byRoom": "By room",
+        "actual": "Actual",
+        "essentialsPending": "Essentials pending"
+      },
+      "essentials": {
+        "warning": "{count, plural, one {# ESSENTIAL item still in \"to buy\"} other {# ESSENTIAL items still in \"to buy\"}}",
+        "hint": "Prioritize these before NICE_TO_HAVE or LUXURY items."
+      },
+      "overall": {
+        "title": "Overall progress",
+        "label": "Completed",
+        "sublabel": "{pct}% of {total} items"
+      },
+      "byRoom": {
+        "title": "By room",
+        "empty": "No items added to the trousseau yet."
+      }
+    },
+    "vendorFunnel": {
+      "back": "Back to reports",
+      "title": "Vendor Funnel",
+      "subtitle": "Distribution by stage and average time between negotiation, contract, and finalization.",
+      "series": {
+        "negotiating": "Negotiating",
+        "contracted": "Contracted",
+        "finalized": "Finalized"
+      },
+      "tiles": {
+        "negotiation": "In negotiation",
+        "contracted": "Contracted",
+        "finalized": "Finalized"
+      },
+      "byCategory": {
+        "title": "By category",
+        "vendorCount": "{count, plural, one {# vendor} other {# vendors}}"
+      },
+      "avg": {
+        "negToContract": "Average time from negotiation → contract",
+        "contractToFinalized": "Average time from contract → finalization",
+        "daysUnit": "days"
+      }
+    }
+  },
+  "settings": {
+    "page": {
+      "title": "Settings",
+      "subtitle": "Wedding, team, and security settings."
+    },
+    "tabs": {
+      "event": "Wedding",
+      "security": "Security",
+      "team": "Team",
+      "notifications": "Notifications",
+      "whatsapp": "WhatsApp",
+      "profile": "Profile",
+      "backup": "Backup"
+    },
+    "toast": {
+      "failed": "Failed"
+    },
+    "notifications": {
+      "title": "Recent deliveries",
+      "subtitle": "Latest email/WhatsApp deliveries. Use this list to diagnose SMTP failures or invalid recipients (e.g., the default seed admin@admin.com).",
+      "empty": "No deliveries recorded yet.",
+      "col": {
+        "when": "When",
+        "type": "Type",
+        "channel": "Channel",
+        "recipient": "Recipient",
+        "status": "Status",
+        "error": "Error"
+      }
+    },
+    "event": {
+      "title": "Wedding details",
+      "coupleNames": "Couple names",
+      "eventDate": "Event date",
+      "currency": "Currency",
+      "currencyBRL": "Real (BRL)",
+      "currencyUSD": "Dollar (USD)",
+      "currencyEUR": "Euro (EUR)",
+      "contingency": "Contingency (%)",
+      "save": "Save",
+      "toast": {
+        "saved": "Settings saved",
+        "saveFailed": "Failed to save",
+        "pixSaved": "Pix updated"
+      }
+    },
+    "pix": {
+      "title": "Pix (honeymoon fund)",
+      "subtitle": "Set up the couple's Pix key to generate a static QR Code for cash gifts.",
+      "key": "Pix key",
+      "keyType": "Key type",
+      "typeCPF": "CPF",
+      "typeCNPJ": "CNPJ",
+      "typeEmail": "Email",
+      "typePhone": "Phone",
+      "typeRandom": "Random",
+      "holderName": "Recipient name (max. 25)",
+      "city": "Recipient city (max. 15)",
+      "save": "Save Pix"
+    },
+    "security": {
+      "loginRequired": "Sign in to manage security.",
+      "requiredWarningStrong": "2FA is required for your role ({role})",
+      "requiredWarningRest": ". Set it up now to keep guaranteed access.",
+      "title": "Two-factor authentication (2FA)",
+      "descEnabled": "Enabled — login asks for a code from your authenticator app.",
+      "descDisabled": "Add an extra layer using Google Authenticator, 1Password, or similar.",
+      "badgeActive": "Active",
+      "badgeInactive": "Inactive",
+      "enable": "Enable 2FA",
+      "step1": "1. Scan the QR Code with your authenticator app (Google Authenticator, 1Password, Authy).",
+      "manualHint": "If you can't scan, enter it manually:",
+      "step2": "2. Confirm with the current code shown in the app.",
+      "codeLabel": "6-digit code",
+      "confirmEnable": "Confirm and enable",
+      "cancel": "Cancel",
+      "backupTitle": "🔑 Save these backup codes",
+      "backupHint": "Use them instead of the TOTP code if you lose access to the app. Each one works only once.",
+      "backupDismiss": "I've saved them, hide",
+      "disableLabel": "To disable, enter a TOTP or backup code",
+      "disable": "Disable 2FA",
+      "toast": {
+        "enabled": "2FA enabled",
+        "disabled": "2FA disabled"
+      }
+    },
+    "team": {
+      "title": "Members",
+      "subtitleManage": "Create users directly. The system sends credentials by email and/or WhatsApp.",
+      "subtitleReadonly": "Only administrators and the couple can manage members.",
+      "newUser": "New user",
+      "searchPlaceholder": "Search by name or email",
+      "allRoles": "All roles",
+      "showArchived": "Show archived",
+      "noMembers": "No members found with the current filters.",
+      "row": {
+        "you": "(you)",
+        "joined": "joined {date}",
+        "lastLogin": "last login {date}",
+        "archived": "Archived",
+        "active": "Active",
+        "inactive": "Inactive",
+        "twoFactor": "2FA",
+        "tempPassword": "Temporary password",
+        "actions": "Actions"
+      },
+      "menu": {
+        "edit": "Edit",
+        "resetPassword": "Reset password",
+        "reset2fa": "Reset 2FA",
+        "deactivate": "Deactivate",
+        "activate": "Reactivate",
+        "restore": "Restore",
+        "archive": "Archive"
+      },
+      "confirm": {
+        "reset2faTitle": "Reset 2FA for {name}?",
+        "reset2faDesc": "The current codes will stop working. The user will need to set it up again.",
+        "reset2faLabel": "Reset",
+        "activateTitle": "Reactivate {name}?",
+        "deactivateTitle": "Deactivate {name}?",
+        "activateDesc": "The user will be able to sign in again.",
+        "deactivateDesc": "The user won't be able to sign in until reactivated.",
+        "activateLabel": "Reactivate",
+        "deactivateLabel": "Deactivate",
+        "archiveTitle": "Archive {name}?",
+        "archiveDesc": "The user is deactivated and removed from the list (can be restored later).",
+        "archiveLabel": "Archive",
+        "restoreTitle": "Restore {name}?",
+        "restoreDesc": "The user returns to the active list.",
+        "restoreLabel": "Restore"
+      },
+      "toast": {
+        "reset2fa": "2FA reset",
+        "activated": "User reactivated",
+        "deactivated": "User deactivated",
+        "archived": "User archived",
+        "restored": "User restored",
+        "created": "User created",
+        "updated": "User updated",
+        "passwordReset": "Password reset — share the new one with the user"
+      },
+      "password": {
+        "show": "Show",
+        "hide": "Hide",
+        "generate": "Generate"
+      },
+      "create": {
+        "title": "New user",
+        "name": "Name",
+        "email": "Email",
+        "phone": "Phone (WhatsApp, optional)",
+        "phoneHint": "E.164 format (with + and country code). Used to send credentials and reminders.",
+        "tempPassword": "Temporary password (minimum {min} characters)",
+        "mustChangeHint": "The user will be required to change the password at first login.",
+        "role": "Role",
+        "cancel": "Cancel",
+        "submit": "Create user"
+      },
+      "edit": {
+        "title": "Edit {name}",
+        "name": "Name",
+        "email": "Email",
+        "phone": "Phone (WhatsApp, optional)",
+        "role": "Role",
+        "selfRoleHint": "You can't change your own role.",
+        "cancel": "Cancel",
+        "submit": "Save"
+      },
+      "reset": {
+        "title": "Reset password for {name}",
+        "hint": "The user will be required to change the password at next login.",
+        "newPassword": "New temporary password",
+        "cancel": "Cancel",
+        "submit": "Reset"
+      }
+    },
+    "policy": {
+      "title": "Security policy",
+      "subtitle": "Define who needs mandatory 2FA and the minimum password length.",
+      "require2faLabel": "Mandatory 2FA for roles:",
+      "minPasswordLength": "Minimum password length",
+      "save": "Save policy",
+      "toast": {
+        "saved": "Security policy saved"
+      }
+    },
+    "profile": {
+      "loginRequired": "Sign in to manage your profile.",
+      "title": "My profile",
+      "emailLabel": "Email:",
+      "roleLabel": "Role:",
+      "lastLogin": "Last login: {date}",
+      "passwordUpdatedAt": "Password updated on {date}",
+      "passwordNeverChanged": "Password never changed",
+      "displayName": "Display name",
+      "saveName": "Save name",
+      "changePasswordTitle": "Change my password",
+      "changePasswordHint": "Enter your current and new password. The new one must be different from the current one.",
+      "currentPassword": "Current password",
+      "newPassword": "New password",
+      "updatePassword": "Update password",
+      "twoFactorTitle": "Two-factor authentication",
+      "twoFactorEnabled": "Enabled. You can disable it in the Security tab.",
+      "twoFactorDisabled": "Inactive. Enable it in the Security tab to strengthen your account.",
+      "twoFactorSeeTab": "See the “Security” tab to set it up.",
+      "toast": {
+        "nameUpdated": "Name updated",
+        "passwordUpdated": "Password updated"
+      }
+    },
+    "backup": {
+      "exportTitle": "Export backup",
+      "exportSubtitle": "Downloads a JSON with vendors, payments, contributions, settings, guests, and everything else. Includes an SHA-256 checksum for validation.",
+      "exportButton": "Export JSON backup",
+      "exportHint": "Make a monthly backup and before/after the wedding. Keep it in a safe place — the file contains sensitive data.",
+      "restoreTitle": "Restore backup",
+      "restoreSubtitleAdmin": "Upload a JSON exported by this system. The restore wipes and recreates all data in a transaction. Admins only.",
+      "restoreSubtitleReadonly": "Only administrators can restore backups. You can validate the file here, but the restore requires the ADMIN role.",
+      "fileLabel": ".json file",
+      "validateButton": "Validate file",
+      "clear": "Clear",
+      "warnStrong": "The restore wipes ALL current data",
+      "warnRest": " and replaces it with the file's data. This operation cannot be undone. Make a backup first.",
+      "passwordLabel": "Your password (confirmation)",
+      "acknowledgeStart": "I understand that this action",
+      "acknowledgeStrong": "wipes all data",
+      "acknowledgeEnd": " from the system and replaces it with the file's data. I've already made a backup.",
+      "restoreNow": "Restore now",
+      "restoreDone": "Restore complete.",
+      "totalRestored": "Total restored:",
+      "zeroRecords": "0 records",
+      "accountPreserved": "Your account was preserved because it wasn't in the backup.",
+      "confirm": {
+        "title": "Confirm restore",
+        "description": "This action is IRREVERSIBLE. All current data will be replaced with the file's data. Continue?",
+        "restoring": "Restoring…",
+        "confirmLabel": "Yes, restore",
+        "cancel": "Cancel"
+      },
+      "toast": {
+        "selectFirst": "Select a backup file first.",
+        "invalidFile": "Invalid backup file.",
+        "validated": "Backup file validated.",
+        "validateFailed": "Failed to validate file",
+        "restoreFailed": "Failed to restore backup.",
+        "restored": "Backup restored successfully. Reloading…",
+        "restoreError": "Failed to restore"
+      },
+      "validation": {
+        "invalid": "Invalid file",
+        "root": "(root)",
+        "moreIssues": "...and {count} more issues.",
+        "summary": "✓ Backup v{version} valid — {rows} records, exported on {date}.",
+        "host": "host: {host}",
+        "app": "app: v{version}",
+        "checksum": "checksum:"
+      }
+    },
+    "modal": {
+      "close": "Close"
+    },
+    "whatsapp": {
+      "title": "WhatsApp",
+      "subtitle": "Connect a number to send credentials, reminders, and password resets via WhatsApp.",
+      "needsManualAction": "Action needed: the session expired or was unlinked. Click \"Connect\" to generate a new QR Code.",
+      "reconnecting": "Reconnecting automatically · attempts: {attempts}",
+      "lastDisconnect": "dropped at {date}",
+      "qrInstructions": "Open WhatsApp on your phone → Settings → Linked devices → Link a device. Scan:",
+      "qrAlt": "WhatsApp QR Code",
+      "disconnect": "Disconnect",
+      "reopenQr": "Reopen QR",
+      "connect": "Connect",
+      "refresh": "Refresh",
+      "testTitle": "Send test message",
+      "sendTest": "Send test",
+      "status": {
+        "connected": "Connected",
+        "connectedWithPhone": "Connected ({phone})",
+        "waitingQr": "Waiting for QR Code scan",
+        "connecting": "Connecting...",
+        "disconnected": "Disconnected"
+      },
+      "toast": {
+        "connecting": "Starting connection. Scan the QR Code.",
+        "disconnected": "WhatsApp disconnected",
+        "numberRequired": "Enter a number",
+        "testSent": "Test message sent"
+      }
+    }
+  },
+  "tasks": {
+    "page": {
+      "title": "Tasks",
+      "subtitle": "Use the ready-made 12-month template or create standalone tasks. Exports to your calendar."
+    },
+    "toast": {
+      "created": "Task created",
+      "updated": "Task updated",
+      "removed": "Task removed",
+      "failed": "Failed",
+      "templatesAllExist": "All template tasks already exist",
+      "templatesCreated": "{count, plural, one {# task created} other {# tasks created}}"
+    },
+    "filter": {
+      "all": "All",
+      "open": "Open",
+      "overdue": "Overdue",
+      "week": "Next 7 days"
+    },
+    "view": {
+      "list": "List",
+      "kanban": "Kanban"
+    },
+    "toolbar": {
+      "exportIcs": "Export (.ics)",
+      "loadTemplate": "Load template",
+      "newTask": "New task"
+    },
+    "delete": {
+      "title": "Delete task?",
+      "titleNamed": "Delete \"{title}\"?"
+    },
+    "list": {
+      "empty": "No tasks in this filter."
+    },
+    "kanban": {
+      "empty": "Empty"
+    },
+    "row": {
+      "complete": "Complete",
+      "reopen": "Reopen",
+      "template": "template"
+    },
+    "status": {
+      "TODO": "To do",
+      "IN_PROGRESS": "In progress",
+      "DONE": "Done",
+      "BLOCKED": "Blocked"
+    },
+    "priority": {
+      "LOW": "Low",
+      "MEDIUM": "Medium",
+      "HIGH": "High",
+      "URGENT": "Urgent"
+    },
+    "form": {
+      "createTitle": "New task",
+      "editTitle": "Edit task",
+      "title": "Title",
+      "deadline": "Deadline",
+      "responsible": "Responsible",
+      "responsiblePlaceholder": "groom / bride / planner",
+      "priority": "Priority",
+      "vendor": "Vendor",
+      "venue": "Venue"
+    }
+  },
+  "trousseau": {
+    "page": {
+      "title": "Trousseau",
+      "subtitle": "List what you still need to buy, set priorities and track the budget by room."
+    },
+    "stats": {
+      "estimated": "Estimated",
+      "bought": "Bought",
+      "toBuy": "To buy",
+      "gifted": "Gifted"
+    },
+    "filter": {
+      "all": "All"
+    },
+    "status": {
+      "TO_BUY": "To buy",
+      "BOUGHT": "Bought",
+      "GIFTED": "Gifted"
+    },
+    "room": {
+      "KITCHEN": "Kitchen",
+      "BATHROOM": "Bathroom",
+      "BEDROOM": "Bedroom",
+      "LIVING": "Living room",
+      "LAUNDRY": "Laundry",
+      "ELECTRONICS": "Appliances",
+      "OTHER": "Other"
+    },
+    "priority": {
+      "ESSENTIAL": "Essential",
+      "NICE_TO_HAVE": "Nice to have",
+      "LUXURY": "Luxury"
+    },
+    "list": {
+      "add": "New item",
+      "empty": "Nothing here yet."
+    },
+    "card": {
+      "paid": "(paid: {value})",
+      "storeLink": "Store link",
+      "toggleBought": "Toggle bought",
+      "toggleGifted": "Gifted"
+    },
+    "confirmDelete": {
+      "title": "Delete item?"
+    },
+    "form": {
+      "createTitle": "New trousseau item",
+      "editTitle": "Edit item",
+      "item": "Item",
+      "room": "Room",
+      "priority": "Priority",
+      "estimatedPrice": "Estimated price",
+      "actualPrice": "Price paid",
+      "store": "Store",
+      "link": "Link",
+      "notes": "Notes"
+    },
+    "toast": {
+      "created": "Item added",
+      "updated": "Item updated",
+      "deleted": "Item removed"
+    }
+  },
+  "vendors": {
+    "page": {
+      "title": "Vendors"
+    },
+    "list": {
+      "new": "New Vendor",
+      "empty": "No vendors registered yet.",
+      "noResults": "No results for this filter.",
+      "searchPlaceholder": "Search vendor..."
+    },
+    "filter": {
+      "allStatus": "All statuses"
+    },
+    "status": {
+      "negotiation": "Negotiating",
+      "contracted": "Contracted",
+      "finalized": "Finalized"
+    },
+    "value": {
+      "real": "Actual",
+      "estimated": "Estimated"
+    },
+    "table": {
+      "category": "Category",
+      "select": "Select",
+      "selectVendor": "Select {name}"
+    },
+    "compareButton": {
+      "label": "Compare ({count})",
+      "selectMore": "Select 1 more to compare"
+    },
+    "statusPrompt": {
+      "message": "What is the ACTUAL amount contracted with {name}? (numbers only, e.g. 12500.00)",
+      "invalidValue": "Invalid amount"
+    },
+    "form": {
+      "createTitle": "New Vendor",
+      "editTitle": "Edit {name}",
+      "name": "Name",
+      "namePlaceholder": "e.g. Colonial Catering",
+      "category": "Category",
+      "categoryChoose": "— choose —",
+      "freeLabel": "Free label",
+      "freeLabelPlaceholder": "e.g. Catering",
+      "estimatedValue": "Estimated amount ($)",
+      "estimatedValuePlaceholder": "e.g. 15000.00",
+      "actualValue": "Actual amount ($)",
+      "actualValuePlaceholder": "Empty = not closed yet",
+      "contractLink": "Contract link (optional)",
+      "notes": "Notes",
+      "notesPlaceholder": "Notes, contacts, terms...",
+      "saveChanges": "Save changes"
+    },
+    "delete": {
+      "title": "Delete vendor?",
+      "titleNamed": "Delete {name}?",
+      "description": "This will soft-delete the vendor along with its budgets and associated payments.\nYou will no longer see these records in the listings."
+    },
+    "toast": {
+      "created": "Vendor created",
+      "createFailed": "Failed to create",
+      "updated": "Vendor updated",
+      "updateFailed": "Failed to update",
+      "deleted": "Vendor deleted",
+      "deleteFailed": "Failed to delete",
+      "statusUpdated": "Status updated",
+      "failed": "Failed"
+    },
+    "compare": {
+      "back": "Back to vendors",
+      "title": "Compare proposals",
+      "hint": "Select 2 to 4 vendors from the list and click \"Compare\".",
+      "comparing": "{count, plural, one {Comparing # vendor.} other {Comparing # vendors.}}",
+      "criterion": "Criterion",
+      "open": "Open →",
+      "legend": "💡 Green on the price marks the cheapest; ⭐ on the rating marks the best rated.",
+      "status": {
+        "negotiation": "Negotiating",
+        "contracted": "Contracted",
+        "finalized": "Finalized"
+      },
+      "row": {
+        "status": "Status",
+        "rating": "Rating",
+        "totalValue": "Total amount",
+        "paid": "Paid",
+        "balance": "Balance",
+        "indicatedBy": "Referred by",
+        "tags": "Tags",
+        "counts": "Contacts / Contracts / Attachments",
+        "notes": "Notes",
+        "lastInteraction": "Last interaction",
+        "contractLink": "Contract link"
+      },
+      "empty": {
+        "title": "No vendor selected.",
+        "description": "Go back to the list, check the boxes for the vendors you want to compare and click \"Compare\".",
+        "cta": "Go to vendors →"
+      }
+    },
+    "detail": {
+      "back": "Back to vendors",
+      "status": {
+        "negotiation": "Negotiating",
+        "contracted": "Contracted",
+        "finalized": "Finalized"
+      },
+      "header": {
+        "indicatedBy": "Referred by: {name}",
+        "contractLink": "Contract link",
+        "budgeted": "Budgeted",
+        "paid": "Paid",
+        "balance": "Balance"
+      },
+      "toast": {
+        "failed": "Failed"
+      },
+      "contacts": {
+        "title": "Contacts",
+        "empty": "No contacts registered.",
+        "primary": "Primary",
+        "deleteAria": "Delete contact",
+        "formTitle": "New contact",
+        "name": "Name",
+        "role": "Role (e.g. manager, front desk)",
+        "isPrimary": "Primary contact",
+        "removeTitle": "Remove contact?",
+        "added": "Contact added",
+        "removed": "Contact removed"
+      },
+      "notes": {
+        "title": "Notes and negotiation",
+        "bodyPlaceholder": "Write down what happened, decided, agreed...",
+        "add": "Add",
+        "empty": "No notes yet. Use this space as a negotiation log.",
+        "deleteAria": "Delete note",
+        "removeTitle": "Remove note?",
+        "added": "Note added",
+        "removed": "Note removed"
+      },
+      "noteKind": {
+        "NOTE": "Note",
+        "NEGOTIATION_EVENT": "Negotiation",
+        "MEETING": "Meeting",
+        "DECISION": "Decision"
+      },
+      "contracts": {
+        "title": "Contracts",
+        "empty": "No contracts recorded. Use this to store key clauses and versions.",
+        "value": "Amount",
+        "signed": "Signed",
+        "expires": "Expires",
+        "paymentTerms": "Payment terms",
+        "cancellationPolicy": "Cancellation policy",
+        "included": "Included",
+        "excluded": "Not included",
+        "notes": "Notes",
+        "deleteAria": "Delete contract",
+        "removeTitle": "Delete contract?",
+        "removeDescription": "The contract will be removed from the listing but can be recovered from the database.",
+        "created": "Contract created",
+        "removed": "Contract removed"
+      },
+      "contractStatus": {
+        "DRAFT": "Draft",
+        "SENT": "Sent",
+        "NEGOTIATING": "Negotiating",
+        "SIGNED_DIGITAL": "Signed (digital)",
+        "SIGNED_PHYSICAL": "Signed (physical)",
+        "CANCELLED": "Cancelled"
+      },
+      "contractForm": {
+        "title": "New contract",
+        "titleLabel": "Title",
+        "titlePlaceholder": "e.g. Colonial Catering Contract",
+        "totalValue": "Total amount ($)",
+        "signedAt": "Signature date",
+        "expiresAt": "Validity / expiration",
+        "includedItems": "What is included",
+        "excludedItems": "What is NOT included",
+        "save": "Save contract"
+      },
+      "contractFile": {
+        "noViewPermission": "Contract document available, but your profile doesn't have permission to view it.",
+        "title": "Contract file",
+        "inlineFallback": "The browser couldn't display the PDF inline.",
+        "openNewTab": "Open the contract in a new tab",
+        "uploadedAt": "uploaded on {date}",
+        "uploadedBy": "by {name}",
+        "downloadPdf": "Download PDF",
+        "noPdfYet": "No PDF attached to this contract yet.",
+        "replaceLabel": "Replace contract (becomes v{version})",
+        "uploadLabel": "Upload contract PDF",
+        "onlyPdf": "PDF only, up to 8 MB.",
+        "send": "Upload",
+        "markSigned": "Mark as signed:",
+        "signDigital": "Digital signature",
+        "signPhysical": "Physical signature",
+        "historyShow": "Show history ({count, plural, one {# version} other {# versions}})",
+        "historyHide": "Hide history ({count, plural, one {# version} other {# versions}})",
+        "download": "Download",
+        "newVersionTitle": "Create new version v{version}?",
+        "newVersionDescription": "The current version will be archived (kept in history for 30 days). Are you sure?",
+        "confirmReplace": "Yes, replace",
+        "updated": "Contract updated",
+        "newVersionToast": "New version v{version}",
+        "pdfSent": "Contract PDF uploaded",
+        "keptVersionToast": "Kept as v{version}",
+        "signed": "Contract signed"
+      },
+      "attachments": {
+        "title": "Attachments",
+        "fileLabel": "File (PDF/PNG/JPG, up to 10MB)",
+        "kindLabel": "Type",
+        "send": "Upload",
+        "empty": "No files attached.",
+        "deleteAria": "Delete attachment",
+        "removeTitle": "Delete attachment?",
+        "uploaded": "File attached",
+        "removed": "Attachment removed"
+      },
+      "attachmentKind": {
+        "CONTRACT": "Contract",
+        "PROPOSAL": "Proposal",
+        "RECEIPT": "Receipt",
+        "INVOICE": "Invoice / Bill",
+        "ID_DOC": "Document",
+        "PHOTO": "Photo",
+        "OTHER": "Other"
+      },
+      "payments": {
+        "title": "Payments",
+        "empty": "No payments. Use the Payments tab to add some.",
+        "paid": "Paid",
+        "pending": "Pending",
+        "manage": "Manage payments →"
+      }
+    }
+  },
+  "venues": {
+    "page": {
+      "title": "Venues",
+      "subtitle": "Compare candidates, jot down pros and cons, and keep your visit checklist up to date."
+    },
+    "list": {
+      "new": "New venue",
+      "empty": "No venues added yet. Add candidates to compare them side by side.",
+      "favorite": "Favorite",
+      "deleteAria": "Delete venue",
+      "checklistCount": "Checklist {done}/{total}",
+      "attachments": "{count, plural, one {# attachment} other {# attachments}}",
+      "visitedOn": "Visited on {date}",
+      "noVisit": "Not visited"
+    },
+    "fields": {
+      "seated": "Seated",
+      "standing": "Standing",
+      "rate": "Rental",
+      "name": "Name",
+      "address": "Address",
+      "mapsUrl": "Google Maps / Waze link",
+      "baseRate": "Rental price ($)",
+      "capacitySeated": "Seated capacity",
+      "capacityStanding": "Standing capacity",
+      "contactName": "Contact (name)",
+      "contactPhone": "Contact (phone)",
+      "visitedAt": "Visit date",
+      "pros": "Pros",
+      "cons": "Cons",
+      "restrictions": "Restrictions",
+      "pricingNotes": "Pricing notes",
+      "notes": "General notes"
+    },
+    "form": {
+      "namePlaceholder": "e.g. Lakeside Manor",
+      "markFavorite": "Mark as favorite",
+      "seedChecklist": "Create the default visit checklist (20 questions)"
+    },
+    "delete": {
+      "confirmTitle": "Delete {name}?",
+      "confirmTitleFallback": "Delete venue?",
+      "confirmDescription": "The venue and its checklist will be removed from the listings.",
+      "confirmDescriptionDetail": "The venue and its checklist will be marked as deleted."
+    },
+    "toast": {
+      "created": "Venue created",
+      "removed": "Venue removed",
+      "updated": "Updated",
+      "fail": "Failed"
+    },
+    "detail": {
+      "back": "Back to venues",
+      "contactLabel": "Contact:",
+      "openMaps": "Open in Maps",
+      "closeEdit": "Close editing",
+      "deleteVenue": "Delete venue"
+    },
+    "editForm": {
+      "title": "Edit venue",
+      "mapsUrl": "Maps link",
+      "baseRate": "Rental ($)",
+      "contactName": "Contact",
+      "contactPhone": "Phone",
+      "visitedAt": "Visited on",
+      "favorite": "Favorite",
+      "pricingNotes": "Pricing notes"
+    },
+    "checklist": {
+      "title": "Visit checklist",
+      "answered": "{done}/{total} answered",
+      "answerPlaceholder": "Note the answer",
+      "deleteItemAria": "Delete item",
+      "addPlaceholder": "New question for the checklist..."
+    },
+    "attachments": {
+      "title": "Attachments",
+      "file": "File",
+      "kind": "Type",
+      "kinds": {
+        "PHOTO": "Visit photo",
+        "CONTRACT": "Contract",
+        "PROPOSAL": "Proposal",
+        "OTHER": "Other"
+      },
+      "upload": "Upload",
+      "empty": "No attachments yet.",
+      "removed": "Attachment removed",
+      "deleteAria": "Delete attachment",
+      "deleteTitle": "Delete attachment?"
+    }
+  },
+  "weddingDay": {
+    "header": {
+      "mode": "Wedding Day Mode",
+      "fallbackTitle": "The big day",
+      "countdown": "Countdown",
+      "daysLeft": "{count, plural, one {# day} other {# days}}"
+    },
+    "stats": {
+      "confirmed": "Confirmed",
+      "totalHeads": "Total headcount",
+      "arrived": "Arrived",
+      "tasksToday": "Tasks today"
+    },
+    "seatingLink": {
+      "title": "Seating chart",
+      "description": "Arrange the tables and drag confirmed guests to their seats."
+    },
+    "schedule": {
+      "title": "Day schedule",
+      "empty": "No schedule added yet. Use the button below to set one up (e.g. 7:00 AM hairdresser, 2:00 PM catering arrival...).",
+      "placeholder": "E.g.:\n07:00 — hairdresser arrives\n11:00 — getting-ready photos\n16:30 — ceremony\n..."
+    },
+    "rainPlan": {
+      "title": "Rain plan B / contingencies",
+      "empty": "No plan B documented."
+    },
+    "notes": {
+      "title": "Special notes",
+      "empty": "No notes.",
+      "closeEdit": "Close editing",
+      "openEdit": "Edit schedule / plan B / notes",
+      "placeholder": "First-dance song, waltz, surprise, cake flavors..."
+    },
+    "contacts": {
+      "title": "Key contacts",
+      "empty": "No contracted vendors.",
+      "addContact": "Add contact"
+    },
+    "tasks": {
+      "title": "Tasks today",
+      "empty": "No tasks scheduled for today."
+    },
+    "payments": {
+      "title": "Payments today"
+    },
+    "checkin": {
+      "title": "Quick check-in",
+      "searchPlaceholder": "Search guest...",
+      "empty": "No guests.",
+      "childPrefix": "Child · ",
+      "arrived": "Arrived",
+      "mark": "Check in"
+    },
+    "toast": {
+      "saved": "Saved",
+      "error": "Failed"
+    },
+    "seating": {
+      "title": "Seating chart",
+      "subtitle": "Drag confirmed guests onto the tables. Capacity accounts for +1s.",
+      "newTable": "New table",
+      "stats": {
+        "tables": "Tables",
+        "totalSeats": "Total seats",
+        "allocatedGuests": "Assigned guests"
+      },
+      "hint": {
+        "empty": "Create the first table to get started.",
+        "help": "Drop a guest onto a table to assign them; drag the handle to reorder."
+      },
+      "table": {
+        "dropGuests": "Drop guests here"
+      },
+      "pool": {
+        "title": "Guest pool",
+        "empty": "All confirmed guests are assigned. Drop here to unassign."
+      },
+      "form": {
+        "createTitle": "New table",
+        "editTitle": "Edit table",
+        "capacity": "Capacity",
+        "shape": "Shape",
+        "saving": "Saving..."
+      },
+      "shape": {
+        "round": "Round",
+        "rect": "Rectangular",
+        "square": "Square"
+      },
+      "delete": {
+        "title": "Delete table?",
+        "description": "Table \"{name}\" will be removed and its guests will become unassigned."
+      },
+      "toast": {
+        "errorTitle": "Error",
+        "error": "Failed",
+        "created": "Table created",
+        "updated": "Table updated",
+        "deleted": "Table deleted",
+        "tableFull": "Table full",
+        "tableFullDetail": "Capacity {capacity}, occupied {used}, required {needed}"
+      },
+      "chip": {
+        "dragAria": "Drag {name}"
+      },
+      "card": {
+        "reorderAria": "Reorder table",
+        "editAria": "Edit table",
+        "deleteAria": "Delete table"
+      }
+    }
+  }
+}

--- a/src/messages/es/actions.json
+++ b/src/messages/es/actions.json
@@ -1,4 +1,31 @@
 {
+  "asset": {
+    "notFound": "Aporte no encontrado",
+    "errorCreate": "Error al crear el aporte",
+    "errorUpdate": "Error al actualizar el aporte",
+    "errorDelete": "Error al eliminar el aporte"
+  },
+  "attachment": {
+    "notFound": "Adjunto no encontrado",
+    "vendorNotFound": "Proveedor no encontrado",
+    "contractNotFound": "Contrato no encontrado",
+    "venueNotFound": "Lugar no encontrado",
+    "noPermission": "Sin permiso",
+    "noPermissionEdit": "Sin permiso para editar",
+    "noPermissionKind": "Sin permiso para este tipo de adjunto",
+    "noPermissionView": "Sin permiso para este adjunto",
+    "onlyAdminCoupleRemoveContract": "Solo el administrador, el novio o la novia pueden eliminar contratos.",
+    "rateLimitUser": "Demasiadas subidas seguidas. Inténtalo de nuevo en 1 minuto.",
+    "rateLimitIp": "Límite de subidas superado.",
+    "invalidTarget": "Destino inválido",
+    "fileRequired": "Archivo obligatorio",
+    "errorUpload": "Error al subir el archivo",
+    "errorDelete": "Error al eliminar el adjunto"
+  },
+  "auth": {
+    "invalidCredentials": "Credenciales inválidas.",
+    "loginGenericError": "Algo salió mal al iniciar sesión."
+  },
   "common": {
     "unauthorized": "No autorizado",
     "forbidden": "Acceso denegado",
@@ -6,9 +33,96 @@
     "notFound": "No encontrado",
     "generic": "Algo salió mal. Inténtalo de nuevo."
   },
-  "auth": {
-    "invalidCredentials": "Credenciales inválidas.",
-    "loginGenericError": "Algo salió mal al iniciar sesión."
+  "contract": {
+    "notFound": "Contrato no encontrado",
+    "noPermissionSign": "Sin permiso para firmar",
+    "noPermissionUpload": "Sin permiso para subir el contrato",
+    "rateLimitUser": "Demasiadas subidas seguidas. Inténtalo de nuevo en 1 minuto.",
+    "rateLimitIp": "Límite de subidas superado.",
+    "invalidTarget": "Destino inválido",
+    "fileRequired": "Archivo obligatorio",
+    "errorCreate": "Error al crear el contrato",
+    "errorUpdate": "Error al actualizar el contrato",
+    "errorDelete": "Error al eliminar el contrato",
+    "errorSign": "Error al registrar la firma",
+    "errorUpload": "Error al subir el contrato"
+  },
+  "gift": {
+    "notFound": "Regalo no encontrado",
+    "errorCreating": "Error al registrar el regalo",
+    "errorUpdating": "Error al actualizar el regalo",
+    "errorUpdatingShort": "Error al actualizar",
+    "errorDeleting": "Error al eliminar el regalo",
+    "errorMarkingPix": "Error al marcar Pix como recibido",
+    "pixAlreadyReceived": "Pix ya marcado como recibido",
+    "assetTitle": "Pix de {giver}{honeymoon}",
+    "assetGuestFallback": "invitado",
+    "assetHoneymoonSuffix": " (aporte luna de miel)",
+    "assetNotes": "Generado a partir del regalo #{id}"
+  },
+  "goal": {
+    "notFound": "Meta no encontrada",
+    "errorCreate": "Error al crear la meta",
+    "errorUpdate": "Error al actualizar la meta",
+    "errorDelete": "Error al eliminar la meta"
+  },
+  "guest": {
+    "errorCreating": "Error al crear el invitado",
+    "notFound": "Invitado no encontrado",
+    "errorUpdating": "Error al actualizar el invitado",
+    "errorDeleting": "Error al eliminar el invitado",
+    "errorCheckin": "Error al registrar la asistencia",
+    "noLinesFound": "No se encontraron líneas",
+    "errorImporting": "Error al importar",
+    "tooManyAttempts": "Demasiados intentos. Inténtalo de nuevo en unos minutos.",
+    "inviteNotFound": "Invitación no encontrada",
+    "linkExpired": "Enlace caducado. Solicita una nueva invitación.",
+    "errorRsvp": "Error al registrar la respuesta",
+    "tooManyUploads": "Demasiadas subidas seguidas. Espera 1 minuto.",
+    "uploadLimitExceeded": "Límite de subidas superado.",
+    "fileRequired": "Archivo obligatorio",
+    "unknownSource": "Origen desconocido",
+    "unsupportedFormat": "Formato no compatible. Usa .xlsx (Wedy) o .csv (exportación del propio sistema).",
+    "unrecognizedFormat": "No se pudo identificar el formato. Compatibles: Wedy (.xlsx) o CSV exportado por el propio sistema.",
+    "noValidRows": "No se encontró ninguna fila válida en la planilla.",
+    "rowLimit": "Límite de {max} filas por importación.",
+    "errorProcessingFile": "Error al procesar el archivo",
+    "importSessionExpired": "La sesión de importación caducó. Reenvía el archivo.",
+    "errorCommittingImport": "Error al guardar la importación"
+  },
+  "guestGroup": {
+    "errorCreating": "Error al crear el grupo",
+    "notFound": "Grupo no encontrado",
+    "errorUpdating": "Error al actualizar el grupo",
+    "invalidId": "ID no válido",
+    "errorDeleting": "Error al eliminar el grupo",
+    "errorUpdatingMembers": "Error al actualizar los miembros",
+    "tooManyAttempts": "Demasiados intentos. Inténtalo de nuevo en unos minutos.",
+    "groupInviteNotFound": "Invitación de grupo no encontrada",
+    "linkExpired": "Enlace caducado. Solicita una nueva invitación.",
+    "guestOutsideGroup": "Respuesta no válida (invitado fuera del grupo)",
+    "errorRsvp": "Error al registrar las respuestas"
+  },
+  "honeymoon": {
+    "itemNotFound": "Ítem no encontrado",
+    "errorSaving": "Error al guardar",
+    "errorAdding": "Error al agregar",
+    "errorUpdating": "Error al actualizar",
+    "errorDeleting": "Error al eliminar"
+  },
+  "income": {
+    "notFound": "Ingreso no encontrado",
+    "errorCreate": "Error al crear el ingreso",
+    "errorUpdate": "Error al actualizar el ingreso",
+    "errorMarkReceived": "Error al marcar como recibido",
+    "errorDelete": "Error al eliminar el ingreso"
+  },
+  "onboarding": {
+    "coupleNameRequired": "Ingresa el nombre de la pareja",
+    "invalidDate": "Fecha inválida",
+    "errorCouple": "Error al guardar datos de la pareja",
+    "errorBudget": "Error al guardar el presupuesto",
+    "errorFinish": "Error al finalizar la incorporación"
   },
   "passwordReset": {
     "invalidEmail": "Correo inválido",
@@ -19,12 +133,18 @@
     "userNotFoundOrInactive": "Usuario no encontrado o inactivo",
     "errorResetting": "Error al restablecer la contraseña"
   },
-  "onboarding": {
-    "coupleNameRequired": "Ingresa el nombre de la pareja",
-    "invalidDate": "Fecha inválida",
-    "errorCouple": "Error al guardar datos de la pareja",
-    "errorBudget": "Error al guardar el presupuesto",
-    "errorFinish": "Error al finalizar la incorporación"
+  "payment": {
+    "vendorNotFound": "Proveedor no encontrado",
+    "notFound": "Pago no encontrado",
+    "notFoundOrPaid": "Pago no encontrado o ya pagado",
+    "cannotUndo": "No se puede revertir este pago",
+    "errorCreate": "Error al crear el pago",
+    "errorUpdate": "Error al actualizar el pago",
+    "errorMarkPaid": "Error al saldar el pago",
+    "errorUndo": "Error al revertir el pago",
+    "errorDelete": "Error al eliminar el pago",
+    "errorSplit": "Error al crear los pagos divididos",
+    "errorInstallments": "Error al generar las cuotas"
   },
   "profile": {
     "invalidLocale": "Idioma inválido",
@@ -34,5 +154,109 @@
     "wrongPassword": "La contraseña actual es incorrecta",
     "emailTaken": "Ya existe un usuario con este correo",
     "emailUpdated": "Correo actualizado. Úsalo en tu próximo inicio de sesión."
+  },
+  "seatingTable": {
+    "errorCreate": "Error al crear la mesa",
+    "tableNotFound": "Mesa no encontrada",
+    "errorUpdate": "Error al actualizar la mesa",
+    "invalidId": "ID inválido",
+    "errorDelete": "Error al eliminar la mesa",
+    "invalidOrder": "Orden inválido",
+    "errorReorder": "Error al reordenar las mesas",
+    "invalidCoords": "Coordenadas inválidas",
+    "errorMove": "Error al mover la mesa",
+    "invalidGuestId": "ID de invitado inválido",
+    "invalidTableId": "ID de mesa inválido",
+    "guestNotFound": "Invitado no encontrado",
+    "tableFull": "La mesa \"{name}\" no tiene asientos suficientes (capacidad {capacity}, ocupados {used}, necesario {needed})",
+    "errorAssign": "Error al asignar al invitado"
+  },
+  "security": {
+    "errorGenerating": "Error al generar la configuración 2FA",
+    "invalidCode": "Código inválido",
+    "invalidTotp": "Código TOTP inválido",
+    "errorEnabling": "Error al activar 2FA",
+    "codeRequired": "Código obligatorio",
+    "notActive": "2FA no está activo",
+    "errorDisabling": "Error al desactivar 2FA"
+  },
+  "settings": {
+    "errorSaving": "Error al guardar la configuración",
+    "errorSavingPix": "Error al guardar la configuración de Pix"
+  },
+  "task": {
+    "notFound": "Tarea no encontrada",
+    "errorCreate": "Error al crear la tarea",
+    "errorUpdate": "Error al actualizar la tarea",
+    "errorStatus": "Error al actualizar el estado",
+    "errorDelete": "Error al eliminar la tarea",
+    "errorTemplates": "Error al cargar la plantilla",
+    "eventDateRequired": "Configura la fecha del evento en Ajustes para usar las plantillas."
+  },
+  "trousseau": {
+    "notFound": "Artículo no encontrado",
+    "errorAdding": "Error al añadir",
+    "errorUpdating": "Error al actualizar",
+    "errorUpdatingStatus": "Error al actualizar el estado",
+    "errorDeleting": "Error al eliminar"
+  },
+  "user": {
+    "noPermission": "Sin permiso",
+    "invalidSession": "Sesión inválida",
+    "emailTaken": "Ya existe un usuario con este correo",
+    "passwordTooShort": "La contraseña debe tener al menos {min} caracteres",
+    "passwordTooLong": "Contraseña demasiado larga",
+    "errorCreating": "Error al crear el usuario",
+    "notFound": "Usuario no encontrado",
+    "cannotChangeOwnRole": "No puedes cambiar tu propio rol",
+    "cannotDeactivateSelf": "No puedes desactivarte a ti mismo",
+    "keepOneAdmin": "Mantén al menos un administrador activo",
+    "errorUpdating": "Error al actualizar el usuario",
+    "errorResettingPassword": "Error al restablecer la contraseña",
+    "invalidId": "ID inválido",
+    "errorResetting2FA": "Error al restablecer 2FA",
+    "cannotArchiveSelf": "No puedes archivarte a ti mismo",
+    "errorArchiving": "Error al archivar el usuario",
+    "errorRestoring": "Error al restaurar el usuario",
+    "newPasswordMustDiffer": "La nueva contraseña debe ser diferente de la actual",
+    "wrongCurrentPassword": "La contraseña actual es incorrecta",
+    "errorChangingPassword": "Error al cambiar la contraseña",
+    "errorUpdatingProfile": "Error al actualizar el perfil",
+    "securityPolicyAdminOnly": "Solo los administradores pueden cambiar la política de seguridad",
+    "errorSavingSecurityPolicy": "Error al guardar la política de seguridad"
+  },
+  "vendor": {
+    "errorCreate": "Error al crear el proveedor",
+    "errorUpdate": "Error al actualizar el proveedor",
+    "errorStatus": "Error al actualizar el estado",
+    "errorDelete": "Error al eliminar el proveedor"
+  },
+  "vendorContact": {
+    "notFound": "Contacto no encontrado",
+    "errorCreate": "Error al añadir el contacto",
+    "errorUpdate": "Error al actualizar el contacto",
+    "errorDelete": "Error al eliminar el contacto"
+  },
+  "vendorNote": {
+    "notFound": "Nota no encontrada",
+    "errorCreate": "Error al añadir la nota",
+    "errorDelete": "Error al eliminar la nota"
+  },
+  "venue": {
+    "errorCreate": "Error al crear el lugar",
+    "notFound": "Lugar no encontrado",
+    "errorUpdate": "Error al actualizar el lugar",
+    "errorDelete": "Error al eliminar el lugar",
+    "errorAddItem": "Error al agregar el elemento",
+    "errorUpdateItem": "Error al actualizar el elemento",
+    "itemNotFound": "Elemento no encontrado",
+    "errorDeleteItem": "Error al eliminar el elemento"
+  },
+  "weddingDay": {
+    "errorSaving": "Error al guardar"
+  },
+  "whatsapp": {
+    "adminOnly": "Solo administradores",
+    "testMessageBody": "*Wedding Finance*\n\nMensaje de prueba enviado con éxito. Tu integración con WhatsApp está funcionando. ✅"
   }
 }

--- a/src/messages/es/dashboard.json
+++ b/src/messages/es/dashboard.json
@@ -1,1 +1,2033 @@
-{}
+{
+  "assets": {
+    "page": {
+      "title": "Caja (Dinero Ahorrado)"
+    },
+    "list": {
+      "searchPlaceholder": "Buscar aporte...",
+      "total": "Total: {value}",
+      "new": "Nuevo Aporte",
+      "empty": "Ningún aporte registrado.",
+      "noResults": "Sin resultados para el filtro."
+    },
+    "table": {
+      "date": "Fecha",
+      "source": "Origen",
+      "amount": "Importe",
+      "actions": "Acciones"
+    },
+    "delete": {
+      "title": "¿Eliminar aporte?"
+    },
+    "toast": {
+      "created": "Aporte registrado",
+      "updated": "Aporte actualizado",
+      "deleted": "Aporte eliminado",
+      "failTitle": "Error"
+    },
+    "form": {
+      "titleCreate": "Nuevo aporte",
+      "titleEdit": "Editar aporte",
+      "titleLabel": "Título / Origen",
+      "titlePlaceholder": "Ej.: Salario de marzo",
+      "amountLabel": "Importe",
+      "dateLabel": "Fecha",
+      "goalLabel": "Vincular a una meta (opcional)",
+      "goalNone": "— sin meta —",
+      "notesLabel": "Notas"
+    }
+  },
+  "gifts": {
+    "page": {
+      "title": "Regalos recibidos",
+      "subtitle": "Registra lo que recibiste (dinero o artículo), de quién, y marca cuándo se envió el agradecimiento."
+    },
+    "stats": {
+      "cashTotal": "Total en dinero",
+      "itemsReceived": "Artículos recibidos",
+      "pendingThank": "Pendiente de agradecer"
+    },
+    "filter": {
+      "all": "Todos",
+      "pendingThank": "Pendiente de agradecer"
+    },
+    "list": {
+      "empty": "Ningún regalo registrado."
+    },
+    "anonymous": "Anónimo",
+    "type": {
+      "cash": "Dinero",
+      "item": "Artículo"
+    },
+    "badge": {
+      "thanked": "Agradecido",
+      "honeymoon": "luna de miel",
+      "pixReceived": "Pix recibido"
+    },
+    "actions": {
+      "new": "Nuevo regalo",
+      "generatePix": "Generar QR Pix",
+      "toggleThank": "Alternar agradecimiento",
+      "markThanked": "Marcar como agradecido",
+      "unmarkThanked": "Desmarcar agradecido"
+    },
+    "delete": {
+      "title": "¿Eliminar regalo?"
+    },
+    "form": {
+      "titleCreate": "Nuevo regalo",
+      "titleEdit": "Editar regalo",
+      "type": "Tipo",
+      "guest": "Invitado (opcional)",
+      "giverName": "Nombre de quien lo dio (si no hay invitado)",
+      "amount": "Importe",
+      "description": "Descripción",
+      "receivedAt": "Recibido el",
+      "honeymoonShare": "Aporte para la luna de miel (mostrar QR Pix dedicado)",
+      "notes": "Notas"
+    },
+    "toast": {
+      "created": "Regalo registrado",
+      "updated": "Regalo actualizado",
+      "removed": "Regalo eliminado",
+      "thanked": "Marcado como agradecido",
+      "unthanked": "Desmarcado",
+      "failed": "Error"
+    },
+    "pix": {
+      "back": "Volver",
+      "title": "Código QR Pix",
+      "qrAlt": "Código QR Pix",
+      "errorGenerating": "Error al generar el código QR",
+      "errorPrefix": "Error al generar Pix:",
+      "field": {
+        "key": "clave Pix",
+        "holder": "nombre del beneficiario",
+        "city": "ciudad"
+      },
+      "incomplete": {
+        "title": "Configuración de Pix incompleta",
+        "intro": "Para generar el código QR, configura:",
+        "goToSettings": "Ir a Ajustes"
+      },
+      "summary": {
+        "title": "Resumen",
+        "gift": "Regalo",
+        "value": "Importe",
+        "freeValue": "sin importe (libre)",
+        "status": "Estado Pix",
+        "receivedOn": "Recibido el",
+        "awaiting": "Esperando confirmación"
+      },
+      "copyPaste": {
+        "title": "Pix copiar y pegar",
+        "copyButton": "Copiar código"
+      },
+      "confirm": {
+        "title": "Confirmar recepción",
+        "hint": "Después de verificar el pago en tu cuenta, márcalo como recibido.",
+        "addToAsset": "Agregar importe a caja (Asset)",
+        "saving": "Guardando...",
+        "markReceived": "Marcar como recibido"
+      },
+      "toast": {
+        "copied": "Código copiado",
+        "marked": "Pix marcado como recibido",
+        "error": "Error",
+        "copyFailed": "No se pudo copiar"
+      }
+    }
+  },
+  "goals": {
+    "page": {
+      "title": "Metas de ahorro",
+      "subtitle": "Define cuánto ahorrar y para cuándo. Los aportes (efectivo) pueden vincularse a una meta."
+    },
+    "list": {
+      "new": "Nueva meta",
+      "empty": "Aún no hay metas. Crea una para seguir el progreso del ahorro hasta la fecha objetivo."
+    },
+    "card": {
+      "inactive": "inactiva",
+      "target": "Objetivo: {date}",
+      "pctReached": "{pct}% alcanzado",
+      "contributions": "{count, plural, one {# aporte} other {# aportes}}",
+      "remaining": "Falta",
+      "perMonth": "Por mes"
+    },
+    "form": {
+      "createTitle": "Nueva meta",
+      "editTitle": "Editar meta",
+      "name": "Nombre",
+      "targetAmount": "Monto objetivo (R$)",
+      "targetDate": "Fecha objetivo",
+      "imageUrl": "URL de imagen de inspiración (opcional)",
+      "imageUrlPlaceholder": "https://ejemplo.com/imagen.jpg",
+      "isActive": "Meta activa",
+      "notes": "Notas"
+    },
+    "delete": {
+      "title": "¿Eliminar meta?",
+      "description": "Los aportes vinculados siguen existiendo, pero pierden el vínculo."
+    },
+    "toast": {
+      "created": "Meta creada",
+      "updated": "Meta actualizada",
+      "removed": "Meta eliminada",
+      "failed": "Error"
+    }
+  },
+  "guests": {
+    "page": {
+      "title": "Invitados",
+      "subtitle": "Gestiona la lista, envía enlaces únicos de RSVP y haz seguimiento de las confirmaciones."
+    },
+    "stats": {
+      "list": "Lista",
+      "guests": "invitados",
+      "confirmed": "Confirmados",
+      "heads": "{count, plural, one {# persona} other {# personas}}",
+      "pending": "Pendientes",
+      "declined": "Rechazaron"
+    },
+    "filters": {
+      "searchPlaceholder": "Buscar...",
+      "all": "Todos",
+      "confirmed": "Confirmados",
+      "pending": "Pendientes",
+      "padrinhos": "Padrinos y madrinas",
+      "children": "Niños",
+      "checkedIn": "Ya llegaron"
+    },
+    "actions": {
+      "groups": "Grupos",
+      "csv": "CSV",
+      "importList": "Importar lista",
+      "newGuest": "Nuevo invitado"
+    },
+    "table": {
+      "name": "Nombre",
+      "group": "Grupo",
+      "rsvp": "RSVP",
+      "plusOne": "+1",
+      "table": "Mesa",
+      "attendance": "Asistencia",
+      "actions": "Acciones",
+      "empty": "Lista vacía.",
+      "noResults": "Sin resultados."
+    },
+    "tags": {
+      "padrinhoShort": "P",
+      "child": "Niño",
+      "vip": "VIP"
+    },
+    "attendance": {
+      "arrived": "Llegó",
+      "mark": "Marcar"
+    },
+    "rowActions": {
+      "copyRsvp": "Copiar enlace RSVP"
+    },
+    "rsvp": {
+      "notInvited": "No invitado",
+      "invited": "Invitado",
+      "confirmed": "Confirmado",
+      "declined": "Rechazó",
+      "maybe": "Quizás"
+    },
+    "delete": {
+      "confirmTitle": "¿Eliminar {name}?",
+      "confirmTitleGeneric": "¿Eliminar?"
+    },
+    "toast": {
+      "created": "Invitado creado",
+      "updated": "Invitado actualizado",
+      "removed": "Invitado eliminado",
+      "checkinReverted": "Check-in revertido",
+      "checkinDone": "Asistencia registrada",
+      "linkCopied": "Enlace copiado",
+      "copyFailed": "Error al copiar"
+    },
+    "csv": {
+      "name": "Nombre",
+      "phone": "Teléfono",
+      "email": "Email",
+      "side": "Lado",
+      "group": "Grupo",
+      "status": "Estado",
+      "plusOnesConfirmed": "+1 confirmados",
+      "table": "Mesa",
+      "dietary": "Restricciones",
+      "city": "Ciudad",
+      "padrinho": "Padrino",
+      "vip": "VIP",
+      "child": "Niño",
+      "yes": "sí",
+      "fileName": "invitados"
+    },
+    "form": {
+      "createTitle": "Nuevo invitado",
+      "editTitle": "Editar {name}",
+      "name": "Nombre",
+      "phone": "Teléfono",
+      "email": "Email",
+      "side": "Lado",
+      "groupName": "Grupo (ej.: familia de él)",
+      "city": "Ciudad",
+      "rsvpStatus": "Estado RSVP",
+      "plusOnesAllowed": "Acompañantes permitidos",
+      "tableNumber": "Mesa / sector",
+      "dietary": "Restricciones alimentarias",
+      "isChild": "Niño",
+      "isVIP": "VIP",
+      "isPadrinho": "Padrino / madrina",
+      "notes": "Notas"
+    },
+    "side": {
+      "groom": "Novio",
+      "bride": "Novia",
+      "both": "Ambos"
+    },
+    "groups": {
+      "backToGuests": "Volver a invitados",
+      "title": "Grupos / Familias",
+      "subtitle": "Crea grupos para generar un único enlace de RSVP por familia.",
+      "newGroup": "Nuevo grupo",
+      "empty": "Ningún grupo registrado.",
+      "card": {
+        "contact": "Contacto: {name}",
+        "people": "{count, plural, one {# persona} other {# personas}}",
+        "yes": "{count} sí",
+        "pending": "{count} pendiente",
+        "no": "{count} no",
+        "copyLink": "Copiar enlace",
+        "members": "Miembros"
+      },
+      "form": {
+        "createTitle": "Nuevo grupo",
+        "editTitle": "Editar grupo",
+        "name": "Nombre del grupo",
+        "contactName": "Contacto (opcional)",
+        "email": "Email",
+        "phone": "Teléfono",
+        "notes": "Observaciones",
+        "saving": "Guardando..."
+      },
+      "members": {
+        "title": "Miembros de {name}",
+        "subtitle": "Selecciona los invitados que pertenecen a este grupo.",
+        "searchPlaceholder": "Buscar invitado...",
+        "noneAvailable": "Ningún invitado disponible.",
+        "selectedCount": "{count, plural, one {# seleccionado} other {# seleccionados}}"
+      },
+      "toast": {
+        "linkCopied": "Enlace copiado",
+        "copyFailed": "No se pudo copiar",
+        "created": "Grupo creado",
+        "updated": "Grupo actualizado",
+        "deleted": "Grupo eliminado",
+        "membersUpdated": "Miembros actualizados"
+      },
+      "delete": {
+        "title": "¿Eliminar grupo?",
+        "description": "El grupo \"{name}\" será eliminado. Los invitados no se borrarán."
+      }
+    },
+    "import": {
+      "backToGuests": "Volver a invitados",
+      "title": "Importar lista de invitados",
+      "subtitle": "Sube el archivo exportado de otro sistema (hoy: {sources}). Verás una vista previa antes de confirmar.",
+      "toast": {
+        "selectFile": "Selecciona un archivo .xlsx",
+        "unexpectedResponse": "Respuesta inesperada del servidor",
+        "importFailed": "Error al importar"
+      },
+      "upload": {
+        "fileLabel": "Archivo (.xlsx o .csv)",
+        "fileHint": "Tamaño máximo: 5 MB. Hasta 2000 filas por importación. Wedy exporta en .xlsx; el propio sistema exporta en .csv (botón CSV en /dashboard/guests).",
+        "sourceLabel": "Origen",
+        "autoDetect": "Detectar automáticamente",
+        "preferPaste": "¿Prefieres pegar texto sin formato?",
+        "analyze": "Analizar archivo"
+      },
+      "preview": {
+        "rowsInFile": "Filas en el archivo",
+        "new": "Nuevos",
+        "existingSameGroup": "Ya existen (mismo grupo)",
+        "divergent": "Divergentes",
+        "detectedSource": "Origen detectado",
+        "fileValid": "archivo válido, encabezados reconocidos.",
+        "detectedGroups": "Grupos detectados ({count})",
+        "noGroups": "Ningún grupo en la planilla.",
+        "peopleCount": "{count, plural, one {# persona} other {# personas}}",
+        "pin": "PIN {pin}",
+        "detectedTags": "Etiquetas detectadas ({count})",
+        "noTags": "Ninguna etiqueta.",
+        "tagsNote": "Se crearán etiquetas nuevas. Las etiquetas con el nombre \"Padrinhos\", \"Madrinha\", etc. también activan la marca de padrino del invitado.",
+        "sampleTitle": "Muestra (hasta {count} filas)",
+        "filterAll": "Todas",
+        "filterNew": "Nuevas",
+        "filterExisting": "Ya existen",
+        "filterDivergent": "Divergentes",
+        "confirmImport": "Confirmar importación"
+      },
+      "mode": {
+        "heading": "Cómo tratar los duplicados",
+        "CREATE_NEW_ONLY": {
+          "label": "Omitir filas que ya existen en el mismo grupo",
+          "description": "Más seguro. Solo crea los invitados nuevos; nada se modifica."
+        },
+        "UPSERT_BY_NAME": {
+          "label": "Actualizar datos de quien ya existe en el mismo grupo",
+          "description": "Sobrescribe teléfono, email, estado y etiquetas de los invitados que ya existen. Crea los nuevos."
+        },
+        "CREATE_ALL_DUPLICATES": {
+          "label": "Crear todo, aunque ya exista",
+          "description": "Úsalo cuando haya homónimos en familias diferentes que no deban fusionarse."
+        }
+      },
+      "done": {
+        "title": "Importación completada",
+        "created": "<b>{count}</b> invitado(s) creados.",
+        "updated": "<b>{count}</b> invitado(s) actualizados.",
+        "skipped": "<b>{count}</b> fila(s) omitidas.",
+        "groupsCreated": "<b>{count}</b> grupo(s) creados.",
+        "tagsCreated": "<b>{count}</b> etiqueta(s) creadas.",
+        "viewList": "Ver lista de invitados",
+        "importAnother": "Importar otra"
+      },
+      "table": {
+        "noRowsForFilter": "Ninguna fila para este filtro.",
+        "status": "Estado",
+        "name": "Nombre",
+        "group": "Grupo",
+        "rsvp": "RSVP",
+        "phone": "Teléfono",
+        "email": "Email",
+        "tags": "Etiquetas",
+        "child": "Niño",
+        "pin": "PIN",
+        "statusNew": "Nuevo",
+        "statusDuplicateSame": "Ya existe (mismo grupo)",
+        "statusDuplicateDiff": "Ya existe, los datos difieren",
+        "rawStatusHint": "Estado original \"{raw}\" no reconocido; tratado como Invitado.",
+        "childYes": "Sí",
+        "childYesAge": "Sí ({age})"
+      },
+      "paste": {
+        "title": "Pegar texto sin formato",
+        "instructions": "Pega líneas en el formato <code>Nombre,Teléfono,Email,Lado,Grupo</code> (una línea por invitado). Teléfono, email, lado y grupo son opcionales. Lado acepta NOIVO/NOIVA/AMBOS. Cuando la columna <strong>Grupo</strong> está completa, se crean grupos nuevos automáticamente (y los existentes se reutilizan, comparando por nombre) — los invitados de la misma familia comparten un único enlace de RSVP.",
+        "contentLabel": "Contenido",
+        "placeholder": "Maria Silva,+5511999990000,maria@example.com,NOIVA,Familia\nJoão Souza\nAna,,ana@example.com,,Su trabajo",
+        "separatorLabel": "Separador",
+        "sepAuto": "Detectar automáticamente",
+        "sepComma": ", (coma)",
+        "sepSemicolon": "; (punto y coma)",
+        "sepTab": "Tab",
+        "submit": "Importar",
+        "toast": {
+          "importedTitle": "{count} importados",
+          "skippedLines": "{count, plural, one {# línea omitida} other {# líneas omitidas}}",
+          "groupsSuffix": ", {count, plural, one {# grupo creado} other {# grupos creados}}"
+        }
+      }
+    }
+  },
+  "home": {
+    "header": {
+      "title": "Vista general",
+      "weddingOn": "Boda el {date}",
+      "configurePrompt": "Configura tu evento para empezar"
+    },
+    "onboarding": {
+      "title": "¿Configuramos tu boda?",
+      "body": "En menos de 2 minutos defines la fecha, los nombres de la pareja y cómo funcionarán las notificaciones. Haz clic aquí para iniciar el asistente."
+    },
+    "quitAlert": {
+      "title": "¡Alerta de liquidación!",
+      "body": "{days, plural, one {Queda # día y aún hay un saldo pendiente de {balance}.} other {Quedan # días y aún hay un saldo pendiente de {balance}.}}",
+      "pendingValues": "importes pendientes"
+    },
+    "kpi": {
+      "totalBudget": {
+        "title": "Presupuesto total",
+        "hint": "Contingencia: {value}"
+      },
+      "totalPaid": {
+        "title": "Total pagado",
+        "hint": "{pct}% del presupuesto"
+      },
+      "remainingBalance": {
+        "title": "Saldo pendiente"
+      },
+      "cashCoverage": {
+        "title": "Cobertura de caja",
+        "hintPct": "{pct}% del saldo pendiente",
+        "hintPaid": "Saldo liquidado"
+      },
+      "vendors": {
+        "title": "Proveedores",
+        "hint": "{pct}% contratados"
+      },
+      "tasks": {
+        "title": "Tareas",
+        "hintOverdue": "{count, plural, one {# atrasada} other {# atrasadas}}",
+        "hintUpToDate": "Todo al día"
+      },
+      "guests": {
+        "title": "Invitados",
+        "hint": "{total} en total · {confirmed} confirmados"
+      },
+      "daysToEvent": {
+        "title": "Días para el evento"
+      },
+      "budgetSummary": {
+        "title": "Resumen del presupuesto",
+        "hint": "Contratado: {contracted} · Pagado: {paid}"
+      }
+    },
+    "risks": {
+      "title": "Señales de atención"
+    },
+    "funnel": {
+      "title": "Embudo de proveedores",
+      "empty": "No hay proveedores registrados.",
+      "negotiating": "Negociando",
+      "contracted": "Contratados",
+      "finalized": "Finalizados"
+    },
+    "budgetDistribution": {
+      "title": "Distribución del presupuesto"
+    },
+    "upcomingPayments": {
+      "title": "Próximos vencimientos",
+      "empty": "No hay pagos en los próximos 30 días.",
+      "dueLabel": "Vence: {date}"
+    },
+    "charts": {
+      "noData": "Datos insuficientes para el gráfico"
+    },
+    "rsvp": {
+      "title": "Confirmaciones (RSVP)",
+      "empty": "Aún no hay invitados registrados.",
+      "respondedConfirming": "{confirmed} de {total} han confirmado",
+      "confirmed": "{count, plural, one {# confirmado} other {# confirmados}}",
+      "maybe": "{count, plural, one {# quizá} other {# quizá}}",
+      "declined": "{count, plural, one {# rechazo} other {# rechazos}}",
+      "pending": "{count, plural, one {# pendiente} other {# pendientes}}",
+      "plusOnes": "{count, plural, one {+# acompañante confirmado} other {+# acompañantes confirmados}}",
+      "totalGuests": "{count, plural, one {# invitado en total} other {# invitados en total}}"
+    },
+    "gifts": {
+      "title": "Regalos recibidos",
+      "empty": "Aún no hay regalos registrados.",
+      "breakdown": "{cash} en efectivo · {items} en artículos",
+      "thankedLabel": "Agradecidos:",
+      "thankedCount": "{thanked} de {total}"
+    },
+    "upcomingTasks": {
+      "title": "Próximas tareas",
+      "empty": "No hay tareas pendientes.",
+      "noDeadline": "Sin plazo",
+      "priority": {
+        "urgent": "URGENT",
+        "high": "HIGH",
+        "medium": "MEDIUM",
+        "low": "LOW"
+      }
+    },
+    "countdown": {
+      "past": "El evento ya pasó",
+      "today": "¡Hoy es el día!",
+      "remaining": "{days, plural, one {Queda # día} other {Quedan # días}}"
+    },
+    "install": {
+      "dismiss": "Ignorar",
+      "title": "Instalar como aplicación",
+      "iosBody": "Añade Wedding Finance Planner directamente a la pantalla de inicio de tu iPhone para una experiencia a pantalla completa idéntica a una app nativa:",
+      "iosTap": "Toca",
+      "iosShare": "Compartir",
+      "iosAddToHome": "Añadir a pantalla de inicio",
+      "androidBody": "Añade la aplicación Wedding Finance Planner a tu pantalla de inicio para seguir tus finanzas y tareas de forma ágil, con acceso rápido y notificaciones.",
+      "installButton": "Instalar aplicación"
+    }
+  },
+  "honeymoon": {
+    "page": {
+      "title": "Luna de miel",
+      "subtitle": "Itinerario, reservas, documentos y presupuesto del viaje posboda."
+    },
+    "info": {
+      "destination": "Destino",
+      "notDecided": "Aún sin decidir",
+      "budget": "Presupuesto",
+      "committed": "Comprometido",
+      "editTrip": "Editar datos del viaje",
+      "departure": "Salida",
+      "return": "Regreso"
+    },
+    "currency": {
+      "brl": "Real (BRL)",
+      "usd": "Dólar (USD)",
+      "eur": "Euro (EUR)"
+    },
+    "list": {
+      "empty": "Nada agregado todavía. Empieza por los vuelos y hoteles."
+    },
+    "actions": {
+      "newItem": "Nuevo ítem"
+    },
+    "kind": {
+      "FLIGHT": "Vuelo",
+      "HOTEL": "Alojamiento",
+      "TRANSFER": "Traslado",
+      "ACTIVITY": "Excursión",
+      "DOCUMENT": "Documento",
+      "BAGGAGE": "Equipaje",
+      "OTHER": "Otro"
+    },
+    "status": {
+      "PLANNED": "Planificado",
+      "BOOKED": "Reservado",
+      "CONFIRMED": "Confirmado",
+      "PAID": "Pagado",
+      "CANCELLED": "Cancelado"
+    },
+    "form": {
+      "titleCreate": "Nuevo ítem",
+      "titleEdit": "Editar ítem",
+      "kind": "Tipo",
+      "title": "Título",
+      "vendor": "Aerolínea / proveedor",
+      "start": "Inicio",
+      "end": "Fin",
+      "amount": "Importe",
+      "confirmationNumber": "Localizador"
+    },
+    "delete": {
+      "confirmTitle": "¿Eliminar ítem?"
+    },
+    "toast": {
+      "updated": "Actualizado",
+      "itemAdded": "Ítem agregado",
+      "itemUpdated": "Ítem actualizado",
+      "itemRemoved": "Ítem eliminado",
+      "failed": "Error"
+    }
+  },
+  "income": {
+    "page": {
+      "title": "Ingresos y ganancias",
+      "subtitle": "Ingresos recurrentes, bonos, regalos en efectivo y ventas previas a la boda."
+    },
+    "summary": {
+      "total": "Total estimado",
+      "expected": "Por recibir",
+      "received": "Recibido"
+    },
+    "actions": {
+      "new": "Nuevo ingreso",
+      "received": "Lo recibí"
+    },
+    "table": {
+      "title": "Título",
+      "source": "Origen",
+      "amount": "Importe",
+      "expectedDate": "Fecha prevista",
+      "status": "Estado",
+      "actions": "Acciones",
+      "empty": "No hay ingresos registrados."
+    },
+    "row": {
+      "givenBy": "de {name}"
+    },
+    "frequency": {
+      "ONE_TIME": "Puntual",
+      "MONTHLY": "Mensual"
+    },
+    "source": {
+      "SALARY": "Salario",
+      "BONUS": "Bono / aguinaldo",
+      "GIFT": "Regalo en efectivo",
+      "FREELANCE": "Freelance",
+      "SALE": "Venta",
+      "RESTITUTION": "Devolución de impuestos",
+      "OTHER": "Otro"
+    },
+    "status": {
+      "EXPECTED": "Prevista",
+      "RECEIVED": "Recibida",
+      "CANCELLED": "Cancelada"
+    },
+    "form": {
+      "titleCreate": "Nuevo ingreso",
+      "titleEdit": "Editar ingreso",
+      "title": "Título",
+      "source": "Origen",
+      "amount": "Importe",
+      "expectedDate": "Fecha prevista",
+      "frequency": "Frecuencia",
+      "status": "Estado",
+      "givenByName": "Dado por (regalo)",
+      "notes": "Notas"
+    },
+    "confirmDelete": {
+      "title": "¿Eliminar ingreso?"
+    },
+    "toast": {
+      "created": "Ingreso registrado",
+      "updated": "Ingreso actualizado",
+      "marked": "Marcado como recibido",
+      "deleted": "Ingreso eliminado",
+      "fail": "Error"
+    }
+  },
+  "insights": {
+    "header": {
+      "title": "Insights financieros",
+      "subtitle": "Proyección, salud del proyecto y detector de desvío del presupuesto por categoría."
+    },
+    "noData": "Aún no hay datos.",
+    "health": {
+      "label": "Health Score",
+      "statusGood": "Proyecto saludable.",
+      "statusWarn": "Atención en algunos puntos.",
+      "statusBad": "Necesita ajustes urgentes."
+    },
+    "cashflow": {
+      "title": "Flujo de caja proyectado",
+      "worstBalance": "Peor saldo: {value}",
+      "description": "Saldo acumulado hasta el evento, considerando aportes existentes + ingresos previstos − pagos pendientes."
+    },
+    "monthlyFlow": {
+      "title": "Entradas y salidas por mes",
+      "description": "Barras verdes = ingresos. Barras rojas = pagos. Zona roja de fondo = saldo negativo proyectado."
+    },
+    "sCurve": {
+      "title": "Curva S — Previsto vs Realizado",
+      "hint": "Banda = contingencia configurada"
+    },
+    "burndown": {
+      "title": "Burndown de Tareas",
+      "hint": "Ideal vs real hasta la fecha del evento"
+    },
+    "waterfall": {
+      "title": "Variación por Categoría",
+      "hint": "Verde = ahorró · Rosa = se pasó"
+    },
+    "whatIf": {
+      "title": "¿Puedo cerrar este contrato ahora?",
+      "description": "Simula agregar un pago futuro y observa el impacto en el flujo de caja hasta {date}.",
+      "amountLabel": "Importe ($)",
+      "dateLabel": "Fecha prevista",
+      "fillPrompt": "Ingresa importe y fecha",
+      "balanceAt": "Saldo en {month}",
+      "worstBalance": "Peor saldo hasta el evento",
+      "finalBalance": "Saldo final en el evento",
+      "canAfford": "Puedes cerrarlo",
+      "exceedsCash": "Agota tu caja"
+    },
+    "creep": {
+      "title": "Variación por categoría",
+      "description": "Compara estimado vs contratado en cada categoría. Los ítems con aumento > 10% requieren atención.",
+      "allWithinBudget": "Ninguna categoría está por encima de lo estimado.",
+      "estimated": "Estimado: {value}",
+      "contracted": "Contratado: {value}"
+    },
+    "heatmap": {
+      "title": "Concentración de pagos pendientes",
+      "description": "Hasta {date} ({days, plural, one {# día} other {# días}}). Cuanto más intenso, más concentrado el día.",
+      "cellTitle": "{date} · {value} ({count, plural, one {# pago} other {# pagos}})"
+    },
+    "chartLegend": {
+      "ending": "Saldo final",
+      "income": "Ingresos",
+      "outflow": "Pagos"
+    }
+  },
+  "payments": {
+    "title": "Pagos",
+    "view": {
+      "list": "Lista",
+      "calendar": "Calendario"
+    },
+    "actions": {
+      "new": "Nuevo Pago",
+      "generateInstallments": "Generar Cuotas",
+      "markPaid": "Saldar",
+      "revert": "Revertir"
+    },
+    "filter": {
+      "allStatus": "Todos los estados"
+    },
+    "list": {
+      "searchPlaceholder": "Buscar por proveedor...",
+      "empty": "Ningún pago registrado.",
+      "noResults": "Sin resultados para el filtro."
+    },
+    "table": {
+      "dueDate": "Vencimiento",
+      "vendor": "Proveedor",
+      "method": "Método",
+      "installment": "Cuota"
+    },
+    "card": {
+      "dueOn": "Vence el {date}"
+    },
+    "method": {
+      "PIX": "PIX",
+      "BOLETO": "Boleto",
+      "CREDIT": "Tarjeta de Crédito",
+      "TRANSFER": "Transferencia",
+      "CASH": "Efectivo"
+    },
+    "amount": {
+      "adjustedTooltip": "Base {base} + recargo {lateFee} + intereses {interest} ({days} día(s) de atraso)"
+    },
+    "form": {
+      "createTitle": "Nuevo Pago",
+      "editTitle": "Editar pago",
+      "splitToggle": "Anticipo + Saldo",
+      "vendor": "Proveedor",
+      "selectPlaceholder": "Selecciona...",
+      "amount": "Importe (R$)",
+      "dueDate": "Vencimiento",
+      "method": "Método",
+      "status": "Estado",
+      "installments": "Cuotas",
+      "installmentNumberPlaceholder": "ej: 1",
+      "installmentNumberLabel": "Número de cuota actual",
+      "installmentOf": "de",
+      "totalInstallmentsPlaceholder": "ej: 12",
+      "totalInstallmentsLabel": "Total de cuotas",
+      "installmentsHint": "Deja en blanco para un pago único.",
+      "notes": "Notas",
+      "optionalShort": "opcional",
+      "lateFee": "Recargo (%)",
+      "lateFeePlaceholder": "ej: 2",
+      "interest": "Intereses %/mes",
+      "interestPlaceholder": "ej: 1"
+    },
+    "split": {
+      "depositTitle": "1. Anticipo (pagado hoy)",
+      "balanceTitle": "2. Saldo final (pendiente)",
+      "balanceMethod": "Método del saldo"
+    },
+    "delete": {
+      "title": "¿Eliminar pago?",
+      "description": "Pago de {amount} a {vendor}.\nEsta acción hará una eliminación lógica y el registro desaparecerá de los listados."
+    },
+    "installmentsModal": {
+      "title": "Generar cuotas",
+      "description": "Crea N pagos pendientes con intervalo fijo. Útil para contratos en cuotas.",
+      "totalAmount": "Importe total (R$)",
+      "count": "N.º de cuotas",
+      "eachInstallment": "Cada cuota:",
+      "firstDate": "1.ª fecha",
+      "intervalDays": "Intervalo (días)",
+      "lateFee": "Recargo (%) opcional",
+      "interest": "Intereses %/mes opcional",
+      "generating": "Generando...",
+      "generateButton": "Generar {count, plural, one {# cuota} other {# cuotas}}"
+    },
+    "toast": {
+      "created": "Pago creado",
+      "splitCreated": "Anticipo y saldo registrados",
+      "createFailed": "Error al crear",
+      "updated": "Pago actualizado",
+      "updateFailed": "Error al actualizar",
+      "markedPaid": "Pago saldado",
+      "reverted": "Pago revertido",
+      "genericFailed": "Error",
+      "deleted": "Pago eliminado",
+      "deleteFailed": "Error al eliminar",
+      "installmentsGenerated": "Cuotas generadas"
+    },
+    "calendar": {
+      "annualView": "Vista Anual",
+      "yearTitle": "Calendario Financiero de {year}",
+      "monthTitle": "{month} de {year}",
+      "prevYear": "Año anterior",
+      "nextYear": "Año siguiente",
+      "prevMonth": "Mes anterior",
+      "nextMonth": "Mes siguiente",
+      "noScheduled": "Sin gastos programados",
+      "paymentCount": "{count, plural, one {# pago} other {# pagos}}",
+      "totalPlanned": "Total Planificado:",
+      "paidWithCount": "Pagado ({count}):",
+      "pendingWithCount": "Pendiente ({count}):",
+      "progress": "PROGRESO",
+      "percentPaid": "{percent}% pagado",
+      "moreOthers": "+{count} más",
+      "allExpensesOf": "Todos los Gastos de {month}",
+      "expensesOfDay": "Gastos del {day} de {month}",
+      "viewAllMonth": "Ver todos del mes",
+      "noExpenses": "Ningún gasto registrado para este período.",
+      "month": {
+        "0": "Enero",
+        "1": "Febrero",
+        "2": "Marzo",
+        "3": "Abril",
+        "4": "Mayo",
+        "5": "Junio",
+        "6": "Julio",
+        "7": "Agosto",
+        "8": "Septiembre",
+        "9": "Octubre",
+        "10": "Noviembre",
+        "11": "Diciembre"
+      }
+    }
+  },
+  "reports": {
+    "hub": {
+      "title": "Informes",
+      "subtitle": "Vistas analíticas detalladas por área. Los gráficos BI dentro de /dashboard/insights también aparecen aquí como acceso directo.",
+      "inInsights": "En Insights",
+      "items": {
+        "scurve": {
+          "title": "Curva S — Previsto vs Realizado",
+          "description": "Compara el pago previsto con el realizado a lo largo del tiempo, con banda de contingencia."
+        },
+        "vendorFunnel": {
+          "title": "Embudo de Proveedores",
+          "description": "Sigue cuántos están en negociación, contratados y finalizados."
+        },
+        "risk": {
+          "title": "Radar de Riesgos",
+          "description": "Señales de alerta consolidadas en un único panel."
+        },
+        "guests": {
+          "title": "Invitados y RSVP",
+          "description": "Tasa de respuesta, acompañantes, VIPs y distribución por grupo y ciudad."
+        },
+        "gifts": {
+          "title": "Regalos",
+          "description": "EFECTIVO × ARTÍCULO, agradecimientos pendientes, principales donantes y la cuota de la luna de miel."
+        },
+        "burndown": {
+          "title": "Burndown de Tareas",
+          "description": "Compara el ritmo ideal vs el real de las tareas completadas hasta la fecha del evento."
+        },
+        "honeymoon": {
+          "title": "Luna de Miel",
+          "description": "Estado por etapa y financiación con los regalos vía PIX."
+        },
+        "trousseau": {
+          "title": "Ajuar",
+          "description": "Progreso por habitación y elementos esenciales aún pendientes."
+        },
+        "waterfall": {
+          "title": "Variación por Categoría",
+          "description": "Waterfall que muestra dónde se excedió el presupuesto y por cuánto."
+        },
+        "activity": {
+          "title": "Cronología de Actividad",
+          "description": "Últimos cambios relevantes registrados en auditoría."
+        }
+      }
+    },
+    "activity": {
+      "back": "Volver a los informes",
+      "title": "Cronología de Actividad",
+      "subtitle": "Últimos 100 cambios registrados en el sistema. Filtra por entidad abajo.",
+      "filterAll": "Todas",
+      "empty": "Aún no hay registros de auditoría.",
+      "systemActor": "Sistema",
+      "action": {
+        "CREATE": "creó",
+        "UPDATE": "actualizó",
+        "DELETE": "eliminó",
+        "RESTORE": "restauró",
+        "MARK_PAID": "marcó como pagado",
+        "UNDO_PAID": "deshizo el pago",
+        "STATUS_CHANGE": "cambió el estado",
+        "UPLOAD": "subió",
+        "DOWNLOAD": "descargó",
+        "REPLACE": "reemplazó",
+        "SIGN": "firmó",
+        "ARCHIVE": "archivó",
+        "RESET_PASSWORD": "restableció la contraseña",
+        "RESET_2FA": "eliminó el 2FA",
+        "CHANGE_OWN_PASSWORD": "cambió su propia contraseña",
+        "LOGIN": "inició sesión",
+        "BULK_CREATE": "creó en masa",
+        "ASSIGN_TABLE": "asignó una mesa",
+        "UNASSIGN_TABLE": "quitó de una mesa",
+        "RSVP_GROUP_RESPOND": "respondió un RSVP en grupo",
+        "MARK_PIX_RECEIVED": "marcó PIX recibido",
+        "ONBOARDING_COUPLE": "completó la etapa de la pareja",
+        "ONBOARDING_BUDGET": "completó la etapa del presupuesto",
+        "ONBOARDING_FINISH": "finalizó la configuración inicial"
+      },
+      "entity": {
+        "Vendor": "proveedor",
+        "Payment": "pago",
+        "BudgetItem": "ítem de presupuesto",
+        "Asset": "activo",
+        "EventSettings": "ajustes del evento",
+        "User": "usuario",
+        "SecuritySettings": "ajustes de seguridad",
+        "SeatingTable": "mesa",
+        "Guest": "invitado",
+        "GuestGroup": "grupo de invitados",
+        "Gift": "regalo",
+        "Contract": "contrato",
+        "Attachment": "adjunto"
+      }
+    },
+    "gifts": {
+      "back": "Volver a los informes",
+      "title": "Regalos",
+      "subtitle": "Análisis de regalos recibidos: efectivo vs artículos, agradecimientos pendientes, cuota de la luna de miel y principales donantes.",
+      "type": {
+        "cash": "Efectivo",
+        "item": "Artículos"
+      },
+      "tiles": {
+        "count": "Regalos",
+        "totalCash": "Total en efectivo",
+        "cashCount": "En efectivo",
+        "thanked": "Agradecidos",
+        "thankedSub": "{count} de {total}",
+        "honeymoon": "Luna de miel (PIX)",
+        "contributions": "{count, plural, one {# contribución} other {# contribuciones}}",
+        "contributionsShort": "contribuciones"
+      },
+      "distribution": {
+        "title": "Distribución (EFECTIVO × ARTÍCULO)",
+        "giftCount": "{count, plural, one {# regalo} other {# regalos}}"
+      },
+      "cumulative": {
+        "title": "Captación acumulada",
+        "empty": "Sin datos de recepción.",
+        "legendAmount": "Acumulado (R$)",
+        "legendCount": "Cantidad"
+      },
+      "topGivers": {
+        "title": "Principales donantes",
+        "empty": "Sin regalos registrados.",
+        "giftCount": "{count, plural, one {# regalo} other {# regalos}}"
+      }
+    },
+    "guests": {
+      "back": "Volver a los informes",
+      "title": "Invitados y RSVP",
+      "subtitle": "Tasa de respuesta, acompañantes, VIPs, padrinos y distribución por grupo/ciudad.",
+      "status": {
+        "confirmed": "Confirmados",
+        "maybe": "Quizás",
+        "pending": "Pendientes",
+        "declined": "Rechazos"
+      },
+      "tiles": {
+        "invited": "Invitados",
+        "confirmed": "Confirmados",
+        "plusOnes": "+ Acompañantes",
+        "children": "Niños"
+      },
+      "rsvp": {
+        "title": "Estado del RSVP",
+        "peopleCount": "{count, plural, one {# persona} other {# personas}}",
+        "effectiveLabel": "Total efectivo (con +1):"
+      },
+      "byGroup": {
+        "title": "Por grupo",
+        "empty": "No hay grupos de invitados registrados."
+      },
+      "vips": {
+        "title": "VIPs y Padrinos",
+        "vipsConfirmed": "VIPs confirmados",
+        "padrinhosConfirmed": "Padrinos confirmados"
+      },
+      "cities": {
+        "title": "Principales ciudades",
+        "empty": "No se indicó ninguna ciudad."
+      }
+    },
+    "honeymoon": {
+      "back": "Volver a los informes",
+      "title": "Luna de Miel",
+      "subtitle": "Estado por etapa (PLANNED → PAID), por tipo de ítem y cobertura con la cuota de regalos vía PIX.",
+      "noPermission": {
+        "title": "Sin permiso",
+        "body": "Este informe expone valores financieros. Solicita acceso a un administrador."
+      },
+      "status": {
+        "paid": "Pagado",
+        "confirmed": "Confirmado",
+        "booked": "Reservado",
+        "planned": "Planificado",
+        "cancelled": "Cancelado"
+      },
+      "kind": {
+        "FLIGHT": "Vuelos",
+        "HOTEL": "Alojamiento",
+        "TRANSFER": "Traslado",
+        "ACTIVITY": "Actividades",
+        "DOCUMENT": "Documentos",
+        "BAGGAGE": "Equipaje",
+        "OTHER": "Otros"
+      },
+      "tiles": {
+        "items": "Ítems",
+        "booked": "Reservado",
+        "paid": "Pagado",
+        "fundedFromGifts": "Recibido vía PIX (cuota)"
+      },
+      "coverage": {
+        "title": "Cobertura por cuota",
+        "sublabel": "contribuciones vía PIX",
+        "empty": "Define un presupuesto total para la luna de miel para ver la cobertura."
+      },
+      "byKind": {
+        "title": "Por tipo de ítem",
+        "empty": "Aún no se han añadido ítems a la luna de miel."
+      },
+      "foreignCurrency": {
+        "title": "Valores en monedas extranjeras",
+        "body": "Los totales anteriores muestran valores en BRL. Ítems en otras monedas:"
+      }
+    },
+    "risk": {
+      "back": "Volver a los informes",
+      "title": "Radar de Riesgos",
+      "subtitle": "Señales consolidadas que merecen atención: liquidez, contratos a tiempo, tareas atrasadas y proveedores que excedieron el presupuesto estimado.",
+      "empty": "Sin señales de alerta en este momento. Buen trabajo.",
+      "tiles": {
+        "critical": "Críticos",
+        "warning": "Atención",
+        "ok": "Ok"
+      }
+    },
+    "trousseau": {
+      "back": "Volver a los informes",
+      "title": "Ajuar",
+      "subtitle": "Progreso por habitación y elementos esenciales aún pendientes.",
+      "status": {
+        "gifted": "Recibidos",
+        "bought": "Comprados",
+        "toBuy": "Por comprar"
+      },
+      "room": {
+        "KITCHEN": "Cocina",
+        "BATHROOM": "Baño",
+        "BEDROOM": "Dormitorio",
+        "LIVING": "Sala",
+        "LAUNDRY": "Lavandería",
+        "ELECTRONICS": "Electrónicos",
+        "OTHER": "Otros"
+      },
+      "tiles": {
+        "items": "Ítems",
+        "completion": "Finalización",
+        "estimated": "Estimado",
+        "byRoom": "Por habitación",
+        "actual": "Real",
+        "essentialsPending": "Esenciales pendientes"
+      },
+      "essentials": {
+        "warning": "{count, plural, one {# ítem ESSENTIAL aún en \"por comprar\"} other {# ítems ESSENTIAL aún en \"por comprar\"}}",
+        "hint": "Prioriza estos antes que los ítems NICE_TO_HAVE o LUXURY."
+      },
+      "overall": {
+        "title": "Progreso general",
+        "label": "Finalizado",
+        "sublabel": "{pct}% de {total} ítems"
+      },
+      "byRoom": {
+        "title": "Por habitación",
+        "empty": "Aún no se han añadido ítems al ajuar."
+      }
+    },
+    "vendorFunnel": {
+      "back": "Volver a los informes",
+      "title": "Embudo de Proveedores",
+      "subtitle": "Distribución por etapa y tiempo promedio entre negociación, contrato y finalización.",
+      "series": {
+        "negotiating": "Negociando",
+        "contracted": "Contratado",
+        "finalized": "Finalizado"
+      },
+      "tiles": {
+        "negotiation": "En negociación",
+        "contracted": "Contratados",
+        "finalized": "Finalizados"
+      },
+      "byCategory": {
+        "title": "Por categoría",
+        "vendorCount": "{count, plural, one {# proveedor} other {# proveedores}}"
+      },
+      "avg": {
+        "negToContract": "Tiempo promedio de negociación → contrato",
+        "contractToFinalized": "Tiempo promedio de contrato → finalización",
+        "daysUnit": "días"
+      }
+    }
+  },
+  "settings": {
+    "page": {
+      "title": "Ajustes",
+      "subtitle": "Configuración de la boda, el equipo y la seguridad."
+    },
+    "tabs": {
+      "event": "Boda",
+      "security": "Seguridad",
+      "team": "Equipo",
+      "notifications": "Notificaciones",
+      "whatsapp": "WhatsApp",
+      "profile": "Perfil",
+      "backup": "Copia de seguridad"
+    },
+    "toast": {
+      "failed": "Error"
+    },
+    "notifications": {
+      "title": "Envíos recientes",
+      "subtitle": "Últimos envíos de correo/WhatsApp. Usa esta lista para diagnosticar fallos de SMTP o destinatarios inválidos (p. ej., el admin@admin.com predeterminado del seed).",
+      "empty": "Aún no hay envíos registrados.",
+      "col": {
+        "when": "Cuándo",
+        "type": "Tipo",
+        "channel": "Canal",
+        "recipient": "Destinatario",
+        "status": "Estado",
+        "error": "Error"
+      }
+    },
+    "event": {
+      "title": "Datos de la boda",
+      "coupleNames": "Nombres de la pareja",
+      "eventDate": "Fecha del evento",
+      "currency": "Moneda",
+      "currencyBRL": "Real (BRL)",
+      "currencyUSD": "Dólar (USD)",
+      "currencyEUR": "Euro (EUR)",
+      "contingency": "Contingencia (%)",
+      "save": "Guardar",
+      "toast": {
+        "saved": "Configuración guardada",
+        "saveFailed": "Error al guardar",
+        "pixSaved": "Pix actualizado"
+      }
+    },
+    "pix": {
+      "title": "Pix (fondo de luna de miel)",
+      "subtitle": "Configura la clave Pix de la pareja para generar un código QR estático en los regalos en efectivo.",
+      "key": "Clave Pix",
+      "keyType": "Tipo de clave",
+      "typeCPF": "CPF",
+      "typeCNPJ": "CNPJ",
+      "typeEmail": "Correo",
+      "typePhone": "Teléfono",
+      "typeRandom": "Aleatoria",
+      "holderName": "Nombre del receptor (máx. 25)",
+      "city": "Ciudad del receptor (máx. 15)",
+      "save": "Guardar Pix"
+    },
+    "security": {
+      "loginRequired": "Inicia sesión para gestionar la seguridad.",
+      "requiredWarningStrong": "2FA obligatorio para tu rol ({role})",
+      "requiredWarningRest": ". Configúralo ahora para mantener el acceso garantizado.",
+      "title": "Autenticación en dos pasos (2FA)",
+      "descEnabled": "Activada — el inicio de sesión pide un código de tu app de autenticación.",
+      "descDisabled": "Añade una capa extra usando Google Authenticator, 1Password o similar.",
+      "badgeActive": "Activa",
+      "badgeInactive": "Inactiva",
+      "enable": "Activar 2FA",
+      "step1": "1. Escanea el código QR con tu app de autenticación (Google Authenticator, 1Password, Authy).",
+      "manualHint": "Si no puedes escanear, ingrésalo manualmente:",
+      "step2": "2. Confirma con el código actual que muestra la app.",
+      "codeLabel": "Código de 6 dígitos",
+      "confirmEnable": "Confirmar y activar",
+      "cancel": "Cancelar",
+      "backupTitle": "🔑 Guarda estos códigos de respaldo",
+      "backupHint": "Úsalos en lugar del código TOTP si pierdes acceso a la app. Cada uno solo funciona una vez.",
+      "backupDismiss": "Ya los anoté, ocultar",
+      "disableLabel": "Para desactivar, ingresa un código TOTP o de respaldo",
+      "disable": "Desactivar 2FA",
+      "toast": {
+        "enabled": "2FA activado",
+        "disabled": "2FA desactivado"
+      }
+    },
+    "team": {
+      "title": "Miembros",
+      "subtitleManage": "Crea usuarios directamente. El sistema envía las credenciales por correo y/o WhatsApp.",
+      "subtitleReadonly": "Solo los administradores y los novios pueden gestionar miembros.",
+      "newUser": "Nuevo usuario",
+      "searchPlaceholder": "Buscar por nombre o correo",
+      "allRoles": "Todos los roles",
+      "showArchived": "Mostrar archivados",
+      "noMembers": "No se encontraron miembros con los filtros actuales.",
+      "row": {
+        "you": "(tú)",
+        "joined": "se unió {date}",
+        "lastLogin": "último inicio de sesión {date}",
+        "archived": "Archivado",
+        "active": "Activo",
+        "inactive": "Inactivo",
+        "twoFactor": "2FA",
+        "tempPassword": "Contraseña provisional",
+        "actions": "Acciones"
+      },
+      "menu": {
+        "edit": "Editar",
+        "resetPassword": "Restablecer contraseña",
+        "reset2fa": "Restablecer 2FA",
+        "deactivate": "Desactivar",
+        "activate": "Reactivar",
+        "restore": "Restaurar",
+        "archive": "Archivar"
+      },
+      "confirm": {
+        "reset2faTitle": "¿Restablecer 2FA de {name}?",
+        "reset2faDesc": "Los códigos actuales dejarán de funcionar. El usuario tendrá que configurarlo de nuevo.",
+        "reset2faLabel": "Restablecer",
+        "activateTitle": "¿Reactivar a {name}?",
+        "deactivateTitle": "¿Desactivar a {name}?",
+        "activateDesc": "El usuario podrá iniciar sesión de nuevo.",
+        "deactivateDesc": "El usuario no podrá entrar hasta que sea reactivado.",
+        "activateLabel": "Reactivar",
+        "deactivateLabel": "Desactivar",
+        "archiveTitle": "¿Archivar a {name}?",
+        "archiveDesc": "El usuario se desactiva y desaparece de la lista (se puede restaurar después).",
+        "archiveLabel": "Archivar",
+        "restoreTitle": "¿Restaurar a {name}?",
+        "restoreDesc": "El usuario vuelve a la lista activa.",
+        "restoreLabel": "Restaurar"
+      },
+      "toast": {
+        "reset2fa": "2FA restablecido",
+        "activated": "Usuario reactivado",
+        "deactivated": "Usuario desactivado",
+        "archived": "Usuario archivado",
+        "restored": "Usuario restaurado",
+        "created": "Usuario creado",
+        "updated": "Usuario actualizado",
+        "passwordReset": "Contraseña restablecida — comparte la nueva con el usuario"
+      },
+      "password": {
+        "show": "Mostrar",
+        "hide": "Ocultar",
+        "generate": "Generar"
+      },
+      "create": {
+        "title": "Nuevo usuario",
+        "name": "Nombre",
+        "email": "Correo",
+        "phone": "Teléfono (WhatsApp, opcional)",
+        "phoneHint": "Formato E.164 (con + y código de país). Usado para enviar credenciales y recordatorios.",
+        "tempPassword": "Contraseña provisional (mínimo {min} caracteres)",
+        "mustChangeHint": "El usuario deberá cambiar la contraseña en el primer inicio de sesión.",
+        "role": "Rol",
+        "cancel": "Cancelar",
+        "submit": "Crear usuario"
+      },
+      "edit": {
+        "title": "Editar {name}",
+        "name": "Nombre",
+        "email": "Correo",
+        "phone": "Teléfono (WhatsApp, opcional)",
+        "role": "Rol",
+        "selfRoleHint": "No puedes cambiar tu propio rol.",
+        "cancel": "Cancelar",
+        "submit": "Guardar"
+      },
+      "reset": {
+        "title": "Restablecer contraseña de {name}",
+        "hint": "El usuario deberá cambiar la contraseña en el próximo inicio de sesión.",
+        "newPassword": "Nueva contraseña provisional",
+        "cancel": "Cancelar",
+        "submit": "Restablecer"
+      }
+    },
+    "policy": {
+      "title": "Política de seguridad",
+      "subtitle": "Define quién necesita 2FA obligatorio y la longitud mínima de la contraseña.",
+      "require2faLabel": "2FA obligatorio en los roles:",
+      "minPasswordLength": "Longitud mínima de la contraseña",
+      "save": "Guardar política",
+      "toast": {
+        "saved": "Política de seguridad guardada"
+      }
+    },
+    "profile": {
+      "loginRequired": "Inicia sesión para gestionar el perfil.",
+      "title": "Mi perfil",
+      "emailLabel": "Correo:",
+      "roleLabel": "Rol:",
+      "lastLogin": "Último inicio de sesión: {date}",
+      "passwordUpdatedAt": "Contraseña actualizada el {date}",
+      "passwordNeverChanged": "Contraseña nunca cambiada",
+      "displayName": "Nombre para mostrar",
+      "saveName": "Guardar nombre",
+      "changePasswordTitle": "Cambiar mi contraseña",
+      "changePasswordHint": "Ingresa la contraseña actual y la nueva. La nueva debe ser diferente de la actual.",
+      "currentPassword": "Contraseña actual",
+      "newPassword": "Nueva contraseña",
+      "updatePassword": "Actualizar contraseña",
+      "twoFactorTitle": "Autenticación en dos pasos",
+      "twoFactorEnabled": "Activada. Puedes desactivarla en la pestaña Seguridad.",
+      "twoFactorDisabled": "Inactiva. Actívala en la pestaña Seguridad para reforzar tu cuenta.",
+      "twoFactorSeeTab": "Consulta la pestaña “Seguridad” para configurarla.",
+      "toast": {
+        "nameUpdated": "Nombre actualizado",
+        "passwordUpdated": "Contraseña actualizada"
+      }
+    },
+    "backup": {
+      "exportTitle": "Exportar copia de seguridad",
+      "exportSubtitle": "Descarga un JSON con proveedores, pagos, aportes, configuración, invitados y todo lo demás. Incluye checksum SHA-256 para validación.",
+      "exportButton": "Exportar copia JSON",
+      "exportHint": "Haz una copia mensual y antes/después de la boda. Guárdala en un lugar seguro — el archivo contiene datos sensibles.",
+      "restoreTitle": "Restaurar copia de seguridad",
+      "restoreSubtitleAdmin": "Carga un JSON exportado por este sistema. La restauración borra y recrea todos los datos en la transacción. Solo administradores.",
+      "restoreSubtitleReadonly": "Solo los administradores pueden restaurar copias. Puedes validar el archivo aquí, pero la restauración requiere el rol ADMIN.",
+      "fileLabel": "Archivo .json",
+      "validateButton": "Validar archivo",
+      "clear": "Limpiar",
+      "warnStrong": "La restauración borra TODOS los datos actuales",
+      "warnRest": " y los reemplaza por los del archivo. Esta operación no se puede deshacer. Haz una copia antes.",
+      "passwordLabel": "Tu contraseña (confirmación)",
+      "acknowledgeStart": "Entiendo que esta acción",
+      "acknowledgeStrong": "borra todos los datos",
+      "acknowledgeEnd": " del sistema y los reemplaza por los del archivo. Ya hice una copia antes.",
+      "restoreNow": "Restaurar ahora",
+      "restoreDone": "Restauración completada.",
+      "totalRestored": "Total restaurado:",
+      "zeroRecords": "0 registros",
+      "accountPreserved": "Tu cuenta se conservó porque no estaba en la copia.",
+      "confirm": {
+        "title": "Confirmar restauración",
+        "description": "Esta acción es IRREVERSIBLE. Todos los datos actuales serán reemplazados por los del archivo. ¿Continuar?",
+        "restoring": "Restaurando…",
+        "confirmLabel": "Sí, restaurar",
+        "cancel": "Cancelar"
+      },
+      "toast": {
+        "selectFirst": "Selecciona primero un archivo de copia de seguridad.",
+        "invalidFile": "Archivo de copia inválido.",
+        "validated": "Archivo de copia validado.",
+        "validateFailed": "Error al validar el archivo",
+        "restoreFailed": "Error al restaurar la copia.",
+        "restored": "Copia restaurada con éxito. Recargando…",
+        "restoreError": "Error al restaurar"
+      },
+      "validation": {
+        "invalid": "Archivo inválido",
+        "root": "(raíz)",
+        "moreIssues": "...y {count} problemas más.",
+        "summary": "✓ Copia v{version} válida — {rows} registros, exportada el {date}.",
+        "host": "host: {host}",
+        "app": "app: v{version}",
+        "checksum": "checksum:"
+      }
+    },
+    "modal": {
+      "close": "Cerrar"
+    },
+    "whatsapp": {
+      "title": "WhatsApp",
+      "subtitle": "Conecta un número para enviar credenciales, recordatorios y restablecimientos de contraseña por WhatsApp.",
+      "needsManualAction": "Acción necesaria: la sesión expiró o fue desvinculada. Haz clic en \"Conectar\" para generar un nuevo código QR.",
+      "reconnecting": "Reconectando automáticamente · intentos: {attempts}",
+      "lastDisconnect": "cayó el {date}",
+      "qrInstructions": "Abre WhatsApp en el móvil → Configuración → Dispositivos vinculados → Vincular un dispositivo. Escanea:",
+      "qrAlt": "Código QR de WhatsApp",
+      "disconnect": "Desconectar",
+      "reopenQr": "Reabrir QR",
+      "connect": "Conectar",
+      "refresh": "Actualizar",
+      "testTitle": "Enviar mensaje de prueba",
+      "sendTest": "Enviar prueba",
+      "status": {
+        "connected": "Conectado",
+        "connectedWithPhone": "Conectado ({phone})",
+        "waitingQr": "Esperando lectura del código QR",
+        "connecting": "Conectando...",
+        "disconnected": "Desconectado"
+      },
+      "toast": {
+        "connecting": "Iniciando conexión. Escanea el código QR.",
+        "disconnected": "WhatsApp desconectado",
+        "numberRequired": "Indica un número",
+        "testSent": "Mensaje de prueba enviado"
+      }
+    }
+  },
+  "tasks": {
+    "page": {
+      "title": "Tareas",
+      "subtitle": "Usa la plantilla lista de 12 meses o crea tareas sueltas. Se exporta al calendario."
+    },
+    "toast": {
+      "created": "Tarea creada",
+      "updated": "Tarea actualizada",
+      "removed": "Tarea eliminada",
+      "failed": "Error",
+      "templatesAllExist": "Todas las tareas de la plantilla ya existen",
+      "templatesCreated": "{count, plural, one {# tarea creada} other {# tareas creadas}}"
+    },
+    "filter": {
+      "all": "Todas",
+      "open": "Abiertas",
+      "overdue": "Atrasadas",
+      "week": "Próximos 7 días"
+    },
+    "view": {
+      "list": "Lista",
+      "kanban": "Kanban"
+    },
+    "toolbar": {
+      "exportIcs": "Exportar (.ics)",
+      "loadTemplate": "Cargar plantilla",
+      "newTask": "Nueva tarea"
+    },
+    "delete": {
+      "title": "¿Eliminar tarea?",
+      "titleNamed": "¿Eliminar \"{title}\"?"
+    },
+    "list": {
+      "empty": "No hay tareas en este filtro."
+    },
+    "kanban": {
+      "empty": "Vacío"
+    },
+    "row": {
+      "complete": "Completar",
+      "reopen": "Reabrir",
+      "template": "plantilla"
+    },
+    "status": {
+      "TODO": "Por hacer",
+      "IN_PROGRESS": "En curso",
+      "DONE": "Completada",
+      "BLOCKED": "Bloqueada"
+    },
+    "priority": {
+      "LOW": "Baja",
+      "MEDIUM": "Media",
+      "HIGH": "Alta",
+      "URGENT": "Urgente"
+    },
+    "form": {
+      "createTitle": "Nueva tarea",
+      "editTitle": "Editar tarea",
+      "title": "Título",
+      "deadline": "Plazo",
+      "responsible": "Responsable",
+      "responsiblePlaceholder": "novio / novia / wedding planner",
+      "priority": "Prioridad",
+      "vendor": "Proveedor",
+      "venue": "Lugar"
+    }
+  },
+  "trousseau": {
+    "page": {
+      "title": "Ajuar",
+      "subtitle": "Anota lo que aún falta comprar, marca la prioridad y controla el presupuesto por habitación."
+    },
+    "stats": {
+      "estimated": "Estimado",
+      "bought": "Comprado",
+      "toBuy": "Por comprar",
+      "gifted": "Regalado"
+    },
+    "filter": {
+      "all": "Todos"
+    },
+    "status": {
+      "TO_BUY": "Por comprar",
+      "BOUGHT": "Comprado",
+      "GIFTED": "Regalado"
+    },
+    "room": {
+      "KITCHEN": "Cocina",
+      "BATHROOM": "Baño",
+      "BEDROOM": "Dormitorio",
+      "LIVING": "Sala",
+      "LAUNDRY": "Lavandería",
+      "ELECTRONICS": "Electrodomésticos",
+      "OTHER": "Otros"
+    },
+    "priority": {
+      "ESSENTIAL": "Esencial",
+      "NICE_TO_HAVE": "Deseable",
+      "LUXURY": "Lujo"
+    },
+    "list": {
+      "add": "Nuevo artículo",
+      "empty": "Aún no hay nada aquí."
+    },
+    "card": {
+      "paid": "(pagado: {value})",
+      "storeLink": "Enlace de la tienda",
+      "toggleBought": "Alternar comprado",
+      "toggleGifted": "Regalado"
+    },
+    "confirmDelete": {
+      "title": "¿Eliminar artículo?"
+    },
+    "form": {
+      "createTitle": "Nuevo artículo del ajuar",
+      "editTitle": "Editar artículo",
+      "item": "Artículo",
+      "room": "Habitación",
+      "priority": "Prioridad",
+      "estimatedPrice": "Precio estimado",
+      "actualPrice": "Precio pagado",
+      "store": "Tienda",
+      "link": "Enlace",
+      "notes": "Notas"
+    },
+    "toast": {
+      "created": "Artículo añadido",
+      "updated": "Artículo actualizado",
+      "deleted": "Artículo eliminado"
+    }
+  },
+  "vendors": {
+    "page": {
+      "title": "Proveedores"
+    },
+    "list": {
+      "new": "Nuevo proveedor",
+      "empty": "Aún no hay proveedores registrados.",
+      "noResults": "Sin resultados para el filtro.",
+      "searchPlaceholder": "Buscar proveedor..."
+    },
+    "filter": {
+      "allStatus": "Todos los estados"
+    },
+    "status": {
+      "negotiation": "En negociación",
+      "contracted": "Contratado",
+      "finalized": "Finalizado"
+    },
+    "value": {
+      "real": "Real",
+      "estimated": "Estimado"
+    },
+    "table": {
+      "category": "Categoría",
+      "select": "Seleccionar",
+      "selectVendor": "Seleccionar {name}"
+    },
+    "compareButton": {
+      "label": "Comparar ({count})",
+      "selectMore": "Selecciona 1 más para comparar"
+    },
+    "statusPrompt": {
+      "message": "¿Cuál es el importe REAL contratado con {name}? (solo números, ej.: 12500.00)",
+      "invalidValue": "Importe inválido"
+    },
+    "form": {
+      "createTitle": "Nuevo proveedor",
+      "editTitle": "Editar {name}",
+      "name": "Nombre",
+      "namePlaceholder": "Ej.: Catering Colonial",
+      "category": "Categoría",
+      "categoryChoose": "— elegir —",
+      "freeLabel": "Etiqueta libre",
+      "freeLabelPlaceholder": "Ej.: Alimentación",
+      "estimatedValue": "Importe estimado ($)",
+      "estimatedValuePlaceholder": "Ej.: 15000.00",
+      "actualValue": "Importe real ($)",
+      "actualValuePlaceholder": "Vacío = aún no cerrado",
+      "contractLink": "Enlace del contrato (opcional)",
+      "notes": "Notas",
+      "notesPlaceholder": "Observaciones, contactos, condiciones...",
+      "saveChanges": "Guardar cambios"
+    },
+    "delete": {
+      "title": "¿Eliminar proveedor?",
+      "titleNamed": "¿Eliminar {name}?",
+      "description": "Esta acción hará un borrado lógico del proveedor, sus presupuestos y pagos asociados.\nYa no verás estos registros en los listados."
+    },
+    "toast": {
+      "created": "Proveedor creado",
+      "createFailed": "Error al crear",
+      "updated": "Proveedor actualizado",
+      "updateFailed": "Error al actualizar",
+      "deleted": "Proveedor eliminado",
+      "deleteFailed": "Error al eliminar",
+      "statusUpdated": "Estado actualizado",
+      "failed": "Error"
+    },
+    "compare": {
+      "back": "Volver a proveedores",
+      "title": "Comparar propuestas",
+      "hint": "Marca de 2 a 4 proveedores en la lista y haz clic en \"Comparar\".",
+      "comparing": "{count, plural, one {Comparando # proveedor.} other {Comparando # proveedores.}}",
+      "criterion": "Criterio",
+      "open": "Abrir →",
+      "legend": "💡 El verde en el precio marca el más barato; ⭐ en la valoración marca el mejor valorado.",
+      "status": {
+        "negotiation": "En negociación",
+        "contracted": "Contratado",
+        "finalized": "Finalizado"
+      },
+      "row": {
+        "status": "Estado",
+        "rating": "Valoración",
+        "totalValue": "Importe total",
+        "paid": "Ya pagado",
+        "balance": "Saldo",
+        "indicatedBy": "Recomendado por",
+        "tags": "Etiquetas",
+        "counts": "Contactos / Contratos / Adjuntos",
+        "notes": "Notas",
+        "lastInteraction": "Última interacción",
+        "contractLink": "Enlace contrato"
+      },
+      "empty": {
+        "title": "Ningún proveedor seleccionado.",
+        "description": "Vuelve a la lista, marca las casillas de los proveedores que quieres comparar y haz clic en \"Comparar\".",
+        "cta": "Ir a proveedores →"
+      }
+    },
+    "detail": {
+      "back": "Volver a proveedores",
+      "status": {
+        "negotiation": "En negociación",
+        "contracted": "Contratado",
+        "finalized": "Finalizado"
+      },
+      "header": {
+        "indicatedBy": "Recomendado por: {name}",
+        "contractLink": "Enlace del contrato",
+        "budgeted": "Presupuestado",
+        "paid": "Ya pagado",
+        "balance": "Saldo"
+      },
+      "toast": {
+        "failed": "Error"
+      },
+      "contacts": {
+        "title": "Contactos",
+        "empty": "No hay contactos registrados.",
+        "primary": "Principal",
+        "deleteAria": "Eliminar contacto",
+        "formTitle": "Nuevo contacto",
+        "name": "Nombre",
+        "role": "Función (ej.: gerente, recepción)",
+        "isPrimary": "Contacto principal",
+        "removeTitle": "¿Eliminar contacto?",
+        "added": "Contacto añadido",
+        "removed": "Contacto eliminado"
+      },
+      "notes": {
+        "title": "Notas y negociación",
+        "bodyPlaceholder": "Anota lo que pasó, decidiste, acordaste...",
+        "add": "Añadir",
+        "empty": "Aún no hay notas. Usa este espacio como historial de negociación.",
+        "deleteAria": "Eliminar nota",
+        "removeTitle": "¿Eliminar nota?",
+        "added": "Nota añadida",
+        "removed": "Nota eliminada"
+      },
+      "noteKind": {
+        "NOTE": "Nota",
+        "NEGOTIATION_EVENT": "Negociación",
+        "MEETING": "Reunión",
+        "DECISION": "Decisión"
+      },
+      "contracts": {
+        "title": "Contratos",
+        "empty": "No hay contratos registrados. Úsalo para guardar cláusulas clave y versiones.",
+        "value": "Importe",
+        "signed": "Firmado",
+        "expires": "Vence",
+        "paymentTerms": "Condiciones de pago",
+        "cancellationPolicy": "Política de cancelación",
+        "included": "Incluido",
+        "excluded": "No incluido",
+        "notes": "Observaciones",
+        "deleteAria": "Eliminar contrato",
+        "removeTitle": "¿Eliminar contrato?",
+        "removeDescription": "El contrato se eliminará del listado pero puede recuperarse desde la base de datos.",
+        "created": "Contrato creado",
+        "removed": "Contrato eliminado"
+      },
+      "contractStatus": {
+        "DRAFT": "Borrador",
+        "SENT": "Enviado",
+        "NEGOTIATING": "En negociación",
+        "SIGNED_DIGITAL": "Firmado (digital)",
+        "SIGNED_PHYSICAL": "Firmado (físico)",
+        "CANCELLED": "Cancelado"
+      },
+      "contractForm": {
+        "title": "Nuevo contrato",
+        "titleLabel": "Título",
+        "titlePlaceholder": "Ej.: Contrato Catering Colonial",
+        "totalValue": "Importe total ($)",
+        "signedAt": "Fecha de firma",
+        "expiresAt": "Validez / expiración",
+        "includedItems": "Lo que está incluido",
+        "excludedItems": "Lo que NO está incluido",
+        "save": "Guardar contrato"
+      },
+      "contractFile": {
+        "noViewPermission": "Documento del contrato disponible, pero tu perfil no tiene permiso para visualizarlo.",
+        "title": "Archivo del contrato",
+        "inlineFallback": "El navegador no pudo mostrar el PDF en línea.",
+        "openNewTab": "Abrir el contrato en una pestaña nueva",
+        "uploadedAt": "subido el {date}",
+        "uploadedBy": "por {name}",
+        "downloadPdf": "Descargar PDF",
+        "noPdfYet": "Aún no hay PDF adjunto a este contrato.",
+        "replaceLabel": "Reemplazar contrato (pasa a v{version})",
+        "uploadLabel": "Subir PDF del contrato",
+        "onlyPdf": "Solo PDF, hasta 8 MB.",
+        "send": "Subir",
+        "markSigned": "Marcar como firmado:",
+        "signDigital": "Firma digital",
+        "signPhysical": "Firma física",
+        "historyShow": "Ver historial ({count, plural, one {# versión} other {# versiones}})",
+        "historyHide": "Ocultar historial ({count, plural, one {# versión} other {# versiones}})",
+        "download": "Descargar",
+        "newVersionTitle": "¿Crear nueva versión v{version}?",
+        "newVersionDescription": "La versión actual se archivará (se conserva en el historial por 30 días). ¿Estás seguro?",
+        "confirmReplace": "Sí, reemplazar",
+        "updated": "Contrato actualizado",
+        "newVersionToast": "Nueva versión v{version}",
+        "pdfSent": "PDF del contrato subido",
+        "keptVersionToast": "Mantenido como v{version}",
+        "signed": "Contrato firmado"
+      },
+      "attachments": {
+        "title": "Adjuntos",
+        "fileLabel": "Archivo (PDF/PNG/JPG, hasta 10MB)",
+        "kindLabel": "Tipo",
+        "send": "Subir",
+        "empty": "No hay archivos adjuntos.",
+        "deleteAria": "Eliminar adjunto",
+        "removeTitle": "¿Eliminar adjunto?",
+        "uploaded": "Archivo adjuntado",
+        "removed": "Adjunto eliminado"
+      },
+      "attachmentKind": {
+        "CONTRACT": "Contrato",
+        "PROPOSAL": "Propuesta",
+        "RECEIPT": "Comprobante",
+        "INVOICE": "Factura / Recibo",
+        "ID_DOC": "Documento",
+        "PHOTO": "Foto",
+        "OTHER": "Otro"
+      },
+      "payments": {
+        "title": "Pagos",
+        "empty": "No hay pagos. Usa la pestaña Pagos para añadir.",
+        "paid": "Pagado",
+        "pending": "Pendiente",
+        "manage": "Gestionar pagos →"
+      }
+    }
+  },
+  "venues": {
+    "page": {
+      "title": "Lugares",
+      "subtitle": "Compara candidatos, anota pros y contras y mantén al día la lista de la visita."
+    },
+    "list": {
+      "new": "Nuevo lugar",
+      "empty": "Aún no hay lugares registrados. Agrega candidatos para compararlos lado a lado.",
+      "favorite": "Favorito",
+      "deleteAria": "Eliminar lugar",
+      "checklistCount": "Lista {done}/{total}",
+      "attachments": "{count, plural, one {# adjunto} other {# adjuntos}}",
+      "visitedOn": "Visitado el {date}",
+      "noVisit": "Sin visita"
+    },
+    "fields": {
+      "seated": "Sentados",
+      "standing": "De pie",
+      "rate": "Alquiler",
+      "name": "Nombre",
+      "address": "Dirección",
+      "mapsUrl": "Enlace de Google Maps / Waze",
+      "baseRate": "Precio de alquiler ($)",
+      "capacitySeated": "Capacidad sentados",
+      "capacityStanding": "Capacidad de pie",
+      "contactName": "Contacto (nombre)",
+      "contactPhone": "Contacto (teléfono)",
+      "visitedAt": "Fecha de la visita",
+      "pros": "Pros",
+      "cons": "Contras",
+      "restrictions": "Restricciones",
+      "pricingNotes": "Notas de precio",
+      "notes": "Notas generales"
+    },
+    "form": {
+      "namePlaceholder": "Ej.: Villa del Lago",
+      "markFavorite": "Marcar como favorito",
+      "seedChecklist": "Crear la lista estándar de visita (20 preguntas)"
+    },
+    "delete": {
+      "confirmTitle": "¿Eliminar {name}?",
+      "confirmTitleFallback": "¿Eliminar lugar?",
+      "confirmDescription": "El lugar y la lista se quitarán de los listados.",
+      "confirmDescriptionDetail": "El lugar y la lista se marcarán como eliminados."
+    },
+    "toast": {
+      "created": "Lugar creado",
+      "removed": "Lugar eliminado",
+      "updated": "Actualizado",
+      "fail": "Error"
+    },
+    "detail": {
+      "back": "Volver a lugares",
+      "contactLabel": "Contacto:",
+      "openMaps": "Abrir en Maps",
+      "closeEdit": "Cerrar edición",
+      "deleteVenue": "Eliminar lugar"
+    },
+    "editForm": {
+      "title": "Editar lugar",
+      "mapsUrl": "Enlace de Maps",
+      "baseRate": "Alquiler ($)",
+      "contactName": "Contacto",
+      "contactPhone": "Teléfono",
+      "visitedAt": "Visitado el",
+      "favorite": "Favorito",
+      "pricingNotes": "Notas de precio"
+    },
+    "checklist": {
+      "title": "Lista de la visita",
+      "answered": "{done}/{total} respondidas",
+      "answerPlaceholder": "Anota la respuesta",
+      "deleteItemAria": "Eliminar elemento",
+      "addPlaceholder": "Nueva pregunta para la lista..."
+    },
+    "attachments": {
+      "title": "Adjuntos",
+      "file": "Archivo",
+      "kind": "Tipo",
+      "kinds": {
+        "PHOTO": "Foto de la visita",
+        "CONTRACT": "Contrato",
+        "PROPOSAL": "Propuesta",
+        "OTHER": "Otro"
+      },
+      "upload": "Enviar",
+      "empty": "Aún no hay adjuntos.",
+      "removed": "Adjunto eliminado",
+      "deleteAria": "Eliminar adjunto",
+      "deleteTitle": "¿Eliminar adjunto?"
+    }
+  },
+  "weddingDay": {
+    "header": {
+      "mode": "Modo Día de la Boda",
+      "fallbackTitle": "El gran día",
+      "countdown": "Cuenta regresiva",
+      "daysLeft": "{count, plural, one {# día} other {# días}}"
+    },
+    "stats": {
+      "confirmed": "Confirmados",
+      "totalHeads": "Total de asistentes",
+      "arrived": "Llegaron",
+      "tasksToday": "Tareas del día"
+    },
+    "seatingLink": {
+      "title": "Plano de mesas",
+      "description": "Organiza las mesas y arrastra a los invitados confirmados a sus lugares."
+    },
+    "schedule": {
+      "title": "Cronograma del día",
+      "empty": "Aún no se agregó ningún cronograma. Usa el botón de abajo para registrarlo (ej.: 07:00 peluquero, 14:00 llegada del catering...).",
+      "placeholder": "Ej.:\n07:00 — llega el peluquero\n11:00 — fotos de preparativos\n16:30 — ceremonia\n..."
+    },
+    "rainPlan": {
+      "title": "Plan B lluvia / contingencias",
+      "empty": "Sin plan B documentado."
+    },
+    "notes": {
+      "title": "Observaciones especiales",
+      "empty": "Sin observaciones.",
+      "closeEdit": "Cerrar edición",
+      "openEdit": "Editar cronograma / plan B / observaciones",
+      "placeholder": "Canción del primer baile, vals, sorpresa, sabores del pastel..."
+    },
+    "contacts": {
+      "title": "Contactos clave",
+      "empty": "Sin proveedores contratados.",
+      "addContact": "Registrar contacto"
+    },
+    "tasks": {
+      "title": "Tareas del día",
+      "empty": "Ninguna tarea programada para hoy."
+    },
+    "payments": {
+      "title": "Pagos del día"
+    },
+    "checkin": {
+      "title": "Registro rápido",
+      "searchPlaceholder": "Buscar invitado...",
+      "empty": "Ningún invitado.",
+      "childPrefix": "Niño · ",
+      "arrived": "Llegó",
+      "mark": "Registrar"
+    },
+    "toast": {
+      "saved": "Guardado",
+      "error": "Error"
+    },
+    "seating": {
+      "title": "Plano de mesas",
+      "subtitle": "Arrastra a los invitados confirmados a las mesas. La capacidad considera los +1.",
+      "newTable": "Nueva mesa",
+      "stats": {
+        "tables": "Mesas",
+        "totalSeats": "Asientos totales",
+        "allocatedGuests": "Invitados asignados"
+      },
+      "hint": {
+        "empty": "Crea la primera mesa para empezar.",
+        "help": "Suelta a un invitado en una mesa para asignarlo; arrastra desde el asa para reordenar."
+      },
+      "table": {
+        "dropGuests": "Suelta invitados aquí"
+      },
+      "pool": {
+        "title": "Grupo de invitados",
+        "empty": "Todos los confirmados están asignados. Suelta aquí para quitar la asignación."
+      },
+      "form": {
+        "createTitle": "Nueva mesa",
+        "editTitle": "Editar mesa",
+        "capacity": "Capacidad",
+        "shape": "Forma",
+        "saving": "Guardando..."
+      },
+      "shape": {
+        "round": "Redonda",
+        "rect": "Rectangular",
+        "square": "Cuadrada"
+      },
+      "delete": {
+        "title": "¿Eliminar mesa?",
+        "description": "La mesa \"{name}\" se eliminará y sus invitados quedarán sin asignación."
+      },
+      "toast": {
+        "errorTitle": "Error",
+        "error": "Error",
+        "created": "Mesa creada",
+        "updated": "Mesa actualizada",
+        "deleted": "Mesa eliminada",
+        "tableFull": "Mesa llena",
+        "tableFullDetail": "Capacidad {capacity}, ocupados {used}, necesario {needed}"
+      },
+      "chip": {
+        "dragAria": "Arrastrar {name}"
+      },
+      "card": {
+        "reorderAria": "Reordenar mesa",
+        "editAria": "Editar mesa",
+        "deleteAria": "Eliminar mesa"
+      }
+    }
+  }
+}

--- a/src/messages/pt-BR/actions.json
+++ b/src/messages/pt-BR/actions.json
@@ -1,4 +1,31 @@
 {
+  "asset": {
+    "notFound": "Aporte não encontrado",
+    "errorCreate": "Erro ao criar aporte",
+    "errorUpdate": "Erro ao atualizar aporte",
+    "errorDelete": "Erro ao excluir aporte"
+  },
+  "attachment": {
+    "notFound": "Anexo não encontrado",
+    "vendorNotFound": "Fornecedor não encontrado",
+    "contractNotFound": "Contrato não encontrado",
+    "venueNotFound": "Local não encontrado",
+    "noPermission": "Sem permissão",
+    "noPermissionEdit": "Sem permissão para editar",
+    "noPermissionKind": "Sem permissão para este tipo de anexo",
+    "noPermissionView": "Sem permissão para este anexo",
+    "onlyAdminCoupleRemoveContract": "Apenas administrador, noivo ou noiva podem remover contratos.",
+    "rateLimitUser": "Muitos uploads em sequência. Tente novamente em 1 minuto.",
+    "rateLimitIp": "Limite de uploads excedido.",
+    "invalidTarget": "Destino inválido",
+    "fileRequired": "Arquivo obrigatório",
+    "errorUpload": "Erro ao enviar arquivo",
+    "errorDelete": "Erro ao excluir anexo"
+  },
+  "auth": {
+    "invalidCredentials": "Credenciais inválidas.",
+    "loginGenericError": "Algo deu errado ao fazer o login."
+  },
   "common": {
     "unauthorized": "Não autorizado",
     "forbidden": "Acesso negado",
@@ -6,9 +33,96 @@
     "notFound": "Não encontrado",
     "generic": "Algo deu errado. Tente novamente."
   },
-  "auth": {
-    "invalidCredentials": "Credenciais inválidas.",
-    "loginGenericError": "Algo deu errado ao fazer o login."
+  "contract": {
+    "notFound": "Contrato não encontrado",
+    "noPermissionSign": "Sem permissão para assinar",
+    "noPermissionUpload": "Sem permissão para enviar contrato",
+    "rateLimitUser": "Muitos uploads em sequência. Tente novamente em 1 minuto.",
+    "rateLimitIp": "Limite de uploads excedido.",
+    "invalidTarget": "Destino inválido",
+    "fileRequired": "Arquivo obrigatório",
+    "errorCreate": "Erro ao criar contrato",
+    "errorUpdate": "Erro ao atualizar contrato",
+    "errorDelete": "Erro ao excluir contrato",
+    "errorSign": "Erro ao registrar assinatura",
+    "errorUpload": "Erro ao enviar contrato"
+  },
+  "gift": {
+    "notFound": "Presente não encontrado",
+    "errorCreating": "Erro ao registrar presente",
+    "errorUpdating": "Erro ao atualizar presente",
+    "errorUpdatingShort": "Erro ao atualizar",
+    "errorDeleting": "Erro ao excluir presente",
+    "errorMarkingPix": "Erro ao marcar Pix recebido",
+    "pixAlreadyReceived": "Pix já marcado como recebido",
+    "assetTitle": "Pix de {giver}{honeymoon}",
+    "assetGuestFallback": "convidado",
+    "assetHoneymoonSuffix": " (cota lua de mel)",
+    "assetNotes": "Gerado a partir do presente #{id}"
+  },
+  "goal": {
+    "notFound": "Meta não encontrada",
+    "errorCreate": "Erro ao criar meta",
+    "errorUpdate": "Erro ao atualizar meta",
+    "errorDelete": "Erro ao excluir meta"
+  },
+  "guest": {
+    "errorCreating": "Erro ao criar convidado",
+    "notFound": "Convidado não encontrado",
+    "errorUpdating": "Erro ao atualizar convidado",
+    "errorDeleting": "Erro ao excluir convidado",
+    "errorCheckin": "Erro ao registrar presença",
+    "noLinesFound": "Nenhuma linha encontrada",
+    "errorImporting": "Erro ao importar",
+    "tooManyAttempts": "Muitas tentativas. Tente novamente em alguns minutos.",
+    "inviteNotFound": "Convite não encontrado",
+    "linkExpired": "Link expirado. Solicite um novo convite.",
+    "errorRsvp": "Erro ao registrar resposta",
+    "tooManyUploads": "Muitos uploads em sequência. Aguarde 1 minuto.",
+    "uploadLimitExceeded": "Limite de uploads excedido.",
+    "fileRequired": "Arquivo obrigatório",
+    "unknownSource": "Origem desconhecida",
+    "unsupportedFormat": "Formato não suportado. Use .xlsx (Wedy) ou .csv (exportação do próprio sistema).",
+    "unrecognizedFormat": "Não foi possível identificar o formato. Suportados: Wedy (.xlsx) ou CSV exportado pelo próprio sistema.",
+    "noValidRows": "Nenhuma linha válida encontrada na planilha.",
+    "rowLimit": "Limite de {max} linhas por importação.",
+    "errorProcessingFile": "Erro ao processar arquivo",
+    "importSessionExpired": "Sessão de importação expirou. Reenvie o arquivo.",
+    "errorCommittingImport": "Erro ao gravar importação"
+  },
+  "guestGroup": {
+    "errorCreating": "Erro ao criar grupo",
+    "notFound": "Grupo não encontrado",
+    "errorUpdating": "Erro ao atualizar grupo",
+    "invalidId": "ID inválido",
+    "errorDeleting": "Erro ao excluir grupo",
+    "errorUpdatingMembers": "Erro ao atualizar membros",
+    "tooManyAttempts": "Muitas tentativas. Tente novamente em alguns minutos.",
+    "groupInviteNotFound": "Convite de grupo não encontrado",
+    "linkExpired": "Link expirado. Solicite um novo convite.",
+    "guestOutsideGroup": "Resposta inválida (convidado fora do grupo)",
+    "errorRsvp": "Erro ao registrar respostas"
+  },
+  "honeymoon": {
+    "itemNotFound": "Item não encontrado",
+    "errorSaving": "Erro ao salvar",
+    "errorAdding": "Erro ao adicionar",
+    "errorUpdating": "Erro ao atualizar",
+    "errorDeleting": "Erro ao excluir"
+  },
+  "income": {
+    "notFound": "Receita não encontrada",
+    "errorCreate": "Erro ao criar receita",
+    "errorUpdate": "Erro ao atualizar receita",
+    "errorMarkReceived": "Erro ao marcar como recebida",
+    "errorDelete": "Erro ao excluir receita"
+  },
+  "onboarding": {
+    "coupleNameRequired": "Informe o nome do casal",
+    "invalidDate": "Data inválida",
+    "errorCouple": "Erro ao salvar dados do casal",
+    "errorBudget": "Erro ao salvar orçamento",
+    "errorFinish": "Erro ao concluir onboarding"
   },
   "passwordReset": {
     "invalidEmail": "Email inválido",
@@ -19,12 +133,18 @@
     "userNotFoundOrInactive": "Usuário não encontrado ou inativo",
     "errorResetting": "Erro ao redefinir senha"
   },
-  "onboarding": {
-    "coupleNameRequired": "Informe o nome do casal",
-    "invalidDate": "Data inválida",
-    "errorCouple": "Erro ao salvar dados do casal",
-    "errorBudget": "Erro ao salvar orçamento",
-    "errorFinish": "Erro ao concluir onboarding"
+  "payment": {
+    "vendorNotFound": "Fornecedor não encontrado",
+    "notFound": "Pagamento não encontrado",
+    "notFoundOrPaid": "Pagamento não encontrado ou já pago",
+    "cannotUndo": "Não é possível estornar este pagamento",
+    "errorCreate": "Erro ao criar pagamento",
+    "errorUpdate": "Erro ao atualizar pagamento",
+    "errorMarkPaid": "Erro ao quitar pagamento",
+    "errorUndo": "Erro ao estornar pagamento",
+    "errorDelete": "Erro ao excluir pagamento",
+    "errorSplit": "Erro ao criar pagamentos divididos",
+    "errorInstallments": "Erro ao gerar parcelas"
   },
   "profile": {
     "invalidLocale": "Idioma inválido",
@@ -34,5 +154,109 @@
     "wrongPassword": "Senha atual incorreta",
     "emailTaken": "Já existe um usuário com este e-mail",
     "emailUpdated": "E-mail atualizado. Use-o no próximo login."
+  },
+  "seatingTable": {
+    "errorCreate": "Erro ao criar mesa",
+    "tableNotFound": "Mesa não encontrada",
+    "errorUpdate": "Erro ao atualizar mesa",
+    "invalidId": "ID inválido",
+    "errorDelete": "Erro ao excluir mesa",
+    "invalidOrder": "Ordem inválida",
+    "errorReorder": "Erro ao reordenar mesas",
+    "invalidCoords": "Coordenadas inválidas",
+    "errorMove": "Erro ao mover mesa",
+    "invalidGuestId": "ID de convidado inválido",
+    "invalidTableId": "ID de mesa inválido",
+    "guestNotFound": "Convidado não encontrado",
+    "tableFull": "Mesa \"{name}\" não tem assentos suficientes (capacidade {capacity}, ocupados {used}, necessário {needed})",
+    "errorAssign": "Erro ao alocar convidado"
+  },
+  "security": {
+    "errorGenerating": "Erro ao gerar configuração 2FA",
+    "invalidCode": "Código inválido",
+    "invalidTotp": "Código TOTP inválido",
+    "errorEnabling": "Erro ao ativar 2FA",
+    "codeRequired": "Código obrigatório",
+    "notActive": "2FA não está ativo",
+    "errorDisabling": "Erro ao desativar 2FA"
+  },
+  "settings": {
+    "errorSaving": "Erro ao salvar configurações",
+    "errorSavingPix": "Erro ao salvar configurações Pix"
+  },
+  "task": {
+    "notFound": "Tarefa não encontrada",
+    "errorCreate": "Erro ao criar tarefa",
+    "errorUpdate": "Erro ao atualizar tarefa",
+    "errorStatus": "Erro ao atualizar status",
+    "errorDelete": "Erro ao excluir tarefa",
+    "errorTemplates": "Erro ao carregar template",
+    "eventDateRequired": "Configure a data do evento em Ajustes para usar os templates."
+  },
+  "trousseau": {
+    "notFound": "Item não encontrado",
+    "errorAdding": "Erro ao adicionar",
+    "errorUpdating": "Erro ao atualizar",
+    "errorUpdatingStatus": "Erro ao atualizar status",
+    "errorDeleting": "Erro ao excluir"
+  },
+  "user": {
+    "noPermission": "Sem permissão",
+    "invalidSession": "Sessão inválida",
+    "emailTaken": "Já existe um usuário com este email",
+    "passwordTooShort": "Senha deve ter ao menos {min} caracteres",
+    "passwordTooLong": "Senha muito longa",
+    "errorCreating": "Erro ao criar usuário",
+    "notFound": "Usuário não encontrado",
+    "cannotChangeOwnRole": "Você não pode alterar sua própria função",
+    "cannotDeactivateSelf": "Você não pode desativar a si mesmo",
+    "keepOneAdmin": "Mantenha pelo menos um administrador ativo",
+    "errorUpdating": "Erro ao atualizar usuário",
+    "errorResettingPassword": "Erro ao redefinir senha",
+    "invalidId": "ID inválido",
+    "errorResetting2FA": "Erro ao redefinir 2FA",
+    "cannotArchiveSelf": "Você não pode arquivar a si mesmo",
+    "errorArchiving": "Erro ao arquivar usuário",
+    "errorRestoring": "Erro ao restaurar usuário",
+    "newPasswordMustDiffer": "A nova senha deve ser diferente da atual",
+    "wrongCurrentPassword": "Senha atual incorreta",
+    "errorChangingPassword": "Erro ao trocar senha",
+    "errorUpdatingProfile": "Erro ao atualizar perfil",
+    "securityPolicyAdminOnly": "Apenas administradores podem alterar política de segurança",
+    "errorSavingSecurityPolicy": "Erro ao salvar política de segurança"
+  },
+  "vendor": {
+    "errorCreate": "Erro ao criar fornecedor",
+    "errorUpdate": "Erro ao atualizar fornecedor",
+    "errorStatus": "Erro ao atualizar status",
+    "errorDelete": "Erro ao excluir fornecedor"
+  },
+  "vendorContact": {
+    "notFound": "Contato não encontrado",
+    "errorCreate": "Erro ao adicionar contato",
+    "errorUpdate": "Erro ao atualizar contato",
+    "errorDelete": "Erro ao excluir contato"
+  },
+  "vendorNote": {
+    "notFound": "Nota não encontrada",
+    "errorCreate": "Erro ao adicionar nota",
+    "errorDelete": "Erro ao excluir nota"
+  },
+  "venue": {
+    "errorCreate": "Erro ao criar local",
+    "notFound": "Local não encontrado",
+    "errorUpdate": "Erro ao atualizar local",
+    "errorDelete": "Erro ao excluir local",
+    "errorAddItem": "Erro ao adicionar item",
+    "errorUpdateItem": "Erro ao atualizar item",
+    "itemNotFound": "Item não encontrado",
+    "errorDeleteItem": "Erro ao excluir item"
+  },
+  "weddingDay": {
+    "errorSaving": "Erro ao salvar"
+  },
+  "whatsapp": {
+    "adminOnly": "Apenas administradores",
+    "testMessageBody": "*Wedding Finance*\n\nMensagem de teste enviada com sucesso. Sua integração com WhatsApp está funcionando. ✅"
   }
 }

--- a/src/messages/pt-BR/dashboard.json
+++ b/src/messages/pt-BR/dashboard.json
@@ -1,1 +1,2033 @@
-{}
+{
+  "assets": {
+    "page": {
+      "title": "Caixa (Dinheiro Guardado)"
+    },
+    "list": {
+      "searchPlaceholder": "Buscar aporte...",
+      "total": "Total: {value}",
+      "new": "Novo Aporte",
+      "empty": "Nenhum aporte registrado.",
+      "noResults": "Nenhum resultado para o filtro."
+    },
+    "table": {
+      "date": "Data",
+      "source": "Origem",
+      "amount": "Valor",
+      "actions": "Ações"
+    },
+    "delete": {
+      "title": "Excluir aporte?"
+    },
+    "toast": {
+      "created": "Aporte registrado",
+      "updated": "Aporte atualizado",
+      "deleted": "Aporte excluído",
+      "failTitle": "Falha"
+    },
+    "form": {
+      "titleCreate": "Novo aporte",
+      "titleEdit": "Editar aporte",
+      "titleLabel": "Título / Origem",
+      "titlePlaceholder": "Ex: Salário de Março",
+      "amountLabel": "Valor (R$)",
+      "dateLabel": "Data",
+      "goalLabel": "Vincular a uma meta (opcional)",
+      "goalNone": "— sem meta —",
+      "notesLabel": "Notas"
+    }
+  },
+  "gifts": {
+    "page": {
+      "title": "Presentes recebidos",
+      "subtitle": "Registre o que recebeu (dinheiro ou item), de quem, e marque quando o agradecimento já foi enviado."
+    },
+    "stats": {
+      "cashTotal": "Total em dinheiro",
+      "itemsReceived": "Itens recebidos",
+      "pendingThank": "Aguardando agradecer"
+    },
+    "filter": {
+      "all": "Todos",
+      "pendingThank": "Aguardando agradecer"
+    },
+    "list": {
+      "empty": "Nenhum presente registrado."
+    },
+    "anonymous": "Anônimo",
+    "type": {
+      "cash": "Dinheiro",
+      "item": "Item"
+    },
+    "badge": {
+      "thanked": "Agradecido",
+      "honeymoon": "lua de mel",
+      "pixReceived": "Pix recebido"
+    },
+    "actions": {
+      "new": "Novo presente",
+      "generatePix": "Gerar QR Pix",
+      "toggleThank": "Alternar agradecimento",
+      "markThanked": "Marcar como agradecido",
+      "unmarkThanked": "Desmarcar agradecido"
+    },
+    "delete": {
+      "title": "Excluir presente?"
+    },
+    "form": {
+      "titleCreate": "Novo presente",
+      "titleEdit": "Editar presente",
+      "type": "Tipo",
+      "guest": "Convidado (opcional)",
+      "giverName": "Nome de quem deu (se não tiver convidado)",
+      "amount": "Valor (R$)",
+      "description": "Descrição",
+      "receivedAt": "Recebido em",
+      "honeymoonShare": "Cota da lua de mel (mostrar QR Pix dedicado)",
+      "notes": "Notas"
+    },
+    "toast": {
+      "created": "Presente registrado",
+      "updated": "Presente atualizado",
+      "removed": "Presente removido",
+      "thanked": "Marcado como agradecido",
+      "unthanked": "Desmarcado",
+      "failed": "Falha"
+    },
+    "pix": {
+      "back": "Voltar",
+      "title": "QR Code Pix",
+      "qrAlt": "QR Code Pix",
+      "errorGenerating": "Erro ao gerar QR Code",
+      "errorPrefix": "Erro ao gerar Pix:",
+      "field": {
+        "key": "chave Pix",
+        "holder": "nome do recebedor",
+        "city": "cidade"
+      },
+      "incomplete": {
+        "title": "Configuração Pix incompleta",
+        "intro": "Para gerar o QR Code, configure:",
+        "goToSettings": "Ir para Ajustes"
+      },
+      "summary": {
+        "title": "Resumo",
+        "gift": "Presente",
+        "value": "Valor",
+        "freeValue": "sem valor (livre)",
+        "status": "Status Pix",
+        "receivedOn": "Recebido em",
+        "awaiting": "Aguardando confirmação"
+      },
+      "copyPaste": {
+        "title": "Pix copia e cola",
+        "copyButton": "Copiar código"
+      },
+      "confirm": {
+        "title": "Confirmar recebimento",
+        "hint": "Após verificar o pagamento na sua conta, marque como recebido.",
+        "addToAsset": "Adicionar valor ao caixa (Asset)",
+        "saving": "Salvando...",
+        "markReceived": "Marcar como recebido"
+      },
+      "toast": {
+        "copied": "Código copiado",
+        "marked": "Pix marcado como recebido",
+        "error": "Erro",
+        "copyFailed": "Não foi possível copiar"
+      }
+    }
+  },
+  "goals": {
+    "page": {
+      "title": "Metas de poupança",
+      "subtitle": "Defina quanto guardar até quando. Os aportes (caixa) podem ser vinculados a uma meta."
+    },
+    "list": {
+      "new": "Nova meta",
+      "empty": "Nenhuma meta. Crie uma para acompanhar o progresso da poupança até a data alvo."
+    },
+    "card": {
+      "inactive": "inativa",
+      "target": "Alvo: {date}",
+      "pctReached": "{pct}% atingido",
+      "contributions": "{count} aporte(s)",
+      "remaining": "Falta",
+      "perMonth": "Por mês"
+    },
+    "form": {
+      "createTitle": "Nova meta",
+      "editTitle": "Editar meta",
+      "name": "Nome",
+      "targetAmount": "Valor alvo (R$)",
+      "targetDate": "Data alvo",
+      "imageUrl": "URL da Imagem de Inspiração (Opcional)",
+      "imageUrlPlaceholder": "https://exemplo.com/imagem.jpg",
+      "isActive": "Meta ativa",
+      "notes": "Notas"
+    },
+    "delete": {
+      "title": "Excluir meta?",
+      "description": "Os aportes vinculados continuam existindo, mas perdem a vinculação."
+    },
+    "toast": {
+      "created": "Meta criada",
+      "updated": "Meta atualizada",
+      "removed": "Meta removida",
+      "failed": "Falha"
+    }
+  },
+  "guests": {
+    "page": {
+      "title": "Convidados",
+      "subtitle": "Gerencie a lista, envie links únicos de RSVP e acompanhe confirmações."
+    },
+    "stats": {
+      "list": "Lista",
+      "guests": "convidados",
+      "confirmed": "Confirmados",
+      "heads": "{count} cabeças",
+      "pending": "Pendentes",
+      "declined": "Recusaram"
+    },
+    "filters": {
+      "searchPlaceholder": "Buscar...",
+      "all": "Todos",
+      "confirmed": "Confirmados",
+      "pending": "Pendentes",
+      "padrinhos": "Padrinhos",
+      "children": "Crianças",
+      "checkedIn": "Já chegaram"
+    },
+    "actions": {
+      "groups": "Grupos",
+      "csv": "CSV",
+      "importList": "Importar lista",
+      "newGuest": "Novo convidado"
+    },
+    "table": {
+      "name": "Nome",
+      "group": "Grupo",
+      "rsvp": "RSVP",
+      "plusOne": "+1",
+      "table": "Mesa",
+      "attendance": "Presença",
+      "actions": "Ações",
+      "empty": "Lista vazia.",
+      "noResults": "Nenhum resultado."
+    },
+    "tags": {
+      "padrinhoShort": "P",
+      "child": "Criança",
+      "vip": "VIP"
+    },
+    "attendance": {
+      "arrived": "Chegou",
+      "mark": "Marcar"
+    },
+    "rowActions": {
+      "copyRsvp": "Copiar link RSVP"
+    },
+    "rsvp": {
+      "notInvited": "Não convidado",
+      "invited": "Convidado",
+      "confirmed": "Confirmado",
+      "declined": "Recusou",
+      "maybe": "Talvez"
+    },
+    "delete": {
+      "confirmTitle": "Excluir {name}?",
+      "confirmTitleGeneric": "Excluir?"
+    },
+    "toast": {
+      "created": "Convidado criado",
+      "updated": "Convidado atualizado",
+      "removed": "Convidado removido",
+      "checkinReverted": "Check-in revertido",
+      "checkinDone": "Presença registrada",
+      "linkCopied": "Link copiado",
+      "copyFailed": "Falha ao copiar"
+    },
+    "csv": {
+      "name": "Nome",
+      "phone": "Telefone",
+      "email": "Email",
+      "side": "Lado",
+      "group": "Grupo",
+      "status": "Status",
+      "plusOnesConfirmed": "+1 confirmados",
+      "table": "Mesa",
+      "dietary": "Restrições",
+      "city": "Cidade",
+      "padrinho": "Padrinho",
+      "vip": "VIP",
+      "child": "Criança",
+      "yes": "sim",
+      "fileName": "convidados"
+    },
+    "form": {
+      "createTitle": "Novo convidado",
+      "editTitle": "Editar {name}",
+      "name": "Nome",
+      "phone": "Telefone",
+      "email": "Email",
+      "side": "Lado",
+      "groupName": "Grupo (ex: família dele)",
+      "city": "Cidade",
+      "rsvpStatus": "Status RSVP",
+      "plusOnesAllowed": "Acompanhantes permitidos",
+      "tableNumber": "Mesa / setor",
+      "dietary": "Restrições alimentares",
+      "isChild": "Criança",
+      "isVIP": "VIP",
+      "isPadrinho": "Padrinho / madrinha",
+      "notes": "Notas"
+    },
+    "side": {
+      "groom": "Noivo",
+      "bride": "Noiva",
+      "both": "Ambos"
+    },
+    "groups": {
+      "backToGuests": "Voltar para convidados",
+      "title": "Grupos / Famílias",
+      "subtitle": "Crie grupos para gerar um único link de RSVP por família.",
+      "newGroup": "Novo grupo",
+      "empty": "Nenhum grupo cadastrado.",
+      "card": {
+        "contact": "Contato: {name}",
+        "people": "{count} pessoas",
+        "yes": "{count} sim",
+        "pending": "{count} pendente",
+        "no": "{count} não",
+        "copyLink": "Copiar link",
+        "members": "Membros"
+      },
+      "form": {
+        "createTitle": "Novo grupo",
+        "editTitle": "Editar grupo",
+        "name": "Nome do grupo",
+        "contactName": "Contato (opcional)",
+        "email": "Email",
+        "phone": "Telefone",
+        "notes": "Observações",
+        "saving": "Salvando..."
+      },
+      "members": {
+        "title": "Membros de {name}",
+        "subtitle": "Selecione os convidados que pertencem a este grupo.",
+        "searchPlaceholder": "Buscar convidado...",
+        "noneAvailable": "Nenhum convidado disponível.",
+        "selectedCount": "{count} selecionado(s)"
+      },
+      "toast": {
+        "linkCopied": "Link copiado",
+        "copyFailed": "Não foi possível copiar",
+        "created": "Grupo criado",
+        "updated": "Grupo atualizado",
+        "deleted": "Grupo excluído",
+        "membersUpdated": "Membros atualizados"
+      },
+      "delete": {
+        "title": "Excluir grupo?",
+        "description": "O grupo \"{name}\" será removido. Os convidados não serão excluídos."
+      }
+    },
+    "import": {
+      "backToGuests": "Voltar para convidados",
+      "title": "Importar lista de convidados",
+      "subtitle": "Suba o arquivo exportado de outro sistema (hoje: {sources}). Você verá um preview antes de confirmar.",
+      "toast": {
+        "selectFile": "Selecione um arquivo .xlsx",
+        "unexpectedResponse": "Resposta inesperada do servidor",
+        "importFailed": "Falha ao importar"
+      },
+      "upload": {
+        "fileLabel": "Arquivo (.xlsx ou .csv)",
+        "fileHint": "Tamanho máximo: 5 MB. Até 2000 linhas por importação. Wedy exporta em .xlsx; o próprio sistema exporta em .csv (botão CSV em /dashboard/guests).",
+        "sourceLabel": "Origem",
+        "autoDetect": "Detectar automaticamente",
+        "preferPaste": "Prefere colar texto bruto?",
+        "analyze": "Analisar arquivo"
+      },
+      "preview": {
+        "rowsInFile": "Linhas no arquivo",
+        "new": "Novos",
+        "existingSameGroup": "Já existem (mesmo grupo)",
+        "divergent": "Divergentes",
+        "detectedSource": "Origem detectada",
+        "fileValid": "arquivo válido, headers reconhecidos.",
+        "detectedGroups": "Grupos detectados ({count})",
+        "noGroups": "Nenhum grupo na planilha.",
+        "peopleCount": "{count} pessoa(s)",
+        "pin": "PIN {pin}",
+        "detectedTags": "Tags detectadas ({count})",
+        "noTags": "Nenhuma tag.",
+        "tagsNote": "Tags novas serão criadas. Tags com o nome \"Padrinhos\", \"Madrinha\" etc. também marcam a flag de padrinho do convidado.",
+        "sampleTitle": "Amostra (até {count} linhas)",
+        "filterAll": "Todas",
+        "filterNew": "Novas",
+        "filterExisting": "Já existem",
+        "filterDivergent": "Divergentes",
+        "confirmImport": "Confirmar importação"
+      },
+      "mode": {
+        "heading": "Como tratar duplicatas",
+        "CREATE_NEW_ONLY": {
+          "label": "Pular linhas que já existem no mesmo grupo",
+          "description": "Mais seguro. Só cria os convidados novos; nada é alterado."
+        },
+        "UPSERT_BY_NAME": {
+          "label": "Atualizar dados de quem já existe no mesmo grupo",
+          "description": "Sobrescreve telefone, e-mail, status e tags dos convidados que já existem. Cria os novos."
+        },
+        "CREATE_ALL_DUPLICATES": {
+          "label": "Criar tudo, mesmo que já exista",
+          "description": "Use quando houver homônimos em famílias diferentes que não devem ser fundidos."
+        }
+      },
+      "done": {
+        "title": "Importação concluída",
+        "created": "<b>{count}</b> convidado(s) criados.",
+        "updated": "<b>{count}</b> convidado(s) atualizados.",
+        "skipped": "<b>{count}</b> linha(s) puladas.",
+        "groupsCreated": "<b>{count}</b> grupo(s) criados.",
+        "tagsCreated": "<b>{count}</b> tag(s) criadas.",
+        "viewList": "Ver lista de convidados",
+        "importAnother": "Importar outra"
+      },
+      "table": {
+        "noRowsForFilter": "Nenhuma linha para este filtro.",
+        "status": "Status",
+        "name": "Nome",
+        "group": "Grupo",
+        "rsvp": "RSVP",
+        "phone": "Telefone",
+        "email": "Email",
+        "tags": "Tags",
+        "child": "Criança",
+        "pin": "PIN",
+        "statusNew": "Novo",
+        "statusDuplicateSame": "Já existe (mesmo grupo)",
+        "statusDuplicateDiff": "Já existe, dados divergem",
+        "rawStatusHint": "Status original \"{raw}\" não reconhecido; tratado como Convidado.",
+        "childYes": "Sim",
+        "childYesAge": "Sim ({age})"
+      },
+      "paste": {
+        "title": "Colar texto bruto",
+        "instructions": "Cole linhas no formato <code>Nome,Telefone,Email,Lado,Grupo</code> (uma linha por convidado). Telefone, email, lado e grupo são opcionais. Lado aceita NOIVO/NOIVA/AMBOS. Quando a coluna <strong>Grupo</strong> for preenchida, grupos novos são criados automaticamente (e os existentes reaproveitados, comparando pelo nome) — convidados da mesma família passam a compartilhar um único link de RSVP.",
+        "contentLabel": "Conteúdo",
+        "placeholder": "Maria Silva,+5511999990000,maria@example.com,NOIVA,Família\nJoão Souza\nAna,,ana@example.com,,Trabalho dele",
+        "separatorLabel": "Separador",
+        "sepAuto": "Detectar automaticamente",
+        "sepComma": ", (vírgula)",
+        "sepSemicolon": "; (ponto-vírgula)",
+        "sepTab": "Tab",
+        "submit": "Importar",
+        "toast": {
+          "importedTitle": "{count} importados",
+          "skippedLines": "{count} linhas puladas",
+          "groupsSuffix": ", {count} grupo(s) criado(s)"
+        }
+      }
+    }
+  },
+  "home": {
+    "header": {
+      "title": "Visão Geral",
+      "weddingOn": "Casamento em {date}",
+      "configurePrompt": "Configure seu evento para começar"
+    },
+    "onboarding": {
+      "title": "Vamos configurar seu casamento?",
+      "body": "Em menos de 2 minutos você define a data, os nomes do casal e como as notificações vão funcionar. Clique aqui para iniciar o assistente."
+    },
+    "quitAlert": {
+      "title": "Alerta de Quitação!",
+      "body": "Faltam {days} dia(s) e ainda há saldo devedor de {balance}.",
+      "pendingValues": "valores pendentes"
+    },
+    "kpi": {
+      "totalBudget": {
+        "title": "Orçamento Total",
+        "hint": "Contingência: {value}"
+      },
+      "totalPaid": {
+        "title": "Total Já Pago",
+        "hint": "{pct}% do orçamento"
+      },
+      "remainingBalance": {
+        "title": "Saldo Devedor"
+      },
+      "cashCoverage": {
+        "title": "Cobertura de Caixa",
+        "hintPct": "{pct}% do saldo devedor",
+        "hintPaid": "Saldo quitado"
+      },
+      "vendors": {
+        "title": "Fornecedores",
+        "hint": "{pct}% contratados"
+      },
+      "tasks": {
+        "title": "Tarefas",
+        "hintOverdue": "{count, plural, one {# atrasada(s)} other {# atrasada(s)}}",
+        "hintUpToDate": "Tudo em dia"
+      },
+      "guests": {
+        "title": "Convidados",
+        "hint": "{total} no total · {confirmed} confirmados"
+      },
+      "daysToEvent": {
+        "title": "Dias para o evento"
+      },
+      "budgetSummary": {
+        "title": "Resumo do Orçamento",
+        "hint": "Contratado: {contracted} · Pago: {paid}"
+      }
+    },
+    "risks": {
+      "title": "Sinais de atenção"
+    },
+    "funnel": {
+      "title": "Funil de Fornecedores",
+      "empty": "Nenhum fornecedor cadastrado.",
+      "negotiating": "Negociando",
+      "contracted": "Contratados",
+      "finalized": "Finalizados"
+    },
+    "budgetDistribution": {
+      "title": "Distribuição do Orçamento"
+    },
+    "upcomingPayments": {
+      "title": "Próximos Vencimentos",
+      "empty": "Nenhum pagamento para os próximos 30 dias.",
+      "dueLabel": "Venc.: {date}"
+    },
+    "charts": {
+      "noData": "Sem dados suficientes para o gráfico"
+    },
+    "rsvp": {
+      "title": "Confirmações (RSVP)",
+      "empty": "Nenhum convidado cadastrado ainda.",
+      "respondedConfirming": "{confirmed} de {total} responderam confirmando",
+      "confirmed": "{count} confirmados",
+      "maybe": "{count} talvez",
+      "declined": "{count} recusas",
+      "pending": "{count} pendentes",
+      "plusOnes": "+{count} acompanhantes confirmados",
+      "totalGuests": "{count} convidados no total"
+    },
+    "gifts": {
+      "title": "Presentes recebidos",
+      "empty": "Nenhum presente registrado ainda.",
+      "breakdown": "{cash} em dinheiro · {items} em itens",
+      "thankedLabel": "Agradecidos:",
+      "thankedCount": "{thanked} de {total}"
+    },
+    "upcomingTasks": {
+      "title": "Próximas Tarefas",
+      "empty": "Nenhuma tarefa pendente.",
+      "noDeadline": "Sem prazo",
+      "priority": {
+        "urgent": "URGENT",
+        "high": "HIGH",
+        "medium": "MEDIUM",
+        "low": "LOW"
+      }
+    },
+    "countdown": {
+      "past": "Evento já passou",
+      "today": "Hoje é o dia!",
+      "remaining": "Faltam {days} dias"
+    },
+    "install": {
+      "dismiss": "Ignorar",
+      "title": "Instale como aplicativo",
+      "iosBody": "Adicione o Wedding Finance Planner diretamente na tela de início do seu iPhone para uma experiência em tela cheia idêntica a um app nativo:",
+      "iosTap": "Toque em",
+      "iosShare": "Compartilhar",
+      "iosAddToHome": "Adicionar à Tela de Início",
+      "androidBody": "Adicione o aplicativo Wedding Finance Planner à sua tela de início para acompanhar suas finanças e tarefas de forma ágil, com acesso rápido e notificações.",
+      "installButton": "Instalar Aplicativo"
+    }
+  },
+  "honeymoon": {
+    "page": {
+      "title": "Lua de mel",
+      "subtitle": "Roteiro, reservas, documentos e orçamento da viagem pós-casamento."
+    },
+    "info": {
+      "destination": "Destino",
+      "notDecided": "Ainda não decidido",
+      "budget": "Orçamento",
+      "committed": "Comprometido",
+      "editTrip": "Editar dados da viagem",
+      "departure": "Saída",
+      "return": "Volta"
+    },
+    "currency": {
+      "brl": "Real (BRL)",
+      "usd": "Dólar (USD)",
+      "eur": "Euro (EUR)"
+    },
+    "list": {
+      "empty": "Nada adicionado ainda. Comece pelos voos e hotéis."
+    },
+    "actions": {
+      "newItem": "Novo item"
+    },
+    "kind": {
+      "FLIGHT": "Voo",
+      "HOTEL": "Hospedagem",
+      "TRANSFER": "Transfer",
+      "ACTIVITY": "Passeio",
+      "DOCUMENT": "Documento",
+      "BAGGAGE": "Bagagem",
+      "OTHER": "Outro"
+    },
+    "status": {
+      "PLANNED": "Planejado",
+      "BOOKED": "Reservado",
+      "CONFIRMED": "Confirmado",
+      "PAID": "Pago",
+      "CANCELLED": "Cancelado"
+    },
+    "form": {
+      "titleCreate": "Novo item",
+      "titleEdit": "Editar item",
+      "kind": "Tipo",
+      "title": "Título",
+      "vendor": "Companhia / fornecedor",
+      "start": "Início",
+      "end": "Fim",
+      "amount": "Valor",
+      "confirmationNumber": "Localizador"
+    },
+    "delete": {
+      "confirmTitle": "Excluir item?"
+    },
+    "toast": {
+      "updated": "Atualizado",
+      "itemAdded": "Item adicionado",
+      "itemUpdated": "Item atualizado",
+      "itemRemoved": "Item removido",
+      "failed": "Falha"
+    }
+  },
+  "income": {
+    "page": {
+      "title": "Receitas e ganhos",
+      "subtitle": "Renda recorrente, bônus, presentes em dinheiro e vendas pré-casamento."
+    },
+    "summary": {
+      "total": "Total estimado",
+      "expected": "A receber",
+      "received": "Recebido"
+    },
+    "actions": {
+      "new": "Nova receita",
+      "received": "Recebi"
+    },
+    "table": {
+      "title": "Título",
+      "source": "Origem",
+      "amount": "Valor",
+      "expectedDate": "Data prevista",
+      "status": "Status",
+      "actions": "Ações",
+      "empty": "Nenhuma receita cadastrada."
+    },
+    "row": {
+      "givenBy": "de {name}"
+    },
+    "frequency": {
+      "ONE_TIME": "Avulsa",
+      "MONTHLY": "Mensal"
+    },
+    "source": {
+      "SALARY": "Salário",
+      "BONUS": "Bônus / 13º",
+      "GIFT": "Presente em dinheiro",
+      "FREELANCE": "Freela",
+      "SALE": "Venda",
+      "RESTITUTION": "Restituição IR",
+      "OTHER": "Outro"
+    },
+    "status": {
+      "EXPECTED": "Prevista",
+      "RECEIVED": "Recebida",
+      "CANCELLED": "Cancelada"
+    },
+    "form": {
+      "titleCreate": "Nova receita",
+      "titleEdit": "Editar receita",
+      "title": "Título",
+      "source": "Origem",
+      "amount": "Valor (R$)",
+      "expectedDate": "Data prevista",
+      "frequency": "Frequência",
+      "status": "Status",
+      "givenByName": "Dado por (presente)",
+      "notes": "Notas"
+    },
+    "confirmDelete": {
+      "title": "Excluir receita?"
+    },
+    "toast": {
+      "created": "Receita registrada",
+      "updated": "Receita atualizada",
+      "marked": "Marcada como recebida",
+      "deleted": "Receita removida",
+      "fail": "Falha"
+    }
+  },
+  "insights": {
+    "header": {
+      "title": "Insights financeiros",
+      "subtitle": "Projeção, saúde do projeto e detector de orçamento por categoria."
+    },
+    "noData": "Sem dados ainda.",
+    "health": {
+      "label": "Health Score",
+      "statusGood": "Projeto saudável.",
+      "statusWarn": "Atenção em alguns pontos.",
+      "statusBad": "Precisa de ajustes urgentes."
+    },
+    "cashflow": {
+      "title": "Fluxo de caixa projetado",
+      "worstBalance": "Pior saldo: {value}",
+      "description": "Saldo cumulativo até o evento, considerando aportes existentes + receitas previstas − pagamentos pendentes."
+    },
+    "monthlyFlow": {
+      "title": "Entradas e saídas por mês",
+      "description": "Barras verdes = receitas. Barras vermelhas = pagamentos. Zona vermelha de fundo = saldo negativo projetado."
+    },
+    "sCurve": {
+      "title": "Curva S — Previsto vs Realizado",
+      "hint": "Banda = contingência configurada"
+    },
+    "burndown": {
+      "title": "Burndown de Tarefas",
+      "hint": "Ideal vs real até a data do evento"
+    },
+    "waterfall": {
+      "title": "Variação por Categoria",
+      "hint": "Verde = poupou · Rosa = estourou"
+    },
+    "whatIf": {
+      "title": "Posso fechar esse contrato agora?",
+      "description": "Simule adicionar um pagamento futuro e veja o impacto no fluxo de caixa até {date}.",
+      "amountLabel": "Valor (R$)",
+      "dateLabel": "Data prevista",
+      "fillPrompt": "Preencha valor e data",
+      "balanceAt": "Saldo em {month}",
+      "worstBalance": "Pior saldo até o evento",
+      "finalBalance": "Saldo final no evento",
+      "canAfford": "Pode fechar",
+      "exceedsCash": "Estoura o caixa"
+    },
+    "creep": {
+      "title": "Variação por categoria",
+      "description": "Compara estimado vs contratado em cada categoria. Itens com aumento > 10% precisam de atenção.",
+      "allWithinBudget": "Nenhuma categoria está acima do estimado.",
+      "estimated": "Estimado: {value}",
+      "contracted": "Contratado: {value}"
+    },
+    "heatmap": {
+      "title": "Concentração de pagamentos pendentes",
+      "description": "Até {date} ({days} dias). Quanto mais intenso, mais concentrado o dia.",
+      "cellTitle": "{date} · {value} ({count} pagamento(s))"
+    },
+    "chartLegend": {
+      "ending": "Saldo final",
+      "income": "Receitas",
+      "outflow": "Pagamentos"
+    }
+  },
+  "payments": {
+    "title": "Pagamentos",
+    "view": {
+      "list": "Lista",
+      "calendar": "Calendário"
+    },
+    "actions": {
+      "new": "Novo Pagamento",
+      "generateInstallments": "Gerar Parcelas",
+      "markPaid": "Quitar",
+      "revert": "Estornar"
+    },
+    "filter": {
+      "allStatus": "Todos os status"
+    },
+    "list": {
+      "searchPlaceholder": "Buscar por fornecedor...",
+      "empty": "Nenhum pagamento cadastrado.",
+      "noResults": "Nenhum resultado para o filtro."
+    },
+    "table": {
+      "dueDate": "Vencimento",
+      "vendor": "Fornecedor",
+      "method": "Método",
+      "installment": "Parcela"
+    },
+    "card": {
+      "dueOn": "Vence em {date}"
+    },
+    "method": {
+      "PIX": "PIX",
+      "BOLETO": "Boleto",
+      "CREDIT": "Cartão de Crédito",
+      "TRANSFER": "Transferência",
+      "CASH": "Dinheiro"
+    },
+    "amount": {
+      "adjustedTooltip": "Base {base} + multa {lateFee} + juros {interest} ({days} dia(s) em atraso)"
+    },
+    "form": {
+      "createTitle": "Novo Pagamento",
+      "editTitle": "Editar pagamento",
+      "splitToggle": "Entrada + Saldo",
+      "vendor": "Fornecedor",
+      "selectPlaceholder": "Selecione...",
+      "amount": "Valor (R$)",
+      "dueDate": "Vencimento",
+      "method": "Método",
+      "status": "Status",
+      "installments": "Parcelas",
+      "installmentNumberPlaceholder": "ex: 1",
+      "installmentNumberLabel": "Número da parcela atual",
+      "installmentOf": "de",
+      "totalInstallmentsPlaceholder": "ex: 12",
+      "totalInstallmentsLabel": "Total de parcelas",
+      "installmentsHint": "Deixe em branco para pagamento único.",
+      "notes": "Notas",
+      "optionalShort": "opcional",
+      "lateFee": "Multa (%)",
+      "lateFeePlaceholder": "ex: 2",
+      "interest": "Juros %/mês",
+      "interestPlaceholder": "ex: 1"
+    },
+    "split": {
+      "depositTitle": "1. Entrada (paga hoje)",
+      "balanceTitle": "2. Saldo final (pendente)",
+      "balanceMethod": "Método do saldo"
+    },
+    "delete": {
+      "title": "Excluir pagamento?",
+      "description": "Pagamento de {amount} para {vendor}.\nEssa ação fará exclusão lógica e o registro sumirá das listagens."
+    },
+    "installmentsModal": {
+      "title": "Gerar parcelas",
+      "description": "Cria N pagamentos pendentes com intervalo fixo. Útil para contratos parcelados.",
+      "totalAmount": "Valor total (R$)",
+      "count": "Nº de parcelas",
+      "eachInstallment": "Cada parcela:",
+      "firstDate": "1ª data",
+      "intervalDays": "Intervalo (dias)",
+      "lateFee": "Multa (%) opcional",
+      "interest": "Juros %/mês opcional",
+      "generating": "Gerando...",
+      "generateButton": "Gerar {count} parcelas"
+    },
+    "toast": {
+      "created": "Pagamento criado",
+      "splitCreated": "Entrada e saldo registrados",
+      "createFailed": "Falha ao criar",
+      "updated": "Pagamento atualizado",
+      "updateFailed": "Falha ao atualizar",
+      "markedPaid": "Pagamento quitado",
+      "reverted": "Pagamento estornado",
+      "genericFailed": "Falha",
+      "deleted": "Pagamento excluído",
+      "deleteFailed": "Falha ao excluir",
+      "installmentsGenerated": "Parcelas geradas"
+    },
+    "calendar": {
+      "annualView": "Visão Anual",
+      "yearTitle": "Calendário Financeiro de {year}",
+      "monthTitle": "{month} de {year}",
+      "prevYear": "Ano anterior",
+      "nextYear": "Próximo ano",
+      "prevMonth": "Mês anterior",
+      "nextMonth": "Próximo mês",
+      "noScheduled": "Sem gastos agendados",
+      "paymentCount": "{count, plural, one {# pagamento} other {# pagamentos}}",
+      "totalPlanned": "Total Planejado:",
+      "paidWithCount": "Pago ({count}):",
+      "pendingWithCount": "Pendente ({count}):",
+      "progress": "PROGRESsO",
+      "percentPaid": "{percent}% pago",
+      "moreOthers": "+{count} outros",
+      "allExpensesOf": "Todos os Gastos de {month}",
+      "expensesOfDay": "Gastos de {day} de {month}",
+      "viewAllMonth": "Ver todos do mês",
+      "noExpenses": "Nenhum gasto registrado para este período.",
+      "month": {
+        "0": "Janeiro",
+        "1": "Fevereiro",
+        "2": "Março",
+        "3": "Abril",
+        "4": "Maio",
+        "5": "Junho",
+        "6": "Julho",
+        "7": "Agosto",
+        "8": "Setembro",
+        "9": "Outubro",
+        "10": "Novembro",
+        "11": "Dezembro"
+      }
+    }
+  },
+  "reports": {
+    "hub": {
+      "title": "Relatórios",
+      "subtitle": "Visualizações analíticas detalhadas por área. Os ícones BI dentro de /dashboard/insights também aparecem aqui como atalho.",
+      "inInsights": "Em Insights",
+      "items": {
+        "scurve": {
+          "title": "Curva S — Previsto vs Realizado",
+          "description": "Compara o pagamento previsto com o realizado ao longo do tempo, com banda de contingência."
+        },
+        "vendorFunnel": {
+          "title": "Funil de Fornecedores",
+          "description": "Acompanhe quantos estão em negociação, contratados e finalizados."
+        },
+        "risk": {
+          "title": "Risk Radar",
+          "description": "Sinais vermelhos consolidados em um único painel."
+        },
+        "guests": {
+          "title": "Convidados & RSVP",
+          "description": "Taxa de resposta, plus-ones, VIPs, distribuição por grupo e cidade."
+        },
+        "gifts": {
+          "title": "Presentes",
+          "description": "CASH × ITEM, agradecimentos pendentes, top givers e cota da lua de mel."
+        },
+        "burndown": {
+          "title": "Burndown de Tarefas",
+          "description": "Compare ritmo ideal vs real de tarefas concluídas até a data do evento."
+        },
+        "honeymoon": {
+          "title": "Lua de Mel",
+          "description": "Status por etapa e financiamento pelos presentes via PIX."
+        },
+        "trousseau": {
+          "title": "Enxoval",
+          "description": "Progresso por cômodo e essenciais ainda pendentes."
+        },
+        "waterfall": {
+          "title": "Variação por Categoria",
+          "description": "Waterfall mostrando onde o orçamento estourou e quanto."
+        },
+        "activity": {
+          "title": "Timeline de Atividade",
+          "description": "Últimas alterações relevantes registradas em auditoria."
+        }
+      }
+    },
+    "activity": {
+      "back": "Voltar para relatórios",
+      "title": "Timeline de Atividade",
+      "subtitle": "Últimas 100 alterações registradas no sistema. Filtre por entidade abaixo.",
+      "filterAll": "Todas",
+      "empty": "Sem registros de auditoria ainda.",
+      "systemActor": "Sistema",
+      "action": {
+        "CREATE": "criou",
+        "UPDATE": "atualizou",
+        "DELETE": "removeu",
+        "RESTORE": "restaurou",
+        "MARK_PAID": "marcou como pago",
+        "UNDO_PAID": "desfez pagamento",
+        "STATUS_CHANGE": "mudou status",
+        "UPLOAD": "fez upload",
+        "DOWNLOAD": "baixou",
+        "REPLACE": "substituiu",
+        "SIGN": "assinou",
+        "ARCHIVE": "arquivou",
+        "RESET_PASSWORD": "redefiniu senha",
+        "RESET_2FA": "removeu 2FA",
+        "CHANGE_OWN_PASSWORD": "trocou própria senha",
+        "LOGIN": "fez login",
+        "BULK_CREATE": "criou em massa",
+        "ASSIGN_TABLE": "atribuiu mesa",
+        "UNASSIGN_TABLE": "removeu de mesa",
+        "RSVP_GROUP_RESPOND": "respondeu RSVP em grupo",
+        "MARK_PIX_RECEIVED": "marcou PIX recebido",
+        "ONBOARDING_COUPLE": "completou etapa do casal",
+        "ONBOARDING_BUDGET": "completou etapa do orçamento",
+        "ONBOARDING_FINISH": "finalizou onboarding"
+      },
+      "entity": {
+        "Vendor": "fornecedor",
+        "Payment": "pagamento",
+        "BudgetItem": "item de orçamento",
+        "Asset": "ativo",
+        "EventSettings": "configurações do evento",
+        "User": "usuário",
+        "SecuritySettings": "configurações de segurança",
+        "SeatingTable": "mesa",
+        "Guest": "convidado",
+        "GuestGroup": "grupo de convidados",
+        "Gift": "presente",
+        "Contract": "contrato",
+        "Attachment": "anexo"
+      }
+    },
+    "gifts": {
+      "back": "Voltar para relatórios",
+      "title": "Presentes",
+      "subtitle": "Análise de presentes recebidos: dinheiro vs itens, agradecimentos pendentes, cota da lua de mel e top givers.",
+      "type": {
+        "cash": "Dinheiro",
+        "item": "Itens"
+      },
+      "tiles": {
+        "count": "Presentes",
+        "totalCash": "Total em dinheiro",
+        "cashCount": "Em dinheiro",
+        "thanked": "Agradecidos",
+        "thankedSub": "{count} de {total}",
+        "honeymoon": "Lua de mel (PIX)",
+        "contributions": "{count} contribuição(ões)",
+        "contributionsShort": "contribuições"
+      },
+      "distribution": {
+        "title": "Distribuição (CASH × ITEM)",
+        "giftCount": "{count} presente(s)"
+      },
+      "cumulative": {
+        "title": "Captação cumulativa",
+        "empty": "Sem dados de recebimento.",
+        "legendAmount": "Acumulado (R$)",
+        "legendCount": "Quantidade"
+      },
+      "topGivers": {
+        "title": "Top givers",
+        "empty": "Sem presentes registrados.",
+        "giftCount": "{count} presente(s)"
+      }
+    },
+    "guests": {
+      "back": "Voltar para relatórios",
+      "title": "Convidados & RSVP",
+      "subtitle": "Taxa de resposta, plus-ones, VIPs, padrinhos e distribuição por grupo/cidade.",
+      "status": {
+        "confirmed": "Confirmados",
+        "maybe": "Talvez",
+        "pending": "Pendentes",
+        "declined": "Recusas"
+      },
+      "tiles": {
+        "invited": "Convidados",
+        "confirmed": "Confirmados",
+        "plusOnes": "+ Acompanhantes",
+        "children": "Crianças"
+      },
+      "rsvp": {
+        "title": "Status do RSVP",
+        "peopleCount": "{count} pessoa(s)",
+        "effectiveLabel": "Total efetivo (com +1s):"
+      },
+      "byGroup": {
+        "title": "Por grupo",
+        "empty": "Nenhum grupo de convidados cadastrado."
+      },
+      "vips": {
+        "title": "VIPs & Padrinhos",
+        "vipsConfirmed": "VIPs confirmados",
+        "padrinhosConfirmed": "Padrinhos confirmados"
+      },
+      "cities": {
+        "title": "Top cidades",
+        "empty": "Nenhuma cidade informada."
+      }
+    },
+    "honeymoon": {
+      "back": "Voltar para relatórios",
+      "title": "Lua de Mel",
+      "subtitle": "Status por etapa (PLANNED → PAID), por tipo de item, e cobertura pela cota via PIX dos presentes.",
+      "noPermission": {
+        "title": "Sem permissão",
+        "body": "Esse relatório expõe valores financeiros. Solicite acesso a um administrador."
+      },
+      "status": {
+        "paid": "Pago",
+        "confirmed": "Confirmado",
+        "booked": "Reservado",
+        "planned": "Planejado",
+        "cancelled": "Cancelado"
+      },
+      "kind": {
+        "FLIGHT": "Voos",
+        "HOTEL": "Hospedagem",
+        "TRANSFER": "Translado",
+        "ACTIVITY": "Atividades",
+        "DOCUMENT": "Documentos",
+        "BAGGAGE": "Bagagem",
+        "OTHER": "Outros"
+      },
+      "tiles": {
+        "items": "Itens",
+        "booked": "Reservado",
+        "paid": "Pago",
+        "fundedFromGifts": "Recebido via PIX (cota)"
+      },
+      "coverage": {
+        "title": "Cobertura por cota",
+        "sublabel": "contribuições via PIX",
+        "empty": "Defina um orçamento total para a lua de mel para ver a cobertura."
+      },
+      "byKind": {
+        "title": "Por tipo de item",
+        "empty": "Nenhum item adicionado à lua de mel ainda."
+      },
+      "foreignCurrency": {
+        "title": "Valores em moedas estrangeiras",
+        "body": "Os totais acima exibem valores em BRL. Itens em outras moedas:"
+      }
+    },
+    "risk": {
+      "back": "Voltar para relatórios",
+      "title": "Risk Radar",
+      "subtitle": "Sinais consolidados que merecem atenção: liquidez, contratos no prazo, tarefas atrasadas e fornecedores que estouraram o orçamento estimado.",
+      "empty": "Sem sinais vermelhos no momento. Bom trabalho.",
+      "tiles": {
+        "critical": "Críticos",
+        "warning": "Atenção",
+        "ok": "Ok"
+      }
+    },
+    "trousseau": {
+      "back": "Voltar para relatórios",
+      "title": "Enxoval",
+      "subtitle": "Progresso por cômodo e itens essenciais ainda pendentes.",
+      "status": {
+        "gifted": "Recebidos",
+        "bought": "Comprados",
+        "toBuy": "A comprar"
+      },
+      "room": {
+        "KITCHEN": "Cozinha",
+        "BATHROOM": "Banheiro",
+        "BEDROOM": "Quarto",
+        "LIVING": "Sala",
+        "LAUNDRY": "Lavanderia",
+        "ELECTRONICS": "Eletrônicos",
+        "OTHER": "Outros"
+      },
+      "tiles": {
+        "items": "Itens",
+        "completion": "Conclusão",
+        "estimated": "Estimado",
+        "byRoom": "Por cômodo",
+        "actual": "Atual",
+        "essentialsPending": "Essenciais pendentes"
+      },
+      "essentials": {
+        "warning": "{count} item(ns) ESSENTIAL ainda em \"a comprar\"",
+        "hint": "Priorize esses antes de itens NICE_TO_HAVE ou LUXURY."
+      },
+      "overall": {
+        "title": "Progresso geral",
+        "label": "Concluído",
+        "sublabel": "{pct}% de {total} itens"
+      },
+      "byRoom": {
+        "title": "Por cômodo",
+        "empty": "Nenhum item adicionado ao enxoval ainda."
+      }
+    },
+    "vendorFunnel": {
+      "back": "Voltar para relatórios",
+      "title": "Funil de Fornecedores",
+      "subtitle": "Distribuição por estágio e tempo médio entre negociação, contrato e finalização.",
+      "series": {
+        "negotiating": "Negociando",
+        "contracted": "Contratado",
+        "finalized": "Finalizado"
+      },
+      "tiles": {
+        "negotiation": "Em negociação",
+        "contracted": "Contratados",
+        "finalized": "Finalizados"
+      },
+      "byCategory": {
+        "title": "Por categoria",
+        "vendorCount": "{count} fornecedor(es)"
+      },
+      "avg": {
+        "negToContract": "Tempo médio de negociação → contrato",
+        "contractToFinalized": "Tempo médio de contrato → finalização",
+        "daysUnit": "dias"
+      }
+    }
+  },
+  "settings": {
+    "page": {
+      "title": "Ajustes",
+      "subtitle": "Configurações do casamento, time e segurança."
+    },
+    "tabs": {
+      "event": "Casamento",
+      "security": "Segurança",
+      "team": "Time",
+      "notifications": "Notificações",
+      "whatsapp": "WhatsApp",
+      "profile": "Perfil",
+      "backup": "Backup"
+    },
+    "toast": {
+      "failed": "Falha"
+    },
+    "notifications": {
+      "title": "Envios recentes",
+      "subtitle": "Últimos envios de e-mail/WhatsApp. Use esta lista para diagnosticar falhas de SMTP ou destinatário inválido (ex.: o admin@admin.com padrão do seed).",
+      "empty": "Nenhum envio registrado ainda.",
+      "col": {
+        "when": "Quando",
+        "type": "Tipo",
+        "channel": "Canal",
+        "recipient": "Destinatário",
+        "status": "Status",
+        "error": "Erro"
+      }
+    },
+    "event": {
+      "title": "Dados do casamento",
+      "coupleNames": "Nomes do casal",
+      "eventDate": "Data do evento",
+      "currency": "Moeda",
+      "currencyBRL": "Real (BRL)",
+      "currencyUSD": "Dólar (USD)",
+      "currencyEUR": "Euro (EUR)",
+      "contingency": "Contingência (%)",
+      "save": "Salvar",
+      "toast": {
+        "saved": "Configurações salvas",
+        "saveFailed": "Falha ao salvar",
+        "pixSaved": "Pix atualizado"
+      }
+    },
+    "pix": {
+      "title": "Pix (cota lua de mel)",
+      "subtitle": "Configure a chave Pix do casal para gerar QR Code estático nos presentes em dinheiro.",
+      "key": "Chave Pix",
+      "keyType": "Tipo de chave",
+      "typeCPF": "CPF",
+      "typeCNPJ": "CNPJ",
+      "typeEmail": "Email",
+      "typePhone": "Telefone",
+      "typeRandom": "Aleatória",
+      "holderName": "Nome do recebedor (máx. 25)",
+      "city": "Cidade do recebedor (máx. 15)",
+      "save": "Salvar Pix"
+    },
+    "security": {
+      "loginRequired": "Faça login para gerenciar segurança.",
+      "requiredWarningStrong": "2FA obrigatório para sua função ({role})",
+      "requiredWarningRest": ". Configure agora para manter acesso garantido.",
+      "title": "Autenticação em dois fatores (2FA)",
+      "descEnabled": "Ativada — login pede código do app autenticador.",
+      "descDisabled": "Adicione uma camada extra usando Google Authenticator, 1Password ou similar.",
+      "badgeActive": "Ativa",
+      "badgeInactive": "Inativa",
+      "enable": "Ativar 2FA",
+      "step1": "1. Escaneie o QR Code com seu app autenticador (Google Authenticator, 1Password, Authy).",
+      "manualHint": "Se não conseguir escanear, digite manualmente:",
+      "step2": "2. Confirme com o código atual mostrado no app.",
+      "codeLabel": "Código de 6 dígitos",
+      "confirmEnable": "Confirmar e ativar",
+      "cancel": "Cancelar",
+      "backupTitle": "🔑 Guarde estes códigos de backup",
+      "backupHint": "Use no lugar do código TOTP se perder acesso ao app. Cada um só funciona uma vez.",
+      "backupDismiss": "Já anotei, ocultar",
+      "disableLabel": "Para desativar, digite um código TOTP ou de backup",
+      "disable": "Desativar 2FA",
+      "toast": {
+        "enabled": "2FA ativado",
+        "disabled": "2FA desativado"
+      }
+    },
+    "team": {
+      "title": "Membros",
+      "subtitleManage": "Crie usuários direto. O sistema envia as credenciais por email e/ou WhatsApp.",
+      "subtitleReadonly": "Apenas administradores e os noivos podem gerenciar membros.",
+      "newUser": "Novo usuário",
+      "searchPlaceholder": "Buscar por nome ou email",
+      "allRoles": "Todas as funções",
+      "showArchived": "Mostrar arquivados",
+      "noMembers": "Nenhum membro encontrado com os filtros atuais.",
+      "row": {
+        "you": "(você)",
+        "joined": "entrou {date}",
+        "lastLogin": "último login {date}",
+        "archived": "Arquivado",
+        "active": "Ativo",
+        "inactive": "Inativo",
+        "twoFactor": "2FA",
+        "tempPassword": "Senha provisória",
+        "actions": "Ações"
+      },
+      "menu": {
+        "edit": "Editar",
+        "resetPassword": "Redefinir senha",
+        "reset2fa": "Redefinir 2FA",
+        "deactivate": "Desativar",
+        "activate": "Reativar",
+        "restore": "Restaurar",
+        "archive": "Arquivar"
+      },
+      "confirm": {
+        "reset2faTitle": "Redefinir 2FA de {name}?",
+        "reset2faDesc": "Os códigos atuais deixarão de funcionar. O usuário precisará configurar novamente.",
+        "reset2faLabel": "Redefinir",
+        "activateTitle": "Reativar {name}?",
+        "deactivateTitle": "Desativar {name}?",
+        "activateDesc": "O usuário voltará a poder fazer login.",
+        "deactivateDesc": "O usuário não poderá entrar até ser reativado.",
+        "activateLabel": "Reativar",
+        "deactivateLabel": "Desativar",
+        "archiveTitle": "Arquivar {name}?",
+        "archiveDesc": "O usuário é desativado e some da lista (pode ser restaurado depois).",
+        "archiveLabel": "Arquivar",
+        "restoreTitle": "Restaurar {name}?",
+        "restoreDesc": "O usuário volta para a lista ativa.",
+        "restoreLabel": "Restaurar"
+      },
+      "toast": {
+        "reset2fa": "2FA redefinido",
+        "activated": "Usuário reativado",
+        "deactivated": "Usuário desativado",
+        "archived": "Usuário arquivado",
+        "restored": "Usuário restaurado",
+        "created": "Usuário criado",
+        "updated": "Usuário atualizado",
+        "passwordReset": "Senha redefinida — compartilhe a nova com o usuário"
+      },
+      "password": {
+        "show": "Mostrar",
+        "hide": "Ocultar",
+        "generate": "Gerar"
+      },
+      "create": {
+        "title": "Novo usuário",
+        "name": "Nome",
+        "email": "Email",
+        "phone": "Telefone (WhatsApp, opcional)",
+        "phoneHint": "Formato E.164 (com + e DDI). Usado para enviar credenciais e lembretes.",
+        "tempPassword": "Senha provisória (mínimo {min} caracteres)",
+        "mustChangeHint": "O usuário será obrigado a trocar a senha no primeiro login.",
+        "role": "Função",
+        "cancel": "Cancelar",
+        "submit": "Criar usuário"
+      },
+      "edit": {
+        "title": "Editar {name}",
+        "name": "Nome",
+        "email": "E-mail",
+        "phone": "Telefone (WhatsApp, opcional)",
+        "role": "Função",
+        "selfRoleHint": "Você não pode alterar a própria função.",
+        "cancel": "Cancelar",
+        "submit": "Salvar"
+      },
+      "reset": {
+        "title": "Redefinir senha de {name}",
+        "hint": "O usuário será obrigado a trocar a senha no próximo login.",
+        "newPassword": "Nova senha provisória",
+        "cancel": "Cancelar",
+        "submit": "Redefinir"
+      }
+    },
+    "policy": {
+      "title": "Política de segurança",
+      "subtitle": "Defina quem precisa de 2FA obrigatório e o tamanho mínimo de senha.",
+      "require2faLabel": "2FA obrigatório nas funções:",
+      "minPasswordLength": "Tamanho mínimo da senha",
+      "save": "Salvar política",
+      "toast": {
+        "saved": "Política de segurança salva"
+      }
+    },
+    "profile": {
+      "loginRequired": "Faça login para gerenciar o perfil.",
+      "title": "Meu perfil",
+      "emailLabel": "Email:",
+      "roleLabel": "Função:",
+      "lastLogin": "Último login: {date}",
+      "passwordUpdatedAt": "Senha atualizada em {date}",
+      "passwordNeverChanged": "Senha nunca trocada",
+      "displayName": "Nome de exibição",
+      "saveName": "Salvar nome",
+      "changePasswordTitle": "Trocar minha senha",
+      "changePasswordHint": "Digite a senha atual e a nova. A nova precisa ser diferente da atual.",
+      "currentPassword": "Senha atual",
+      "newPassword": "Nova senha",
+      "updatePassword": "Atualizar senha",
+      "twoFactorTitle": "Autenticação em dois fatores",
+      "twoFactorEnabled": "Ativada. Você pode desativar na aba Segurança.",
+      "twoFactorDisabled": "Inativa. Ative na aba Segurança para reforçar sua conta.",
+      "twoFactorSeeTab": "Veja a aba “Segurança” para configurar.",
+      "toast": {
+        "nameUpdated": "Nome atualizado",
+        "passwordUpdated": "Senha atualizada"
+      }
+    },
+    "backup": {
+      "exportTitle": "Exportar backup",
+      "exportSubtitle": "Baixa um JSON com fornecedores, pagamentos, aportes, configurações, convidados e tudo mais. Inclui checksum SHA-256 para validação.",
+      "exportButton": "Exportar backup JSON",
+      "exportHint": "Faça um backup mensal e antes/depois do casamento. Guarde em local seguro — o arquivo contém dados sensíveis.",
+      "restoreTitle": "Restaurar backup",
+      "restoreSubtitleAdmin": "Carregue um JSON exportado por este sistema. O restore apaga e recria todos os dados na transação. Só admins.",
+      "restoreSubtitleReadonly": "Apenas administradores podem restaurar backups. Você pode validar o arquivo aqui, mas o restore exige role ADMIN.",
+      "fileLabel": "Arquivo .json",
+      "validateButton": "Validar arquivo",
+      "clear": "Limpar",
+      "warnStrong": "O restore apaga TODOS os dados atuais",
+      "warnRest": " e os substitui pelos do arquivo. Esta operação não pode ser desfeita. Faça um backup antes.",
+      "passwordLabel": "Sua senha (confirmação)",
+      "acknowledgeStart": "Entendo que esta ação",
+      "acknowledgeStrong": "apaga todos os dados",
+      "acknowledgeEnd": " do sistema e os substitui pelos do arquivo. Já fiz um backup antes.",
+      "restoreNow": "Restaurar agora",
+      "restoreDone": "Restore concluído.",
+      "totalRestored": "Total restaurado:",
+      "zeroRecords": "0 registros",
+      "accountPreserved": "Sua conta foi preservada pois não estava no backup.",
+      "confirm": {
+        "title": "Confirmar restauração",
+        "description": "Esta ação é IRREVERSÍVEL. Todos os dados atuais serão substituídos pelos do arquivo. Continuar?",
+        "restoring": "Restaurando…",
+        "confirmLabel": "Sim, restaurar",
+        "cancel": "Cancelar"
+      },
+      "toast": {
+        "selectFirst": "Selecione um arquivo de backup primeiro.",
+        "invalidFile": "Arquivo de backup inválido.",
+        "validated": "Arquivo de backup validado.",
+        "validateFailed": "Falha ao validar arquivo",
+        "restoreFailed": "Falha ao restaurar backup.",
+        "restored": "Backup restaurado com sucesso. Recarregando…",
+        "restoreError": "Falha ao restaurar"
+      },
+      "validation": {
+        "invalid": "Arquivo inválido",
+        "root": "(raiz)",
+        "moreIssues": "...e mais {count} problemas.",
+        "summary": "✓ Backup v{version} válido — {rows} registros, exportado em {date}.",
+        "host": "host: {host}",
+        "app": "app: v{version}",
+        "checksum": "checksum:"
+      }
+    },
+    "modal": {
+      "close": "Fechar"
+    },
+    "whatsapp": {
+      "title": "WhatsApp",
+      "subtitle": "Conecte um número para enviar credenciais, lembretes e redefinições de senha pelo WhatsApp.",
+      "needsManualAction": "Ação necessária: a sessão expirou ou foi desvinculada. Clique em \"Conectar\" para gerar um novo QR Code.",
+      "reconnecting": "Tentando reconectar automaticamente · tentativas: {attempts}",
+      "lastDisconnect": "caiu em {date}",
+      "qrInstructions": "Abra o WhatsApp no celular → Configurações → Aparelhos conectados → Conectar um aparelho. Escaneie:",
+      "qrAlt": "QR Code do WhatsApp",
+      "disconnect": "Desconectar",
+      "reopenQr": "Reabrir QR",
+      "connect": "Conectar",
+      "refresh": "Atualizar",
+      "testTitle": "Enviar mensagem de teste",
+      "sendTest": "Enviar teste",
+      "status": {
+        "connected": "Conectado",
+        "connectedWithPhone": "Conectado ({phone})",
+        "waitingQr": "Aguardando leitura do QR Code",
+        "connecting": "Conectando...",
+        "disconnected": "Desconectado"
+      },
+      "toast": {
+        "connecting": "Iniciando conexão. Escaneie o QR Code.",
+        "disconnected": "WhatsApp desconectado",
+        "numberRequired": "Informe um número",
+        "testSent": "Mensagem de teste enviada"
+      }
+    }
+  },
+  "tasks": {
+    "page": {
+      "title": "Tarefas",
+      "subtitle": "Use o template pronto de 12 meses ou crie tarefas avulsas. Exporta para o calendário."
+    },
+    "toast": {
+      "created": "Tarefa criada",
+      "updated": "Tarefa atualizada",
+      "removed": "Tarefa removida",
+      "failed": "Falha",
+      "templatesAllExist": "Todas as tarefas do template já existem",
+      "templatesCreated": "{count} tarefa(s) criadas"
+    },
+    "filter": {
+      "all": "Todas",
+      "open": "Em aberto",
+      "overdue": "Atrasadas",
+      "week": "Próximos 7 dias"
+    },
+    "view": {
+      "list": "Lista",
+      "kanban": "Kanban"
+    },
+    "toolbar": {
+      "exportIcs": "Exportar (.ics)",
+      "loadTemplate": "Carregar template",
+      "newTask": "Nova tarefa"
+    },
+    "delete": {
+      "title": "Excluir tarefa?",
+      "titleNamed": "Excluir \"{title}\"?"
+    },
+    "list": {
+      "empty": "Nenhuma tarefa neste filtro."
+    },
+    "kanban": {
+      "empty": "Vazio"
+    },
+    "row": {
+      "complete": "Concluir",
+      "reopen": "Reabrir",
+      "template": "template"
+    },
+    "status": {
+      "TODO": "A fazer",
+      "IN_PROGRESS": "Em andamento",
+      "DONE": "Concluído",
+      "BLOCKED": "Bloqueado"
+    },
+    "priority": {
+      "LOW": "Baixa",
+      "MEDIUM": "Média",
+      "HIGH": "Alta",
+      "URGENT": "Urgente"
+    },
+    "form": {
+      "createTitle": "Nova tarefa",
+      "editTitle": "Editar tarefa",
+      "title": "Título",
+      "deadline": "Prazo",
+      "responsible": "Responsável",
+      "responsiblePlaceholder": "noivo / noiva / cerimonial",
+      "priority": "Prioridade",
+      "vendor": "Fornecedor",
+      "venue": "Local"
+    }
+  },
+  "trousseau": {
+    "page": {
+      "title": "Enxoval",
+      "subtitle": "Liste o que falta comprar, marque prioridade e acompanhe o orçamento por cômodo."
+    },
+    "stats": {
+      "estimated": "Estimado",
+      "bought": "Comprado",
+      "toBuy": "A comprar",
+      "gifted": "Ganhei"
+    },
+    "filter": {
+      "all": "Todos"
+    },
+    "status": {
+      "TO_BUY": "A comprar",
+      "BOUGHT": "Comprado",
+      "GIFTED": "Ganhei"
+    },
+    "room": {
+      "KITCHEN": "Cozinha",
+      "BATHROOM": "Banheiro",
+      "BEDROOM": "Quarto",
+      "LIVING": "Sala",
+      "LAUNDRY": "Lavanderia",
+      "ELECTRONICS": "Eletro",
+      "OTHER": "Outros"
+    },
+    "priority": {
+      "ESSENTIAL": "Essencial",
+      "NICE_TO_HAVE": "Desejável",
+      "LUXURY": "Luxo"
+    },
+    "list": {
+      "add": "Novo item",
+      "empty": "Nada por aqui ainda."
+    },
+    "card": {
+      "paid": "(pago: {value})",
+      "storeLink": "Link da loja",
+      "toggleBought": "Alternar comprado",
+      "toggleGifted": "Ganhei"
+    },
+    "confirmDelete": {
+      "title": "Excluir item?"
+    },
+    "form": {
+      "createTitle": "Novo item do enxoval",
+      "editTitle": "Editar item",
+      "item": "Item",
+      "room": "Cômodo",
+      "priority": "Prioridade",
+      "estimatedPrice": "Preço estimado",
+      "actualPrice": "Preço pago",
+      "store": "Loja",
+      "link": "Link",
+      "notes": "Notas"
+    },
+    "toast": {
+      "created": "Item adicionado",
+      "updated": "Item atualizado",
+      "deleted": "Item removido"
+    }
+  },
+  "vendors": {
+    "page": {
+      "title": "Fornecedores"
+    },
+    "list": {
+      "new": "Novo Fornecedor",
+      "empty": "Nenhum fornecedor cadastrado.",
+      "noResults": "Nenhum resultado para o filtro.",
+      "searchPlaceholder": "Buscar fornecedor..."
+    },
+    "filter": {
+      "allStatus": "Todos os status"
+    },
+    "status": {
+      "negotiation": "Em Negociação",
+      "contracted": "Contratado",
+      "finalized": "Finalizado"
+    },
+    "value": {
+      "real": "Real",
+      "estimated": "Estimado"
+    },
+    "table": {
+      "category": "Categoria",
+      "select": "Selecionar",
+      "selectVendor": "Selecionar {name}"
+    },
+    "compareButton": {
+      "label": "Comparar ({count})",
+      "selectMore": "Selecione mais 1 para comparar"
+    },
+    "statusPrompt": {
+      "message": "Qual o valor REAL contratado com {name}? (apenas números, ex: 12500.00)",
+      "invalidValue": "Valor inválido"
+    },
+    "form": {
+      "createTitle": "Novo Fornecedor",
+      "editTitle": "Editar {name}",
+      "name": "Nome",
+      "namePlaceholder": "Ex: Buffet Colonial",
+      "category": "Categoria",
+      "categoryChoose": "— escolher —",
+      "freeLabel": "Rótulo livre",
+      "freeLabelPlaceholder": "Ex: Alimentação",
+      "estimatedValue": "Valor estimado (R$)",
+      "estimatedValuePlaceholder": "Ex: 15000.00",
+      "actualValue": "Valor real (R$)",
+      "actualValuePlaceholder": "Vazio = ainda não fechado",
+      "contractLink": "Link do contrato (opcional)",
+      "notes": "Notas",
+      "notesPlaceholder": "Observações, contatos, condições...",
+      "saveChanges": "Salvar alterações"
+    },
+    "delete": {
+      "title": "Excluir fornecedor?",
+      "titleNamed": "Excluir {name}?",
+      "description": "Essa ação fará exclusão lógica do fornecedor, seus orçamentos e pagamentos associados.\nVocê não verá mais esses registros nas listagens."
+    },
+    "toast": {
+      "created": "Fornecedor criado",
+      "createFailed": "Falha ao criar",
+      "updated": "Fornecedor atualizado",
+      "updateFailed": "Falha ao atualizar",
+      "deleted": "Fornecedor excluído",
+      "deleteFailed": "Falha ao excluir",
+      "statusUpdated": "Status atualizado",
+      "failed": "Falha"
+    },
+    "compare": {
+      "back": "Voltar para fornecedores",
+      "title": "Comparar propostas",
+      "hint": "Marque 2 a 4 fornecedores na lista e clique em \"Comparar\".",
+      "comparing": "Comparando {count} fornecedor(es).",
+      "criterion": "Critério",
+      "open": "Abrir →",
+      "legend": "💡 Cor verde no preço marca o mais barato; ⭐ no rating marca o melhor avaliado.",
+      "status": {
+        "negotiation": "Em Negociação",
+        "contracted": "Contratado",
+        "finalized": "Finalizado"
+      },
+      "row": {
+        "status": "Status",
+        "rating": "Rating",
+        "totalValue": "Valor total",
+        "paid": "Já pago",
+        "balance": "Saldo",
+        "indicatedBy": "Indicado por",
+        "tags": "Tags",
+        "counts": "Contatos / Contratos / Anexos",
+        "notes": "Notas",
+        "lastInteraction": "Última interação",
+        "contractLink": "Link contrato"
+      },
+      "empty": {
+        "title": "Nenhum fornecedor selecionado.",
+        "description": "Volte para a lista, marque os checkboxes dos fornecedores que quer comparar e clique em \"Comparar\".",
+        "cta": "Ir para fornecedores →"
+      }
+    },
+    "detail": {
+      "back": "Voltar para fornecedores",
+      "status": {
+        "negotiation": "Em Negociação",
+        "contracted": "Contratado",
+        "finalized": "Finalizado"
+      },
+      "header": {
+        "indicatedBy": "Indicado por: {name}",
+        "contractLink": "Link do contrato",
+        "budgeted": "Orçado",
+        "paid": "Já pago",
+        "balance": "Saldo"
+      },
+      "toast": {
+        "failed": "Falha"
+      },
+      "contacts": {
+        "title": "Contatos",
+        "empty": "Nenhum contato cadastrado.",
+        "primary": "Principal",
+        "deleteAria": "Excluir contato",
+        "formTitle": "Novo contato",
+        "name": "Nome",
+        "role": "Função (ex: gerente, atendimento)",
+        "isPrimary": "Contato principal",
+        "removeTitle": "Remover contato?",
+        "added": "Contato adicionado",
+        "removed": "Contato removido"
+      },
+      "notes": {
+        "title": "Notas e negociação",
+        "bodyPlaceholder": "Anote o que aconteceu, decidiu, combinou...",
+        "add": "Adicionar",
+        "empty": "Sem notas ainda. Use este espaço como histórico de negociação.",
+        "deleteAria": "Excluir nota",
+        "removeTitle": "Remover nota?",
+        "added": "Nota adicionada",
+        "removed": "Nota removida"
+      },
+      "noteKind": {
+        "NOTE": "Nota",
+        "NEGOTIATION_EVENT": "Negociação",
+        "MEETING": "Reunião",
+        "DECISION": "Decisão"
+      },
+      "contracts": {
+        "title": "Contratos",
+        "empty": "Nenhum contrato registrado. Use para guardar cláusulas-chave e versões.",
+        "value": "Valor",
+        "signed": "Assinado",
+        "expires": "Vence",
+        "paymentTerms": "Condições de pagamento",
+        "cancellationPolicy": "Política de cancelamento",
+        "included": "Incluso",
+        "excluded": "Não incluso",
+        "notes": "Observações",
+        "deleteAria": "Excluir contrato",
+        "removeTitle": "Excluir contrato?",
+        "removeDescription": "O contrato será removido da listagem mas pode ser recuperado via banco.",
+        "created": "Contrato criado",
+        "removed": "Contrato removido"
+      },
+      "contractStatus": {
+        "DRAFT": "Rascunho",
+        "SENT": "Enviado",
+        "NEGOTIATING": "Negociando",
+        "SIGNED_DIGITAL": "Assinado (digital)",
+        "SIGNED_PHYSICAL": "Assinado (físico)",
+        "CANCELLED": "Cancelado"
+      },
+      "contractForm": {
+        "title": "Novo contrato",
+        "titleLabel": "Título",
+        "titlePlaceholder": "Ex: Contrato Buffet Colonial",
+        "totalValue": "Valor total (R$)",
+        "signedAt": "Data de assinatura",
+        "expiresAt": "Validade / expiração",
+        "includedItems": "O que está incluso",
+        "excludedItems": "O que NÃO está incluso",
+        "save": "Salvar contrato"
+      },
+      "contractFile": {
+        "noViewPermission": "Documento do contrato disponível, mas seu perfil não tem permissão para visualizá-lo.",
+        "title": "Arquivo do contrato",
+        "inlineFallback": "O navegador não conseguiu exibir o PDF inline.",
+        "openNewTab": "Abrir o contrato em nova aba",
+        "uploadedAt": "enviado em {date}",
+        "uploadedBy": "por {name}",
+        "downloadPdf": "Baixar PDF",
+        "noPdfYet": "Nenhum PDF anexado a este contrato ainda.",
+        "replaceLabel": "Substituir contrato (vira v{version})",
+        "uploadLabel": "Enviar PDF do contrato",
+        "onlyPdf": "Apenas PDF, até 8 MB.",
+        "send": "Enviar",
+        "markSigned": "Marcar como assinado:",
+        "signDigital": "Assinatura digital",
+        "signPhysical": "Assinatura física",
+        "historyShow": "Ver histórico ({count, plural, one {# versão} other {# versões}})",
+        "historyHide": "Esconder histórico ({count, plural, one {# versão} other {# versões}})",
+        "download": "Baixar",
+        "newVersionTitle": "Criar nova versão v{version}?",
+        "newVersionDescription": "A versão atual será arquivada (mantida no histórico por 30 dias). Tem certeza?",
+        "confirmReplace": "Sim, substituir",
+        "updated": "Contrato atualizado",
+        "newVersionToast": "Nova versão v{version}",
+        "pdfSent": "PDF do contrato enviado",
+        "keptVersionToast": "Mantido como v{version}",
+        "signed": "Contrato assinado"
+      },
+      "attachments": {
+        "title": "Anexos",
+        "fileLabel": "Arquivo (PDF/PNG/JPG, até 10MB)",
+        "kindLabel": "Tipo",
+        "send": "Enviar",
+        "empty": "Nenhum arquivo anexado.",
+        "deleteAria": "Excluir anexo",
+        "removeTitle": "Excluir anexo?",
+        "uploaded": "Arquivo anexado",
+        "removed": "Anexo removido"
+      },
+      "attachmentKind": {
+        "CONTRACT": "Contrato",
+        "PROPOSAL": "Proposta",
+        "RECEIPT": "Comprovante",
+        "INVOICE": "NF / Boleto",
+        "ID_DOC": "Documento",
+        "PHOTO": "Foto",
+        "OTHER": "Outro"
+      },
+      "payments": {
+        "title": "Pagamentos",
+        "empty": "Nenhum pagamento. Use a aba Pagamentos para adicionar.",
+        "paid": "Pago",
+        "pending": "Pendente",
+        "manage": "Gerenciar pagamentos →"
+      }
+    }
+  },
+  "venues": {
+    "page": {
+      "title": "Locais / Venues",
+      "subtitle": "Compare candidatos, anote pros e contras e mantenha o checklist da visita."
+    },
+    "list": {
+      "new": "Novo local",
+      "empty": "Nenhum local cadastrado ainda. Adicione candidatos para comparar lado a lado.",
+      "favorite": "Favorito",
+      "deleteAria": "Excluir local",
+      "checklistCount": "Checklist {done}/{total}",
+      "attachments": "{count} anexo(s)",
+      "visitedOn": "Visitado em {date}",
+      "noVisit": "Sem visita"
+    },
+    "fields": {
+      "seated": "Sentados",
+      "standing": "Em pé",
+      "rate": "Locação",
+      "name": "Nome",
+      "address": "Endereço",
+      "mapsUrl": "Link Google Maps / Waze",
+      "baseRate": "Valor locação (R$)",
+      "capacitySeated": "Capacidade sentados",
+      "capacityStanding": "Capacidade em pé",
+      "contactName": "Contato (nome)",
+      "contactPhone": "Contato (telefone)",
+      "visitedAt": "Data da visita",
+      "pros": "Prós",
+      "cons": "Contras",
+      "restrictions": "Restrições",
+      "pricingNotes": "Observações de preço",
+      "notes": "Observações gerais"
+    },
+    "form": {
+      "namePlaceholder": "Ex: Vila dos Lagos",
+      "markFavorite": "Marcar como favorito",
+      "seedChecklist": "Criar checklist padrão de visita (20 perguntas)"
+    },
+    "delete": {
+      "confirmTitle": "Excluir {name}?",
+      "confirmTitleFallback": "Excluir local?",
+      "confirmDescription": "O local e o checklist serão removidos das listagens.",
+      "confirmDescriptionDetail": "O local e o checklist serão marcados como excluídos."
+    },
+    "toast": {
+      "created": "Local criado",
+      "removed": "Local removido",
+      "updated": "Atualizado",
+      "fail": "Falha"
+    },
+    "detail": {
+      "back": "Voltar para locais",
+      "contactLabel": "Contato:",
+      "openMaps": "Abrir no Maps",
+      "closeEdit": "Fechar edição",
+      "deleteVenue": "Excluir local"
+    },
+    "editForm": {
+      "title": "Editar local",
+      "mapsUrl": "Link Maps",
+      "baseRate": "Locação (R$)",
+      "contactName": "Contato",
+      "contactPhone": "Telefone",
+      "visitedAt": "Visitado em",
+      "favorite": "Favorito",
+      "pricingNotes": "Notas de preço"
+    },
+    "checklist": {
+      "title": "Checklist da visita",
+      "answered": "{done}/{total} respondidos",
+      "answerPlaceholder": "Anote a resposta",
+      "deleteItemAria": "Excluir item",
+      "addPlaceholder": "Nova pergunta para o checklist..."
+    },
+    "attachments": {
+      "title": "Anexos",
+      "file": "Arquivo",
+      "kind": "Tipo",
+      "kinds": {
+        "PHOTO": "Foto da visita",
+        "CONTRACT": "Contrato",
+        "PROPOSAL": "Proposta",
+        "OTHER": "Outro"
+      },
+      "upload": "Enviar",
+      "empty": "Sem anexos ainda.",
+      "removed": "Anexo removido",
+      "deleteAria": "Excluir anexo",
+      "deleteTitle": "Excluir anexo?"
+    }
+  },
+  "weddingDay": {
+    "header": {
+      "mode": "Modo Dia do Casamento",
+      "fallbackTitle": "O grande dia",
+      "countdown": "Contagem regressiva",
+      "daysLeft": "{count, plural, one {# dia} other {# dias}}"
+    },
+    "stats": {
+      "confirmed": "Confirmados",
+      "totalHeads": "Total de cabeças",
+      "arrived": "Chegaram",
+      "tasksToday": "Tarefas do dia"
+    },
+    "seatingLink": {
+      "title": "Mapa de assentos",
+      "description": "Organize as mesas e arraste os convidados confirmados para os lugares."
+    },
+    "schedule": {
+      "title": "Cronograma do dia",
+      "empty": "Nenhum cronograma adicionado. Use o botão abaixo para registrar (ex.: 07:00 cabeleireiro, 14:00 chegada do buffet...).",
+      "placeholder": "Ex:\n07:00 — cabeleireiro chega\n11:00 — fotógrafo making of\n16:30 — cerimônia\n..."
+    },
+    "rainPlan": {
+      "title": "Plano B chuva / contingências",
+      "empty": "Sem plano B documentado."
+    },
+    "notes": {
+      "title": "Observações especiais",
+      "empty": "Sem observações.",
+      "closeEdit": "Fechar edição",
+      "openEdit": "Editar cronograma / plano B / observações",
+      "placeholder": "Música primeira dança, valsa, surpresa, sabores do bolo..."
+    },
+    "contacts": {
+      "title": "Contatos críticos",
+      "empty": "Sem fornecedores contratados.",
+      "addContact": "Cadastrar contato"
+    },
+    "tasks": {
+      "title": "Tarefas do dia",
+      "empty": "Nenhuma tarefa marcada para hoje."
+    },
+    "payments": {
+      "title": "Pagamentos do dia"
+    },
+    "checkin": {
+      "title": "Check-in rápido",
+      "searchPlaceholder": "Buscar convidado...",
+      "empty": "Nenhum convidado.",
+      "childPrefix": "Criança · ",
+      "arrived": "Chegou",
+      "mark": "Marcar"
+    },
+    "toast": {
+      "saved": "Salvo",
+      "error": "Falha"
+    },
+    "seating": {
+      "title": "Mapa de assentos",
+      "subtitle": "Arraste convidados confirmados para as mesas. Capacidade considera +1.",
+      "newTable": "Nova mesa",
+      "stats": {
+        "tables": "Mesas",
+        "totalSeats": "Assentos totais",
+        "allocatedGuests": "Convidados alocados"
+      },
+      "hint": {
+        "empty": "Crie a primeira mesa para começar.",
+        "help": "Solte um convidado numa mesa para alocar; arraste pela alça para reordenar."
+      },
+      "table": {
+        "dropGuests": "Solte convidados aqui"
+      },
+      "pool": {
+        "title": "Pool de convidados",
+        "empty": "Todos os confirmados estão alocados. Solte aqui para desalocar."
+      },
+      "form": {
+        "createTitle": "Nova mesa",
+        "editTitle": "Editar mesa",
+        "capacity": "Capacidade",
+        "shape": "Formato",
+        "saving": "Salvando..."
+      },
+      "shape": {
+        "round": "Redonda",
+        "rect": "Retangular",
+        "square": "Quadrada"
+      },
+      "delete": {
+        "title": "Excluir mesa?",
+        "description": "A mesa \"{name}\" será removida e os convidados ficarão sem alocação."
+      },
+      "toast": {
+        "errorTitle": "Erro",
+        "error": "Falha",
+        "created": "Mesa criada",
+        "updated": "Mesa atualizada",
+        "deleted": "Mesa excluída",
+        "tableFull": "Mesa cheia",
+        "tableFullDetail": "Capacidade {capacity}, ocupados {used}, necessário {needed}"
+      },
+      "chip": {
+        "dragAria": "Arrastar {name}"
+      },
+      "card": {
+        "reorderAria": "Reordenar mesa",
+        "editAria": "Editar mesa",
+        "deleteAria": "Excluir mesa"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Resumo

Internacionaliza **toda a UI do dashboard + Server Actions** (pt-BR / en / es), completando a cobertura que o `AGENTS.md` §6.7 listava como *pendente*. Antes, apenas 4 de 80 `.tsx` usavam next-intl.

## O que mudou
- **16 domínios** migrados: home, vendors, venues, tasks, payments, income, assets, goals, guests, gifts, wedding-day, honeymoon, trousseau, insights, reports, settings.
- **Catálogos:** `dashboard.json` (**1403** chaves-folha) e `actions.json` (**206** chaves-folha) em cada idioma, com **paridade total** validada (0 faltando / 0 sobrando entre pt-BR/en/es) e **0 colisões** no merge. Os blocos pré-existentes de `actions.json` (common/auth/passwordReset/onboarding/profile) foram preservados.
- **pt-BR verbatim:** os valores pt-BR preservam as strings originais exatas — não muda nada visualmente em pt-BR e mantém as ~16 suítes de teste de actions passando (o mock de `getTranslations` resolve as chaves para o texto pt-BR real).
- **EN/ES:** traduções reais (não placeholders), com plurais ICU onde há contagem.
- Reaproveita `common` / `actions.common` (save/cancel/labels/status/zod/unauthorized) sem duplicar. **Nenhum** arquivo `*.test.*` alterado.

## Padrão seguido
- Client Component → `useTranslations("dashboard.<domínio>")`
- RSC → `await getTranslations(...)`
- Server Action → `getTranslations("actions.<ns>")` + `zodErrorMessage(err, await getTranslations("common"))`

## Verificação (sobre o main atual, com TypeScript 6.0.3 + baileys rc13)
- `npm run lint` ✅ 0 erros / 0 warnings
- `npm run test:run` ✅ 539 testes
- `npm run build` ✅ limpo, **zero** `MISSING_MESSAGE`

## ⚠️ Revisão necessária
**EN/ES são 1ª passada automatizada por IA** e precisam de **revisão humana de qualidade/idiomática** antes do merge. pt-BR é seguro (verbatim).

## Pendências relacionadas (fora do escopo)
- Propagação de `EventSettings.currency` em `formatCurrency` (~73 call-sites).
- Resolução global de `?lang=` (hoje só no RSVP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
