### PR TITLE
fix: elevar limite de body das Server Actions para uploads (10 MB)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,13 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@whiskeysockets/baileys"],
+  experimental: {
+    // Uploads via Server Action (anexos, arte do Save the Date) chegam a 10 MB.
+    // O padrão do Next é 1 MB, o que causava "Body exceeded 1 MB limit" (413).
+    serverActions: {
+      bodySizeLimit: "12mb",
+    },
+  },
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Problema

Uploads via Server Action (arte do **Save the Date** e **anexos** de fornecedores/locais) falhavam com `Body exceeded 1 MB limit` (HTTP 413) quando o arquivo passava de ~1 MB:

```
uncaughtException: Error: Body exceeded 1 MB limit.
statusCode: 413
```

O padrão do Next.js para Server Actions é **1 MB**, mas as ações de upload aceitam até **10 MB** (`saveSaveTheDateConfig`, `uploadAttachment`). Era um limite latente que passou a aparecer ao salvar a arte do Save the Date.

## Correção

Define `experimental.serverActions.bodySizeLimit = "12mb"` em `next.config.ts` (10 MB do arquivo + folga do multipart). Corrige tanto o Save the Date quanto os uploads de anexos já existentes.

## Verificação

- `npm run build` ✅ (config `serverActions` reconhecida)

> ⚠️ Requer **reiniciar o processo** em produção (`pm2 restart wedding-management-system`) para a mudança de `next.config.ts` valer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)