### PR TITLE
feat(save-the-date): exclusão por tag, variáveis de link, teste p/ outro contato e refinamentos

### DIFF
--- a/docs/banco-de-dados.md
+++ b/docs/banco-de-dados.md
@@ -59,7 +59,7 @@ Arquivo: [prisma/schema.prisma](../prisma/schema.prisma).
 | `PasswordResetToken` | Tokens de reset (hash sha256, expira em 60min). |
 | `NotificationLog` | Histórico de envios (email + WhatsApp), idempotência por dia. |
 | `SecuritySettings` | Singleton: lista de roles que exigem 2FA, tamanho mínimo de senha. |
-| `EventSettings` | Singleton: dados do casamento (data, contingência, moeda, nomes, plano B, `defaultLocale`). Inclui Save the Date: `weddingWebsiteUrl`, `giftRegistryUrl`, `saveTheDateMessage`, `saveTheDateFilePath/Mime/Name` (a arte). |
+| `EventSettings` | Singleton: dados do casamento (data, contingência, moeda, nomes, plano B, `defaultLocale`). Inclui Save the Date: `weddingWebsiteUrl`, `giftRegistryUrl`, `saveTheDateMessage`, `saveTheDateFilePath/Mime/Name` (a arte) e a exclusão de destinatários `saveTheDateExcludeTagIds` (JSON de IDs de tag) + `saveTheDateExcludePadrinhos`. |
 | `Vendor` | Fornecedores com status, categoria, notas, contratos, anexos. |
 | `VendorContact` | Múltiplos contatos por fornecedor (com isPrimary). |
 | `VendorNote` | Histórico de notas livre por fornecedor. |

--- a/docs/save-the-date.md
+++ b/docs/save-the-date.md
@@ -64,3 +64,30 @@ Módulo para avisar os convidados da **data** do casamento — com uma arte
   telefone válido, cai no e-mail; sem nenhum, o destinatário fica `SKIPPED`.
 - Arte: PNG, JPG, WEBP ou PDF, até 10 MB.
 - A arte é servida (preview na UI) por `GET /api/save-the-date/art` (autenticado).
+
+## Iteração 2 — refinamentos
+
+- **Exclusão por tag/padrinho**: `EventSettings.saveTheDateExcludeTagIds` (JSON de
+  IDs de `GuestTag`) + `saveTheDateExcludePadrinhos` (Boolean). Regra **ANY**: um
+  grupo é excluído se **qualquer** integrante tiver a tag/flag; avulso, se ele
+  próprio tiver. Aplicada em `buildSaveTheDateRecipients(..., { excludeTagIds,
+  excludePadrinhos })`.
+- **Variáveis de link**: `{site}` → site dos noivos; `{site-presentes}` → lista de
+  presentes. Quando usadas no corpo, entram inline; quando não, são anexadas ao
+  fim (compatível). Helpers puros em
+  [src/lib/notifications/std-message.ts](../src/lib/notifications/std-message.ts)
+  (`interpolateBaseTags`, `applySiteTags`) — compartilhados por template e preview.
+- **Teste para outro contato**: `sendTestSaveTheDate` aceita `to` (telefone `+55…`
+  ou e-mail); vazio = próprio usuário.
+- **E-mail sem branding**: no kind `SAVE_THE_DATE`, `wrapHtml` recebe cabeçalho =
+  nomes do casal e rodapé vazio (sem "Wedding Finance" / "mensagem automática").
+- **Pré-lista**: `getSaveTheDateRecipients()` devolve quem vai receber (canal +
+  status) — renderizada em "Quem vai receber".
+- **Não reenviar**: toggle `skipAlreadySent` em `startSaveTheDateBroadcast` —
+  coleta `refId`s já `SENT` em broadcasts `SAVE_THE_DATE` e os pula.
+- **Lista detalhada + CSV**: `getSaveTheDateBroadcastRecipients(broadcastId)` +
+  exportação CSV na UI.
+- **Normalização de telefone**: `normalizeMsisdn` (em `std-message.ts`) completa
+  `+55` para números BR sem DDI e **preserva** qualquer número que já comece com
+  `+` (ex.: `+1`, `+34`). Aplicada ao montar destinatários (o número normalizado
+  é gravado em `BroadcastRecipient.phone`).

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,8 @@ model EventSettings {
   saveTheDateFilePath    String?
   saveTheDateFileMime    String?
   saveTheDateFileName    String?
+  saveTheDateExcludeTagIds   String?
+  saveTheDateExcludePadrinhos Boolean @default(false)
   updatedAt              DateTime  @updatedAt
 }
 

--- a/src/app/actions/saveTheDateActions.ts
+++ b/src/app/actions/saveTheDateActions.ts
@@ -10,7 +10,7 @@ import { audit } from "@/lib/audit";
 import { zodErrorMessage } from "@/lib/zod-i18n";
 import { denyIfNoManage } from "@/lib/finance-access";
 import { getClientIp, rateLimit } from "@/lib/rate-limit";
-import { updateEventConfig } from "@/lib/event-config";
+import { getEventConfig, updateEventConfig } from "@/lib/event-config";
 import { coerceLocale } from "@/i18n/config";
 import { saveUpload, removeUpload } from "@/lib/storage";
 import { detectMagic, assertMagicMatchesMime, FileValidationError } from "@/lib/file-validation";
@@ -19,7 +19,8 @@ import {
   sendSaveTheDate,
 } from "@/lib/notifications/save-the-date";
 import { armBroadcastWorker } from "@/lib/notifications/broadcast-worker";
-import { buildSaveTheDateRecipients } from "@/lib/notifications/recipients";
+import { buildSaveTheDateRecipients, type BuiltRecipient } from "@/lib/notifications/recipients";
+import { normalizeMsisdn } from "@/lib/notifications/std-message";
 import type { ActionResult } from "@/types";
 
 const ART_MIME = new Set(["application/pdf", "image/png", "image/jpeg", "image/webp"]);
@@ -46,6 +47,10 @@ const ConfigSchema = z.object({
   removeArt: z
     .preprocess((v) => v === "on" || v === true || v === "true", z.boolean())
     .optional(),
+  excludeTagIds: z.array(z.string().min(1).max(64)).max(100).default([]),
+  excludePadrinhos: z
+    .preprocess((v) => v === "on" || v === true || v === "true", z.boolean())
+    .default(false),
 });
 
 export async function saveSaveTheDateConfig(
@@ -61,6 +66,8 @@ export async function saveSaveTheDateConfig(
     giftRegistryUrl: formData.get("giftRegistryUrl") ?? "",
     saveTheDateMessage: formData.get("saveTheDateMessage") ?? "",
     removeArt: formData.get("removeArt") ?? undefined,
+    excludeTagIds: formData.getAll("excludeTagIds").map(String),
+    excludePadrinhos: formData.get("excludePadrinhos") ?? undefined,
   });
   if (!parsed.success) {
     return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
@@ -117,6 +124,9 @@ export async function saveSaveTheDateConfig(
       weddingWebsiteUrl: parsed.data.weddingWebsiteUrl,
       giftRegistryUrl: parsed.data.giftRegistryUrl,
       saveTheDateMessage: parsed.data.saveTheDateMessage,
+      saveTheDateExcludeTagIds:
+        parsed.data.excludeTagIds.length > 0 ? JSON.stringify(parsed.data.excludeTagIds) : null,
+      saveTheDateExcludePadrinhos: parsed.data.excludePadrinhos,
       ...artUpdate,
     });
 
@@ -139,6 +149,12 @@ export async function saveSaveTheDateConfig(
 
 const TestSchema = z.object({
   channel: z.enum(["WHATSAPP", "EMAIL"]),
+  to: z
+    .string()
+    .trim()
+    .max(160)
+    .optional()
+    .transform((v) => (v && v.length > 0 ? v : null)),
 });
 
 export async function sendTestSaveTheDate(
@@ -158,7 +174,10 @@ export async function sendTestSaveTheDate(
     return { success: false, error: t("tooManyAttempts") };
   }
 
-  const parsed = TestSchema.safeParse({ channel: formData.get("channel") });
+  const parsed = TestSchema.safeParse({
+    channel: formData.get("channel"),
+    to: formData.get("to") ?? "",
+  });
   if (!parsed.success) {
     return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
   }
@@ -169,11 +188,21 @@ export async function sendTestSaveTheDate(
   });
   if (!user) return { success: false, error: t("unauthorized") };
 
-  if (parsed.data.channel === "WHATSAPP" && !user.phone) {
-    return { success: false, error: t("noUserPhone") };
-  }
-  if (parsed.data.channel === "EMAIL" && !user.email) {
-    return { success: false, error: t("noUserEmail") };
+  // Destino: o informado (se houver) ou o próprio usuário.
+  let targetPhone: string | null = null;
+  let targetEmail: string | null = null;
+  if (parsed.data.channel === "WHATSAPP") {
+    const phone = parsed.data.to ? normalizeMsisdn(parsed.data.to) : user.phone;
+    if (!phone) return { success: false, error: t("noUserPhone") };
+    if (!/^\+\d{10,15}$/.test(phone)) return { success: false, error: t("invalidPhone") };
+    targetPhone = phone;
+  } else {
+    const email = parsed.data.to ?? user.email;
+    if (!email) return { success: false, error: t("noUserEmail") };
+    if (!z.string().email().safeParse(email).success) {
+      return { success: false, error: t("invalidEmail") };
+    }
+    targetEmail = email;
   }
 
   const loaded = await loadSaveTheDateContext();
@@ -185,8 +214,8 @@ export async function sendTestSaveTheDate(
     ctx: loaded.ctx,
     target: {
       userId,
-      phone: parsed.data.channel === "WHATSAPP" ? user.phone : null,
-      email: parsed.data.channel === "EMAIL" ? user.email : null,
+      phone: targetPhone,
+      email: targetEmail,
       locale: user.locale ? coerceLocale(user.locale) : loaded.ctx.defaultLocale,
     },
     recipientNames: user.name ?? loaded.ctx.coupleNames,
@@ -204,8 +233,29 @@ export async function sendTestSaveTheDate(
   return { success: true };
 }
 
-async function loadRecipients() {
-  const [groups, guests] = await Promise.all([
+async function loadAlreadySentKeys(): Promise<Set<string>> {
+  const sent = await prisma.broadcastRecipient.findMany({
+    where: { status: "SENT", broadcast: { kind: "SAVE_THE_DATE" } },
+    select: { refType: true, refId: true },
+  });
+  return new Set(sent.map((r) => `${r.refType}:${r.refId}`));
+}
+
+async function loadRecipients(
+  opts: { skipAlreadySent?: boolean } = {},
+): Promise<BuiltRecipient[]> {
+  const cfg = await getEventConfig();
+  let excludeTagIds: string[] = [];
+  if (cfg.saveTheDateExcludeTagIds) {
+    try {
+      const parsed = JSON.parse(cfg.saveTheDateExcludeTagIds);
+      if (Array.isArray(parsed)) excludeTagIds = parsed.filter((x): x is string => typeof x === "string");
+    } catch {
+      excludeTagIds = [];
+    }
+  }
+
+  const [groups, guests, alreadySentKeys] = await Promise.all([
     prisma.guestGroup.findMany({
       where: { deletedAt: null },
       select: {
@@ -215,16 +265,25 @@ async function loadRecipients() {
         contactEmail: true,
         guests: {
           where: { deletedAt: null },
-          select: { name: true },
+          select: { name: true, isPadrinho: true, tags: { select: { tagId: true } } },
           orderBy: { name: "asc" },
         },
       },
     }),
     prisma.guest.findMany({
       where: { deletedAt: null, groupId: null },
-      select: { id: true, name: true, phone: true, email: true, language: true },
+      select: {
+        id: true,
+        name: true,
+        phone: true,
+        email: true,
+        language: true,
+        isPadrinho: true,
+        tags: { select: { tagId: true } },
+      },
       orderBy: { name: "asc" },
     }),
+    opts.skipAlreadySent ? loadAlreadySentKeys() : Promise.resolve(new Set<string>()),
   ]);
 
   return buildSaveTheDateRecipients(
@@ -234,6 +293,8 @@ async function loadRecipients() {
       contactPhone: g.contactPhone,
       contactEmail: g.contactEmail,
       memberNames: g.guests.map((m) => m.name),
+      memberTagIds: g.guests.flatMap((m) => m.tags.map((t) => t.tagId)),
+      hasPadrinho: g.guests.some((m) => m.isPadrinho),
     })),
     guests.map((g) => ({
       id: g.id,
@@ -241,8 +302,47 @@ async function loadRecipients() {
       phone: g.phone,
       email: g.email,
       language: g.language,
+      tagIds: g.tags.map((t) => t.tagId),
+      isPadrinho: g.isPadrinho,
     })),
+    {
+      excludeTagIds,
+      excludePadrinhos: cfg.saveTheDateExcludePadrinhos,
+      alreadySentKeys,
+    },
   );
+}
+
+export type RecipientPreviewRow = {
+  refType: string;
+  refId: string;
+  name: string;
+  memberNames: string;
+  channel: "WHATSAPP" | "EMAIL" | "NONE";
+  status: "PENDING" | "SKIPPED";
+  skipReason: string | null;
+};
+
+function toPreviewRow(r: BuiltRecipient): RecipientPreviewRow {
+  const channel = r.phone ? "WHATSAPP" : r.email ? "EMAIL" : "NONE";
+  return {
+    refType: r.refType,
+    refId: r.refId,
+    name: r.name,
+    memberNames: r.memberNames,
+    channel,
+    status: r.status,
+    skipReason: r.skipReason,
+  };
+}
+
+export async function getSaveTheDateRecipients(
+  skipAlreadySent = true,
+): Promise<RecipientPreviewRow[] | null> {
+  const denied = await denyIfNoManage();
+  if (denied) return null;
+  const recipients = await loadRecipients({ skipAlreadySent });
+  return recipients.map(toPreviewRow);
 }
 
 export type BroadcastProgress = {
@@ -276,7 +376,9 @@ async function progressFor(broadcastId: string): Promise<BroadcastProgress | nul
   };
 }
 
-export async function startSaveTheDateBroadcast(): Promise<ActionResult<BroadcastProgress>> {
+export async function startSaveTheDateBroadcast(
+  skipAlreadySent = true,
+): Promise<ActionResult<BroadcastProgress>> {
   const t = await getTranslations("actions.saveTheDate");
   const denied = await denyIfNoManage();
   if (denied) return denied;
@@ -297,9 +399,13 @@ export async function startSaveTheDateBroadcast(): Promise<ActionResult<Broadcas
   const loaded = await loadSaveTheDateContext();
   if (!loaded.ok) return { success: false, error: t("eventNotConfigured") };
 
-  const recipients = await loadRecipients();
-  if (recipients.length === 0) return { success: false, error: t("noRecipients") };
-  const pendingCount = recipients.filter((r) => r.status === "PENDING").length;
+  const recipients = await loadRecipients({ skipAlreadySent });
+  // Excluídos por tag e já-enviados são intencionais: não viram linha no envio.
+  const toQueue = recipients.filter(
+    (r) => r.skipReason !== "EXCLUDED_TAG" && r.skipReason !== "ALREADY_SENT",
+  );
+  if (toQueue.length === 0) return { success: false, error: t("noRecipients") };
+  const pendingCount = toQueue.filter((r) => r.status === "PENDING").length;
   if (pendingCount === 0) return { success: false, error: t("noEligibleRecipients") };
 
   const broadcast = await prisma.$transaction(async (tx) => {
@@ -313,7 +419,7 @@ export async function startSaveTheDateBroadcast(): Promise<ActionResult<Broadcas
       },
     });
     await tx.broadcastRecipient.createMany({
-      data: recipients.map((r) => ({
+      data: toQueue.map((r) => ({
         broadcastId: created.id,
         refType: r.refType,
         refId: r.refId,
@@ -354,6 +460,42 @@ export async function getSaveTheDateBroadcastProgress(
   const denied = await denyIfNoManage();
   if (denied) return null;
   return progressFor(broadcastId);
+}
+
+export type BroadcastRecipientRow = {
+  name: string;
+  memberNames: string;
+  channelUsed: string | null;
+  status: string;
+  error: string | null;
+  sentAt: string | null;
+};
+
+export async function getSaveTheDateBroadcastRecipients(
+  broadcastId: string,
+): Promise<BroadcastRecipientRow[] | null> {
+  const denied = await denyIfNoManage();
+  if (denied) return null;
+  const rows = await prisma.broadcastRecipient.findMany({
+    where: { broadcastId },
+    select: {
+      name: true,
+      memberNames: true,
+      channelUsed: true,
+      status: true,
+      error: true,
+      sentAt: true,
+    },
+    orderBy: [{ status: "asc" }, { name: "asc" }],
+  });
+  return rows.map((r) => ({
+    name: r.name,
+    memberNames: r.memberNames,
+    channelUsed: r.channelUsed,
+    status: r.status,
+    error: r.error,
+    sentAt: r.sentAt ? r.sentAt.toISOString() : null,
+  }));
 }
 
 export async function resendFailedSaveTheDate(

--- a/src/app/dashboard/save-the-date/page.tsx
+++ b/src/app/dashboard/save-the-date/page.tsx
@@ -4,8 +4,10 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { getEventConfig } from "@/lib/event-config";
 import { getWhatsAppStatus } from "@/lib/notifications/whatsapp";
-import { buildSaveTheDateRecipients } from "@/lib/notifications/recipients";
-import { getActiveSaveTheDateBroadcast } from "@/app/actions/saveTheDateActions";
+import {
+  getActiveSaveTheDateBroadcast,
+  getSaveTheDateRecipients,
+} from "@/app/actions/saveTheDateActions";
 import { coerceLocale } from "@/i18n/config";
 import { formatDate } from "@/lib/format";
 import SaveTheDateClient from "./save-the-date-client";
@@ -20,20 +22,11 @@ export default async function SaveTheDatePage() {
   const locale = coerceLocale(await getLocale());
   const cfg = await getEventConfig();
 
-  const [groups, guests, venue, user, active] = await Promise.all([
-    prisma.guestGroup.findMany({
+  const [tags, venue, user, active, recipients] = await Promise.all([
+    prisma.guestTag.findMany({
       where: { deletedAt: null },
-      select: {
-        id: true,
-        name: true,
-        contactPhone: true,
-        contactEmail: true,
-        guests: { where: { deletedAt: null }, select: { name: true }, orderBy: { name: "asc" } },
-      },
-    }),
-    prisma.guest.findMany({
-      where: { deletedAt: null, groupId: null },
-      select: { id: true, name: true, phone: true, email: true, language: true },
+      select: { id: true, name: true, color: true },
+      orderBy: { name: "asc" },
     }),
     prisma.venue.findFirst({
       where: { deletedAt: null },
@@ -45,28 +38,23 @@ export default async function SaveTheDatePage() {
       select: { phone: true, email: true },
     }),
     getActiveSaveTheDateBroadcast(),
+    getSaveTheDateRecipients(true),
   ]);
 
-  const recipients = buildSaveTheDateRecipients(
-    groups.map((g) => ({
-      id: g.id,
-      name: g.name,
-      contactPhone: g.contactPhone,
-      contactEmail: g.contactEmail,
-      memberNames: g.guests.map((m) => m.name),
-    })),
-    guests.map((g) => ({
-      id: g.id,
-      name: g.name,
-      phone: g.phone,
-      email: g.email,
-      language: g.language,
-    })),
-  );
+  const list = recipients ?? [];
+  const eligible = list.filter((r) => r.status === "PENDING").length;
+  const skipped = list.length - eligible;
+  const sampleNames = list.find((r) => r.status === "PENDING")?.memberNames ?? null;
 
-  const eligible = recipients.filter((r) => r.status === "PENDING").length;
-  const skipped = recipients.length - eligible;
-  const sampleNames = recipients.find((r) => r.status === "PENDING")?.memberNames ?? null;
+  let savedExcludeTagIds: string[] = [];
+  if (cfg.saveTheDateExcludeTagIds) {
+    try {
+      const parsed = JSON.parse(cfg.saveTheDateExcludeTagIds);
+      if (Array.isArray(parsed)) savedExcludeTagIds = parsed.filter((x): x is string => typeof x === "string");
+    } catch {
+      savedExcludeTagIds = [];
+    }
+  }
 
   const eventDateStr = cfg.eventDate
     ? formatDate(cfg.eventDate, locale, {
@@ -91,14 +79,17 @@ export default async function SaveTheDatePage() {
           hasArt: Boolean(cfg.saveTheDateFilePath),
           artName: cfg.saveTheDateFileName ?? null,
           artIsImage: (cfg.saveTheDateFileMime ?? "").startsWith("image/"),
+          excludeTagIds: savedExcludeTagIds,
+          excludePadrinhos: cfg.saveTheDateExcludePadrinhos,
         }}
+        tags={tags}
         event={{
           coupleNames: cfg.coupleNames ?? "",
           eventDateStr,
           venueName: venue?.name ?? null,
           configured: Boolean(cfg.eventDate && cfg.coupleNames),
         }}
-        recipients={{ eligible, skipped, sampleNames }}
+        recipients={{ eligible, skipped, sampleNames, list }}
         capabilities={{
           whatsappConnected: getWhatsAppStatus().state === "CONNECTED",
           hasUserPhone: Boolean(user?.phone),

--- a/src/app/dashboard/save-the-date/save-the-date-client.tsx
+++ b/src/app/dashboard/save-the-date/save-the-date-client.tsx
@@ -5,17 +5,22 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import {
   AlertTriangle,
+  Download,
   FileText,
   Globe,
   Gift,
   Image as ImageIcon,
+  ListChecks,
   Loader2,
   Mail,
   MessageCircle,
   Send,
+  Tags,
   Upload,
+  Users,
 } from "lucide-react";
 import { useToast } from "@/components/toast";
+import { interpolateBaseTags, applySiteTags } from "@/lib/notifications/std-message";
 import {
   saveSaveTheDateConfig,
   sendTestSaveTheDate,
@@ -23,8 +28,13 @@ import {
   resendFailedSaveTheDate,
   cancelSaveTheDateBroadcast,
   getSaveTheDateBroadcastProgress,
+  getSaveTheDateBroadcastRecipients,
   type BroadcastProgress,
+  type RecipientPreviewRow,
+  type BroadcastRecipientRow,
 } from "@/app/actions/saveTheDateActions";
+
+type TagOption = { id: string; name: string; color: string | null };
 
 type Props = {
   config: {
@@ -34,14 +44,22 @@ type Props = {
     hasArt: boolean;
     artName: string | null;
     artIsImage: boolean;
+    excludeTagIds: string[];
+    excludePadrinhos: boolean;
   };
+  tags: TagOption[];
   event: {
     coupleNames: string;
     eventDateStr: string | null;
     venueName: string | null;
     configured: boolean;
   };
-  recipients: { eligible: number; skipped: number; sampleNames: string | null };
+  recipients: {
+    eligible: number;
+    skipped: number;
+    sampleNames: string | null;
+    list: RecipientPreviewRow[];
+  };
   capabilities: { whatsappConnected: boolean; hasUserPhone: boolean; hasUserEmail: boolean };
   activeBroadcast: BroadcastProgress | null;
 };
@@ -49,8 +67,15 @@ type Props = {
 const inputClass =
   "w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50";
 
+const MERGE_VARS = ["nomes", "convidados", "data", "local", "site", "site-presentes"] as const;
+
+function csvCell(value: string): string {
+  return /[",\n;]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
 export default function SaveTheDateClient({
   config,
+  tags,
   event,
   recipients,
   capabilities,
@@ -64,6 +89,7 @@ export default function SaveTheDateClient({
   const [message, setMessage] = useState(config.saveTheDateMessage);
   const [website, setWebsite] = useState(config.weddingWebsiteUrl);
   const [registry, setRegistry] = useState(config.giftRegistryUrl);
+  const messageRef = useRef<HTMLTextAreaElement>(null);
   const [configState, configAction, configPending] = useActionState(saveSaveTheDateConfig, undefined);
 
   const [testState, testAction, testPending] = useActionState(sendTestSaveTheDate, undefined);
@@ -71,6 +97,10 @@ export default function SaveTheDateClient({
   const [progress, setProgress] = useState<BroadcastProgress | null>(activeBroadcast);
   const [busy, setBusy] = useState(false);
   const sendingRef = useRef(false);
+  const [skipAlreadySent, setSkipAlreadySent] = useState(true);
+
+  const [detail, setDetail] = useState<BroadcastRecipientRow[] | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
 
   useEffect(() => {
     if (configState?.success) {
@@ -89,7 +119,6 @@ export default function SaveTheDateClient({
     }
   }, [testState, t, tc, toast]);
 
-  // Polling do progresso enquanto o envio está em andamento.
   useEffect(() => {
     if (!progress || progress.status !== "SENDING") return;
     const id = progress.id;
@@ -100,33 +129,50 @@ export default function SaveTheDateClient({
     return () => clearInterval(timer);
   }, [progress]);
 
+  const insertVar = useCallback(
+    (name: string) => {
+      const token = `{${name}}`;
+      const el = messageRef.current;
+      if (!el) {
+        setMessage((m) => m + token);
+        return;
+      }
+      const start = el.selectionStart ?? message.length;
+      const end = el.selectionEnd ?? message.length;
+      const next = message.slice(0, start) + token + message.slice(end);
+      setMessage(next);
+      requestAnimationFrame(() => {
+        el.focus();
+        const pos = start + token.length;
+        el.setSelectionRange(pos, pos);
+      });
+    },
+    [message],
+  );
+
   const previewBody = useMemo(() => {
     const sample = recipients.sampleNames ?? (event.coupleNames || tc("appTitle"));
-    const tags: Record<string, string> = {
+    const baseTags = {
       nomes: event.coupleNames,
       convidados: sample,
       data: event.eventDateStr ?? "",
       local: event.venueName ?? "",
     };
     const custom = message.trim();
-    let body: string;
-    if (custom) {
-      body = custom.replace(/\{(\w+)\}/g, (m, k: string) => (k in tags ? tags[k] : m));
-    } else {
-      const parts = [
-        tn("greeting", { guests: sample }),
-        "",
-        tn("announce", { names: event.coupleNames }),
-        event.venueName
-          ? tn("whenWhere", { date: event.eventDateStr ?? "", venue: event.venueName })
-          : tn("when", { date: event.eventDateStr ?? "" }),
-        "",
-        tn("signoff", { names: event.coupleNames }),
-      ];
-      body = parts.join("\n");
-    }
-    return body;
-  }, [message, recipients.sampleNames, event, tn, tc]);
+    const core = custom
+      ? interpolateBaseTags(custom, baseTags)
+      : [
+          tn("greeting", { guests: sample }),
+          "",
+          tn("announce", { names: event.coupleNames }),
+          event.venueName
+            ? tn("whenWhere", { date: event.eventDateStr ?? "", venue: event.venueName })
+            : tn("when", { date: event.eventDateStr ?? "" }),
+          "",
+          tn("signoff", { names: event.coupleNames }),
+        ].join("\n");
+    return applySiteTags(core, { siteUrl: website || null, registryUrl: registry || null });
+  }, [message, recipients.sampleNames, event, tn, tc, website, registry]);
 
   const runAction = useCallback(
     async (fn: () => Promise<{ success: boolean; error?: string; data?: BroadcastProgress }>, okMsg: string) => {
@@ -151,8 +197,8 @@ export default function SaveTheDateClient({
 
   const handleStart = useCallback(() => {
     if (!window.confirm(t("broadcast.confirmStart", { count: recipients.eligible }))) return;
-    void runAction(() => startSaveTheDateBroadcast(), t("toasts.broadcastStarted"));
-  }, [runAction, t, recipients.eligible]);
+    void runAction(() => startSaveTheDateBroadcast(skipAlreadySent), t("toasts.broadcastStarted"));
+  }, [runAction, t, recipients.eligible, skipAlreadySent]);
 
   const handleResend = useCallback(() => {
     if (!progress) return;
@@ -166,16 +212,49 @@ export default function SaveTheDateClient({
       const res = await cancelSaveTheDateBroadcast(progress.id);
       const next = await getSaveTheDateBroadcastProgress(progress.id);
       if (next) setProgress(next);
-      return res.success
-        ? { success: true as const }
-        : { success: false as const, error: res.error };
+      return res.success ? { success: true as const } : { success: false as const, error: res.error };
     }, t("toasts.broadcastCancelled"));
   }, [runAction, t, progress]);
 
+  const loadDetail = useCallback(async () => {
+    if (!progress) return;
+    setDetailLoading(true);
+    try {
+      const rows = await getSaveTheDateBroadcastRecipients(progress.id);
+      setDetail(rows ?? []);
+    } finally {
+      setDetailLoading(false);
+    }
+  }, [progress]);
+
+  const exportCsv = useCallback(() => {
+    if (!detail) return;
+    const header = ["nome", "integrantes", "canal", "status", "erro", "enviado_em"];
+    const lines = [header.join(",")];
+    for (const r of detail) {
+      lines.push(
+        [r.name, r.memberNames, r.channelUsed ?? "", r.status, r.error ?? "", r.sentAt ?? ""]
+          .map((c) => csvCell(String(c)))
+          .join(","),
+      );
+    }
+    const blob = new Blob([`﻿${lines.join("\n")}`], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "save-the-date-envio.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [detail]);
+
   const isSending = progress?.status === "SENDING";
-  const done = progress ? progress.pending === 0 && progress.status !== "PAUSED" : false;
   const processed = progress ? progress.sent + progress.failed + progress.skipped : 0;
   const pct = progress && progress.total > 0 ? Math.round((processed / Math.max(progress.total, 1)) * 100) : 0;
+
+  const channelLabel = (c: string) =>
+    c === "WHATSAPP" ? t("preList.channelWhatsapp") : c === "EMAIL" ? t("preList.channelEmail") : "—";
+  const rowStatusLabel = (r: RecipientPreviewRow) =>
+    r.status === "PENDING" ? t("preList.willReceive") : t(`preList.reason.${r.skipReason ?? "SKIPPED"}`);
 
   return (
     <div className="grid gap-6 lg:grid-cols-2">
@@ -255,10 +334,24 @@ export default function SaveTheDateClient({
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-zinc-400">
-              {t("config.messageLabel")}
-            </label>
+            <div className="mb-1 flex items-center justify-between">
+              <label className="text-sm font-medium text-zinc-400">{t("config.messageLabel")}</label>
+              <span className="text-xs text-zinc-500">{message.length}/2000</span>
+            </div>
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {MERGE_VARS.map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => insertVar(v)}
+                  className="rounded-lg border border-zinc-700 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-rose-500/50 hover:text-rose-300"
+                >
+                  {`{${v}}`}
+                </button>
+              ))}
+            </div>
             <textarea
+              ref={messageRef}
               name="saveTheDateMessage"
               value={message}
               onChange={(e) => setMessage(e.target.value)}
@@ -268,6 +361,44 @@ export default function SaveTheDateClient({
               className={inputClass}
             />
             <p className="mt-1 text-xs text-zinc-500">{t("config.mergeTagsHint")}</p>
+          </div>
+
+          {/* Exclusão por tag / padrinhos */}
+          <div>
+            <label className="mb-1 flex items-center gap-2 text-sm font-medium text-zinc-400">
+              <Tags className="h-4 w-4" /> {t("config.excludeLabel")}
+            </label>
+            <p className="mb-2 text-xs text-zinc-500">{t("config.excludeHint")}</p>
+            <label className="mb-2 flex items-center gap-2 text-sm text-zinc-300">
+              <input
+                type="checkbox"
+                name="excludePadrinhos"
+                defaultChecked={config.excludePadrinhos}
+                className="rounded border-zinc-700 bg-zinc-950"
+              />
+              {t("config.excludePadrinhos")}
+            </label>
+            {tags.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <label
+                    key={tag.id}
+                    className="flex items-center gap-1.5 rounded-lg border border-zinc-700 bg-zinc-950 px-2 py-1 text-xs text-zinc-300"
+                  >
+                    <input
+                      type="checkbox"
+                      name="excludeTagIds"
+                      value={tag.id}
+                      defaultChecked={config.excludeTagIds.includes(tag.id)}
+                      className="rounded border-zinc-700 bg-zinc-950"
+                    />
+                    {tag.name}
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-zinc-600">{t("config.noTags")}</p>
+            )}
           </div>
 
           <button
@@ -280,39 +411,39 @@ export default function SaveTheDateClient({
           </button>
         </form>
 
-        {/* Envio de teste */}
-        <div className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
+        {/* Envio de teste (próprio ou outro contato) */}
+        <form action={testAction} className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
           <h2 className="text-lg font-semibold text-white">{t("test.title")}</h2>
           <p className="text-sm text-zinc-400">{t("test.subtitle")}</p>
+          <input name="to" placeholder={t("test.toPlaceholder")} className={inputClass} />
+          <p className="text-xs text-zinc-500">{t("test.toHint")}</p>
           <div className="flex flex-wrap gap-3">
-            <form action={testAction}>
-              <input type="hidden" name="channel" value="WHATSAPP" />
-              <button
-                type="submit"
-                disabled={testPending || !capabilities.whatsappConnected || !capabilities.hasUserPhone}
-                className="inline-flex items-center gap-2 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-200 hover:bg-emerald-500/20 disabled:opacity-40"
-              >
-                <MessageCircle className="h-4 w-4" /> {t("test.whatsapp")}
-              </button>
-            </form>
-            <form action={testAction}>
-              <input type="hidden" name="channel" value="EMAIL" />
-              <button
-                type="submit"
-                disabled={testPending || !capabilities.hasUserEmail}
-                className="inline-flex items-center gap-2 rounded-xl border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-sm font-medium text-sky-200 hover:bg-sky-500/20 disabled:opacity-40"
-              >
-                <Mail className="h-4 w-4" /> {t("test.email")}
-              </button>
-            </form>
+            <button
+              type="submit"
+              name="channel"
+              value="WHATSAPP"
+              disabled={testPending || !capabilities.whatsappConnected}
+              className="inline-flex items-center gap-2 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-200 hover:bg-emerald-500/20 disabled:opacity-40"
+            >
+              <MessageCircle className="h-4 w-4" /> {t("test.whatsapp")}
+            </button>
+            <button
+              type="submit"
+              name="channel"
+              value="EMAIL"
+              disabled={testPending}
+              className="inline-flex items-center gap-2 rounded-xl border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-sm font-medium text-sky-200 hover:bg-sky-500/20 disabled:opacity-40"
+            >
+              <Mail className="h-4 w-4" /> {t("test.email")}
+            </button>
           </div>
           {!capabilities.whatsappConnected && (
             <p className="text-xs text-amber-300/80">{t("test.whatsappOffline")}</p>
           )}
-        </div>
+        </form>
       </div>
 
-      {/* Coluna direita: preview + envio em massa */}
+      {/* Coluna direita: preview + pré-lista + envio */}
       <div className="space-y-6">
         <div className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
           <h2 className="text-lg font-semibold text-white">{t("preview.title")}</h2>
@@ -331,13 +462,13 @@ export default function SaveTheDateClient({
                   )}
                 </div>
               )}
-              <p className="whitespace-pre-wrap break-words">{previewBody}</p>
-              {website && (
+              <p className="whitespace-pre-wrap break-words">{previewBody.text}</p>
+              {website && !previewBody.usedSite && (
                 <p className="mt-2 break-words">
                   • {tn("websiteLabel")}: <span className="underline">{website}</span>
                 </p>
               )}
-              {registry && (
+              {registry && !previewBody.usedRegistry && (
                 <p className="break-words">
                   • {tn("registryLabel")}: <span className="underline">{registry}</span>
                 </p>
@@ -346,8 +477,12 @@ export default function SaveTheDateClient({
           </div>
         </div>
 
-        <div className="space-y-4 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
-          <h2 className="text-lg font-semibold text-white">{t("broadcast.title")}</h2>
+        {/* Pré-lista de quem vai receber */}
+        <div className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
+          <div className="flex items-center gap-2">
+            <Users className="h-5 w-5 text-rose-400" />
+            <h2 className="text-lg font-semibold text-white">{t("preList.title")}</h2>
+          </div>
           <div className="flex gap-4 text-sm">
             <div className="flex-1 rounded-xl bg-zinc-950 p-3 text-center">
               <div className="text-2xl font-bold text-white">{recipients.eligible}</div>
@@ -358,6 +493,61 @@ export default function SaveTheDateClient({
               <div className="text-xs text-zinc-500">{t("broadcast.skipped")}</div>
             </div>
           </div>
+          <div className="max-h-72 overflow-y-auto rounded-xl border border-zinc-800">
+            <table className="w-full text-left text-xs">
+              <thead className="sticky top-0 bg-zinc-900 text-zinc-500">
+                <tr>
+                  <th className="px-3 py-2">{t("preList.colName")}</th>
+                  <th className="px-3 py-2">{t("preList.colChannel")}</th>
+                  <th className="px-3 py-2">{t("preList.colStatus")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recipients.list.map((r) => (
+                  <tr key={`${r.refType}:${r.refId}`} className="border-t border-zinc-800/70">
+                    <td className="px-3 py-2 text-zinc-300">
+                      <div className="font-medium text-zinc-200">{r.name}</div>
+                      {r.memberNames !== r.name && (
+                        <div className="text-zinc-500">{r.memberNames}</div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-zinc-400">{channelLabel(r.channel)}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={
+                          r.status === "PENDING" ? "text-emerald-400" : "text-zinc-500"
+                        }
+                      >
+                        {rowStatusLabel(r)}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+                {recipients.list.length === 0 && (
+                  <tr>
+                    <td colSpan={3} className="px-3 py-4 text-center text-zinc-600">
+                      {t("preList.empty")}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Envio em massa */}
+        <div className="space-y-4 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 shadow-xl">
+          <h2 className="text-lg font-semibold text-white">{t("broadcast.title")}</h2>
+
+          <label className="flex items-center gap-2 text-sm text-zinc-300">
+            <input
+              type="checkbox"
+              checked={skipAlreadySent}
+              onChange={(e) => setSkipAlreadySent(e.target.checked)}
+              className="rounded border-zinc-700 bg-zinc-950"
+            />
+            {t("broadcast.skipAlreadySent")}
+          </label>
 
           {progress && (
             <div className="space-y-2">
@@ -403,9 +593,59 @@ export default function SaveTheDateClient({
                 {t("broadcast.cancel")}
               </button>
             )}
+            {progress && (
+              <button
+                type="button"
+                onClick={loadDetail}
+                disabled={detailLoading}
+                className="inline-flex items-center gap-2 rounded-xl border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-200 hover:bg-zinc-800 disabled:opacity-50"
+              >
+                {detailLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <ListChecks className="h-4 w-4" />}
+                {t("broadcast.viewList")}
+              </button>
+            )}
           </div>
-          {done && progress && progress.status === "DONE" && (
+          {progress && progress.status === "DONE" && (
             <p className="text-sm text-emerald-400">{t("broadcast.doneNote")}</p>
+          )}
+
+          {detail && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-zinc-400">{t("broadcast.detailTitle")}</span>
+                <button
+                  type="button"
+                  onClick={exportCsv}
+                  disabled={detail.length === 0}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-2.5 py-1 text-xs text-zinc-300 hover:bg-zinc-800 disabled:opacity-40"
+                >
+                  <Download className="h-3.5 w-3.5" /> {t("broadcast.exportCsv")}
+                </button>
+              </div>
+              <div className="max-h-72 overflow-y-auto rounded-xl border border-zinc-800">
+                <table className="w-full text-left text-xs">
+                  <thead className="sticky top-0 bg-zinc-900 text-zinc-500">
+                    <tr>
+                      <th className="px-3 py-2">{t("preList.colName")}</th>
+                      <th className="px-3 py-2">{t("preList.colChannel")}</th>
+                      <th className="px-3 py-2">{t("preList.colStatus")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {detail.map((r, i) => (
+                      <tr key={i} className="border-t border-zinc-800/70">
+                        <td className="px-3 py-2 text-zinc-300">{r.name}</td>
+                        <td className="px-3 py-2 text-zinc-400">{r.channelUsed ?? "—"}</td>
+                        <td className="px-3 py-2 text-zinc-400">
+                          {r.status}
+                          {r.error ? <span className="text-rose-400"> · {r.error}</span> : null}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,18 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.7.1",
+    date: "2026-06-02",
+    highlights: [
+      "🚫 Save the Date agora deixa **excluir convidados por tag** (ex.: padrinhos) e por marcação de padrinho/madrinha — um grupo sai do envio se qualquer integrante tiver a tag.",
+      "🔗 Novas variáveis **{site}** e **{site-presentes}** para você escolher onde o site dos noivos e a lista de presentes aparecem na mensagem (sem elas, continuam no fim).",
+      "🧪 No teste, dá para enviar para **um número ou e-mail diferente do seu**.",
+      "✉️ O e-mail do Save the Date saiu com a cara dos noivos: **sem o nome do sistema** e sem rodapé automático.",
+      "👀 **Pré-lista** mostrando quem vai receber (canal e status) antes de disparar.",
+      "📋 Lista de envio detalhada com **exportação CSV**, opção de **não reenviar a quem já recebeu** e **normalização automática de telefone** (+55) — preservando números internacionais como +1 e +34.",
+    ],
+  },
+  {
     version: "0.7.0",
     date: "2026-06-01",
     highlights: [

--- a/src/lib/event-config.ts
+++ b/src/lib/event-config.ts
@@ -18,6 +18,8 @@ export type EventConfig = {
   saveTheDateFilePath: string | null;
   saveTheDateFileMime: string | null;
   saveTheDateFileName: string | null;
+  saveTheDateExcludeTagIds: string | null;
+  saveTheDateExcludePadrinhos: boolean;
 };
 
 export async function getEventConfig(): Promise<EventConfig> {
@@ -48,6 +50,8 @@ export async function getEventConfig(): Promise<EventConfig> {
     saveTheDateFilePath: settings.saveTheDateFilePath,
     saveTheDateFileMime: settings.saveTheDateFileMime,
     saveTheDateFileName: settings.saveTheDateFileName,
+    saveTheDateExcludeTagIds: settings.saveTheDateExcludeTagIds,
+    saveTheDateExcludePadrinhos: settings.saveTheDateExcludePadrinhos,
   };
 }
 
@@ -87,6 +91,12 @@ export async function updateEventConfig(
         input.saveTheDateFileMime === undefined ? undefined : input.saveTheDateFileMime,
       saveTheDateFileName:
         input.saveTheDateFileName === undefined ? undefined : input.saveTheDateFileName,
+      saveTheDateExcludeTagIds:
+        input.saveTheDateExcludeTagIds === undefined ? undefined : input.saveTheDateExcludeTagIds,
+      saveTheDateExcludePadrinhos:
+        input.saveTheDateExcludePadrinhos === undefined
+          ? undefined
+          : input.saveTheDateExcludePadrinhos,
     },
   });
 
@@ -107,6 +117,8 @@ export async function updateEventConfig(
     saveTheDateFilePath: updated.saveTheDateFilePath,
     saveTheDateFileMime: updated.saveTheDateFileMime,
     saveTheDateFileName: updated.saveTheDateFileName,
+    saveTheDateExcludeTagIds: updated.saveTheDateExcludeTagIds,
+    saveTheDateExcludePadrinhos: updated.saveTheDateExcludePadrinhos,
   };
 }
 

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -507,19 +507,24 @@ export const HELP_ARTICLES: HelpArticle[] = [
       },
       {
         title: "Use as variáveis",
-        body: "Na mensagem, {nomes}, {convidados}, {data} e {local} são preenchidos automaticamente por destinatário. Se ficar em branco, uma mensagem padrão é usada. Os links de site/presentes aparecem sozinhos quando preenchidos.",
+        body: "Na mensagem, {nomes}, {convidados}, {data} e {local} são preenchidos por destinatário. Use {site} e {site-presentes} para escolher onde o site dos noivos e a lista de presentes aparecem — sem elas, os links entram no fim quando preenchidos. Botões inserem as variáveis no cursor.",
+      },
+      {
+        title: "Escolha quem NÃO recebe",
+        body: "Em 'Não enviar para', marque tags (ex.: padrinhos) ou 'Excluir padrinhos e madrinhas'. Um grupo é removido se qualquer integrante tiver a tag. A pré-lista 'Quem vai receber' mostra o resultado.",
       },
       {
         title: "Faça um teste",
-        body: "Clique em 'Testar no WhatsApp' ou 'Testar por e-mail' para receber o Save the Date no seu próprio contato antes do disparo.",
+        body: "Clique em 'Testar no WhatsApp' ou 'Testar por e-mail'. Deixe o campo vazio para receber no seu próprio contato, ou informe outro número (+55...) / e-mail.",
       },
       {
         title: "Dispare para todos",
-        body: "'Iniciar envio' manda uma mensagem por grupo (no telefone do grupo, citando os integrantes) e uma por convidado avulso. A fila respeita um intervalo entre mensagens para não ser bloqueada pelo WhatsApp; acompanhe a barra de progresso e reenvie as falhas.",
+        body: "'Iniciar envio' manda uma mensagem por grupo (no telefone do grupo, citando os integrantes) e uma por avulso. Marque 'Pular quem já recebeu' para não duplicar em disparos seguintes. Acompanhe o progresso, veja a lista detalhada e exporte CSV.",
       },
     ],
     tips: [
-      "Telefones devem ter código do país (ex.: +5511999990000) para o WhatsApp. Sem telefone válido, cai no e-mail; sem nenhum dos dois, o destinatário é ignorado.",
+      "Telefones sem código de país são completados com +55 automaticamente; números internacionais (ex.: +1, +34) são preservados como estão.",
+      "O e-mail do Save the Date sai sem o nome do sistema — com a cara dos noivos.",
       "O ritmo do envio é configurável via `BROADCAST_INTERVAL_MS` no .env (padrão 4000ms).",
     ],
     warnings: [

--- a/src/lib/notifications/recipients.test.ts
+++ b/src/lib/notifications/recipients.test.ts
@@ -26,6 +26,8 @@ describe("buildSaveTheDateRecipients", () => {
     contactPhone: "+5511999990000",
     contactEmail: null,
     memberNames: ["Ana", "Lucas"],
+    memberTagIds: [],
+    hasPadrinho: false,
     ...over,
   });
   const guest = (over: Partial<RecipientSourceGuest>): RecipientSourceGuest => ({
@@ -34,6 +36,8 @@ describe("buildSaveTheDateRecipients", () => {
     phone: "+5511888880000",
     email: null,
     language: null,
+    tagIds: [],
+    isPadrinho: false,
     ...over,
   });
 
@@ -56,14 +60,6 @@ describe("buildSaveTheDateRecipients", () => {
     expect(out.every((r) => r.status === "SKIPPED" && r.skipReason === "NO_CONTACT")).toBe(true);
   });
 
-  it("keeps a recipient that has only email", () => {
-    const out = buildSaveTheDateRecipients(
-      [group({ contactPhone: null, contactEmail: "fam@example.com" })],
-      [],
-    );
-    expect(out[0].status).toBe("PENDING");
-  });
-
   it("deduplicates a phone shared between a group and an ungrouped guest", () => {
     const out = buildSaveTheDateRecipients(
       [group({ contactPhone: "+55 11 99999-0000" })],
@@ -72,6 +68,52 @@ describe("buildSaveTheDateRecipients", () => {
     expect(out[0].status).toBe("PENDING");
     expect(out[1].status).toBe("SKIPPED");
     expect(out[1].skipReason).toBe("DUPLICATE_PHONE");
+  });
+
+  it("normalizes phones to E.164 and preserves foreign DDI", () => {
+    const out = buildSaveTheDateRecipients(
+      [group({ id: "g1", contactPhone: "11999990000" })],
+      [guest({ id: "u1", phone: "+34 600 123 456" })],
+    );
+    expect(out[0].phone).toBe("+5511999990000");
+    expect(out[1].phone).toBe("+34600123456");
+  });
+
+  it("excludes a group if ANY member has an excluded tag", () => {
+    const out = buildSaveTheDateRecipients(
+      [group({ memberTagIds: ["t-padrinho", "t-amigo"] })],
+      [guest({ tagIds: ["t-amigo"] })],
+      { excludeTagIds: ["t-padrinho"] },
+    );
+    expect(out[0].status).toBe("SKIPPED");
+    expect(out[0].skipReason).toBe("EXCLUDED_TAG");
+    expect(out[1].status).toBe("PENDING");
+  });
+
+  it("excludes by padrinho flag when enabled", () => {
+    const out = buildSaveTheDateRecipients(
+      [group({ hasPadrinho: true })],
+      [guest({ isPadrinho: true })],
+      { excludePadrinhos: true },
+    );
+    expect(out.every((r) => r.skipReason === "EXCLUDED_TAG")).toBe(true);
+  });
+
+  it("skips recipients already sent in a previous broadcast", () => {
+    const out = buildSaveTheDateRecipients([group({ id: "g1" })], [guest({ id: "u1" })], {
+      alreadySentKeys: new Set(["GuestGroup:g1"]),
+    });
+    expect(out[0].skipReason).toBe("ALREADY_SENT");
+    expect(out[1].status).toBe("PENDING");
+  });
+
+  it("tag exclusion takes priority over already-sent and contact checks", () => {
+    const out = buildSaveTheDateRecipients(
+      [group({ id: "g1", contactPhone: null, contactEmail: null, memberTagIds: ["x"] })],
+      [],
+      { excludeTagIds: ["x"], alreadySentKeys: new Set(["GuestGroup:g1"]) },
+    );
+    expect(out[0].skipReason).toBe("EXCLUDED_TAG");
   });
 
   it("falls back to group name when there are no members", () => {

--- a/src/lib/notifications/recipients.ts
+++ b/src/lib/notifications/recipients.ts
@@ -1,9 +1,13 @@
+import { normalizeMsisdn } from "./std-message";
+
 export type RecipientSourceGroup = {
   id: string;
   name: string;
   contactPhone: string | null;
   contactEmail: string | null;
   memberNames: string[];
+  memberTagIds: string[];
+  hasPadrinho: boolean;
 };
 
 export type RecipientSourceGuest = {
@@ -12,9 +16,11 @@ export type RecipientSourceGuest = {
   phone: string | null;
   email: string | null;
   language: string | null;
+  tagIds: string[];
+  isPadrinho: boolean;
 };
 
-export type SkipReason = "NO_CONTACT" | "DUPLICATE_PHONE";
+export type SkipReason = "NO_CONTACT" | "DUPLICATE_PHONE" | "EXCLUDED_TAG" | "ALREADY_SENT";
 
 export type BuiltRecipient = {
   refType: "GuestGroup" | "Guest";
@@ -26,6 +32,13 @@ export type BuiltRecipient = {
   locale: string | null;
   status: "PENDING" | "SKIPPED";
   skipReason: SkipReason | null;
+};
+
+export type RecipientExcludeOptions = {
+  excludeTagIds?: string[];
+  excludePadrinhos?: boolean;
+  /** Chaves `${refType}:${refId}` que já receberam (dedup entre disparos). */
+  alreadySentKeys?: Set<string>;
 };
 
 function digits(value?: string | null): string {
@@ -44,38 +57,66 @@ export function joinNames(names: string[]): string {
 /**
  * Monta a lista de destinatários do Save the Date: uma entrada por grupo
  * (telefone/e-mail do grupo, citando os integrantes) + uma por convidado avulso
- * (sem grupo). Quem não tem nenhum canal vira `SKIPPED`; telefones repetidos
- * entre grupo e avulso também são pulados para não duplicar o envio.
+ * (sem grupo). Telefones são normalizados (E.164, preservando DDI estrangeiro).
+ *
+ * Regras de `SKIPPED` (nesta ordem de prioridade):
+ *   EXCLUDED_TAG  → tem tag excluída ou é padrinho (quando ligado)
+ *   ALREADY_SENT  → já recebeu num disparo anterior
+ *   NO_CONTACT    → sem telefone e sem e-mail
+ *   DUPLICATE_PHONE → telefone repetido entre grupo e avulso
  */
 export function buildSaveTheDateRecipients(
   groups: RecipientSourceGroup[],
   guests: RecipientSourceGuest[],
+  opts: RecipientExcludeOptions = {},
 ): BuiltRecipient[] {
   const out: BuiltRecipient[] = [];
   const seenPhones = new Set<string>();
+  const excludeTags = new Set(opts.excludeTagIds ?? []);
+  const padrinhos = opts.excludePadrinhos ?? false;
+  const alreadySent = opts.alreadySentKeys ?? new Set<string>();
 
-  const classify = (phone: string | null, email: string | null): {
-    status: "PENDING" | "SKIPPED";
-    skipReason: SkipReason | null;
-  } => {
-    if (!phone && !email) return { status: "SKIPPED", skipReason: "NO_CONTACT" };
-    const key = digits(phone);
-    if (key && seenPhones.has(key)) {
-      return { status: "SKIPPED", skipReason: "DUPLICATE_PHONE" };
+  const isExcludedByTag = (tagIds: string[], hasPadrinho: boolean): boolean => {
+    if (padrinhos && hasPadrinho) return true;
+    if (excludeTags.size === 0) return false;
+    return tagIds.some((id) => excludeTags.has(id));
+  };
+
+  const classify = (
+    key: string,
+    phone: string | null,
+    email: string | null,
+    tagIds: string[],
+    hasPadrinho: boolean,
+  ): { status: "PENDING" | "SKIPPED"; skipReason: SkipReason | null } => {
+    if (isExcludedByTag(tagIds, hasPadrinho)) {
+      return { status: "SKIPPED", skipReason: "EXCLUDED_TAG" };
     }
-    if (key) seenPhones.add(key);
+    if (alreadySent.has(key)) return { status: "SKIPPED", skipReason: "ALREADY_SENT" };
+    if (!phone && !email) return { status: "SKIPPED", skipReason: "NO_CONTACT" };
+    const d = digits(phone);
+    if (d && seenPhones.has(d)) return { status: "SKIPPED", skipReason: "DUPLICATE_PHONE" };
+    if (d) seenPhones.add(d);
     return { status: "PENDING", skipReason: null };
   };
 
   for (const grp of groups) {
-    const { status, skipReason } = classify(grp.contactPhone, grp.contactEmail);
+    const phone = normalizeMsisdn(grp.contactPhone);
+    const key = `GuestGroup:${grp.id}`;
+    const { status, skipReason } = classify(
+      key,
+      phone,
+      grp.contactEmail,
+      grp.memberTagIds,
+      grp.hasPadrinho,
+    );
     const members = grp.memberNames.length > 0 ? grp.memberNames : [grp.name];
     out.push({
       refType: "GuestGroup",
       refId: grp.id,
       name: grp.name,
       memberNames: joinNames(members),
-      phone: grp.contactPhone,
+      phone,
       email: grp.contactEmail,
       locale: null,
       status,
@@ -84,13 +125,15 @@ export function buildSaveTheDateRecipients(
   }
 
   for (const gst of guests) {
-    const { status, skipReason } = classify(gst.phone, gst.email);
+    const phone = normalizeMsisdn(gst.phone);
+    const key = `Guest:${gst.id}`;
+    const { status, skipReason } = classify(key, phone, gst.email, gst.tagIds, gst.isPadrinho);
     out.push({
       refType: "Guest",
       refId: gst.id,
       name: gst.name,
       memberNames: gst.name,
-      phone: gst.phone,
+      phone,
       email: gst.email,
       locale: gst.language,
       status,

--- a/src/lib/notifications/std-message.test.ts
+++ b/src/lib/notifications/std-message.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { interpolateBaseTags, applySiteTags, normalizeMsisdn } from "./std-message";
+
+describe("interpolateBaseTags", () => {
+  const tags = { nomes: "Ana & Lucas", convidados: "Família Silva", data: "21 de setembro", local: "Espaço Di Fieri" };
+
+  it("substitui as variáveis básicas, inclusive no meio do texto", () => {
+    expect(interpolateBaseTags("Oi {convidados}, {nomes} casam em {data} no {local}!", tags)).toBe(
+      "Oi Família Silva, Ana & Lucas casam em 21 de setembro no Espaço Di Fieri!",
+    );
+  });
+
+  it("mantém {site} e {site-presentes} intactas", () => {
+    expect(interpolateBaseTags("Veja {site} e {site-presentes}", tags)).toBe(
+      "Veja {site} e {site-presentes}",
+    );
+  });
+
+  it("deixa variáveis desconhecidas como estão", () => {
+    expect(interpolateBaseTags("{foo}", tags)).toBe("{foo}");
+  });
+});
+
+describe("applySiteTags", () => {
+  const links = { siteUrl: "https://noivos.com", registryUrl: "https://lista.com/123" };
+
+  it("substitui ambas e marca como usadas", () => {
+    const r = applySiteTags("Site: {site} | Lista: {site-presentes}", links);
+    expect(r.text).toBe("Site: https://noivos.com | Lista: https://lista.com/123");
+    expect(r.usedSite).toBe(true);
+    expect(r.usedRegistry).toBe(true);
+  });
+
+  it("não confunde {site} com o prefixo de {site-presentes}", () => {
+    const r = applySiteTags("{site-presentes}", links);
+    expect(r.text).toBe("https://lista.com/123");
+    expect(r.usedRegistry).toBe(true);
+    expect(r.usedSite).toBe(false);
+  });
+
+  it("usadas ficam false quando as variáveis não aparecem", () => {
+    const r = applySiteTags("sem links", links);
+    expect(r.usedSite).toBe(false);
+    expect(r.usedRegistry).toBe(false);
+    expect(r.text).toBe("sem links");
+  });
+});
+
+describe("normalizeMsisdn", () => {
+  it("preserva DDI estrangeiro (+1, +34) — só tira formatação", () => {
+    expect(normalizeMsisdn("+1 415 555 0100")).toBe("+14155550100");
+    expect(normalizeMsisdn("+34 600 12 34 56")).toBe("+34600123456");
+    expect(normalizeMsisdn("+351 912 345 678")).toBe("+351912345678");
+  });
+
+  it("completa +55 para números BR sem DDI", () => {
+    expect(normalizeMsisdn("11999990000")).toBe("+5511999990000");
+    expect(normalizeMsisdn("(11) 99999-0000")).toBe("+5511999990000");
+    expect(normalizeMsisdn("1133334444")).toBe("+551133334444");
+  });
+
+  it("prefixa + quando já vem 55 + DDD + número sem o sinal", () => {
+    expect(normalizeMsisdn("5511999990000")).toBe("+5511999990000");
+  });
+
+  it("devolve original quando não há regra segura", () => {
+    expect(normalizeMsisdn("123")).toBe("123");
+    expect(normalizeMsisdn("")).toBe("");
+    expect(normalizeMsisdn(null)).toBeNull();
+  });
+});

--- a/src/lib/notifications/std-message.ts
+++ b/src/lib/notifications/std-message.ts
@@ -1,0 +1,83 @@
+/**
+ * Helpers puros (sem I/O) para a mensagem do Save the Date — compartilhados pelo
+ * template (servidor) e pelo preview (client), para não divergirem.
+ */
+
+export type BaseTags = {
+  nomes: string;
+  convidados: string;
+  data: string;
+  local: string;
+};
+
+const BASE_KEYS = new Set(["nomes", "convidados", "data", "local"]);
+
+/**
+ * Substitui apenas as variáveis básicas ({nomes}, {convidados}, {data}, {local}).
+ * Mantém {site} e {site-presentes} intactas para tratamento por canal.
+ * Aceita hífen no nome da variável (ex.: {site-presentes}).
+ */
+export function interpolateBaseTags(template: string, tags: BaseTags): string {
+  return template.replace(/\{([\w-]+)\}/g, (match, key: string) =>
+    BASE_KEYS.has(key) ? tags[key as keyof BaseTags] : match,
+  );
+}
+
+export type SiteTagResult = {
+  text: string;
+  usedSite: boolean;
+  usedRegistry: boolean;
+};
+
+/**
+ * Substitui {site} e {site-presentes} pelos respectivos URLs e informa se cada
+ * uma foi usada (para o chamador decidir se ainda anexa a linha no fim).
+ * {site-presentes} é tratada antes de {site} para evitar colisão de prefixo.
+ */
+export function applySiteTags(
+  text: string,
+  links: { siteUrl: string | null; registryUrl: string | null },
+): SiteTagResult {
+  let usedSite = false;
+  let usedRegistry = false;
+
+  let out = text.replace(/\{site-presentes\}/g, () => {
+    usedRegistry = true;
+    return links.registryUrl ?? "";
+  });
+  out = out.replace(/\{site\}/g, () => {
+    usedSite = true;
+    return links.siteUrl ?? "";
+  });
+
+  return { text: out, usedSite, usedRegistry };
+}
+
+/**
+ * Normaliza um telefone para E.164, **sem** alterar números que já trazem código
+ * de país (qualquer coisa começando com "+", ex.: +1, +34, +351).
+ * Só completa "+55" quando o número está sem DDI e tem cara de brasileiro.
+ * Retorna o valor original quando não há regra segura.
+ */
+export function normalizeMsisdn(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (trimmed === "") return raw;
+
+  // Já tem DDI explícito — preserva o código (apenas remove formatação).
+  if (trimmed.startsWith("+")) {
+    return "+" + trimmed.slice(1).replace(/\D+/g, "");
+  }
+
+  const digits = trimmed.replace(/\D+/g, "");
+  // Já vem com 55 + DDD + número (12 ou 13 dígitos).
+  if ((digits.length === 12 || digits.length === 13) && digits.startsWith("55")) {
+    return "+" + digits;
+  }
+  // DDD + número, sem DDI (10 ou 11 dígitos) → assume Brasil.
+  if (digits.length === 10 || digits.length === 11) {
+    return "+55" + digits;
+  }
+  // Não dá para inferir com segurança — devolve como veio.
+  return raw;
+}

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { DEFAULT_LOCALE, type Locale } from "@/i18n/config";
 import { formatCurrency, formatDate } from "@/i18n/format";
+import { interpolateBaseTags } from "./std-message";
 
 export type NotificationKind =
   | "ACCOUNT_CREATED"
@@ -131,6 +132,12 @@ export function escapeWaMarkdown(value: string): string {
 }
 
 function wrapHtml(title: string, body: string, locale: Locale, footer: string, header: string): string {
+  const headerHtml = header
+    ? `<h1 style="margin:0 0 16px;font-size:20px;color:#f4f4f5;">${escapeHtml(header)}</h1>`
+    : "";
+  const footerHtml = footer
+    ? `<p style="margin-top:32px;font-size:12px;color:#71717a;">${escapeHtml(footer)}</p>`
+    : "";
   return `<!doctype html>
 <html lang="${locale}">
 <head>
@@ -142,9 +149,9 @@ function wrapHtml(title: string, body: string, locale: Locale, footer: string, h
 <tr><td align="center">
 <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#18181b;border:1px solid #27272a;border-radius:16px;padding:32px;">
 <tr><td>
-<h1 style="margin:0 0 16px;font-size:20px;color:#f4f4f5;">${escapeHtml(header)}</h1>
+${headerHtml}
 ${body}
-<p style="margin-top:32px;font-size:12px;color:#71717a;">${escapeHtml(footer)}</p>
+${footerHtml}
 </td></tr>
 </table>
 </td></tr>
@@ -526,18 +533,18 @@ ${tk("intro", { guest: escapeWaMarkdown(input.guestName) })}
       const guests = input.recipientNames;
       const venue = input.venueName ?? null;
 
-      let bodyPlain: string;
+      const websiteUrl = input.websiteUrl ?? null;
+      const registryUrl = input.giftRegistryUrl ?? null;
+
+      let bodyCore: string;
       const custom = input.customMessage?.trim();
       if (custom) {
-        const tags: Record<string, string> = {
+        bodyCore = interpolateBaseTags(custom, {
           nomes: names,
           convidados: guests,
           data: dateStr,
           local: venue ?? "",
-        };
-        bodyPlain = custom.replace(/\{(\w+)\}/g, (m, k: string) =>
-          k in tags ? tags[k] : m,
-        );
+        });
       } else {
         const parts = [
           tk("greeting", { guests }),
@@ -547,40 +554,65 @@ ${tk("intro", { guest: escapeWaMarkdown(input.guestName) })}
           "",
           tk("signoff", { names }),
         ];
-        bodyPlain = parts.join("\n");
+        bodyCore = parts.join("\n");
       }
 
       const subject = tk("subject", { names });
 
+      // WhatsApp / texto: {site} e {site-presentes} entram inline; o que não foi
+      // usado inline é anexado no fim (compatível com mensagens antigas).
+      let usedSite = false;
+      let usedRegistry = false;
+      let bodyText = bodyCore.replace(/\{site-presentes\}/g, () => {
+        usedRegistry = true;
+        return registryUrl ?? "";
+      });
+      bodyText = bodyText.replace(/\{site\}/g, () => {
+        usedSite = true;
+        return websiteUrl ?? "";
+      });
       const waLinks: string[] = [];
-      if (input.websiteUrl) waLinks.push(`• ${tk("websiteLabel")}: ${input.websiteUrl}`);
-      if (input.giftRegistryUrl) waLinks.push(`• ${tk("registryLabel")}: ${input.giftRegistryUrl}`);
-      const waText = `${bodyPlain}${waLinks.length ? `\n\n${waLinks.join("\n")}` : ""}`.trim();
+      if (websiteUrl && !usedSite) waLinks.push(`• ${tk("websiteLabel")}: ${websiteUrl}`);
+      if (registryUrl && !usedRegistry) waLinks.push(`• ${tk("registryLabel")}: ${registryUrl}`);
+      const waText = `${bodyText}${waLinks.length ? `\n\n${waLinks.join("\n")}` : ""}`.trim();
       const text = waText;
 
-      const bodyHtml = escapeHtml(bodyPlain).replace(/\n/g, "<br>");
+      // HTML: escapa o corpo (com os tokens {site} ainda intactos) e troca os
+      // tokens por âncoras já depois do escape.
+      const anchor = (url: string) =>
+        `<a href="${escapeHtml(url)}" style="color:#fda4af;">${escapeHtml(url)}</a>`;
+      let usedSiteHtml = false;
+      let usedRegistryHtml = false;
+      let bodyHtmlCore = escapeHtml(bodyCore).replace(/\{site-presentes\}/g, () => {
+        usedRegistryHtml = true;
+        return registryUrl ? anchor(registryUrl) : "";
+      });
+      bodyHtmlCore = bodyHtmlCore.replace(/\{site\}/g, () => {
+        usedSiteHtml = true;
+        return websiteUrl ? anchor(websiteUrl) : "";
+      });
+      const bodyHtml = bodyHtmlCore.replace(/\n/g, "<br>");
       const linkRows: string[] = [];
-      if (input.websiteUrl) {
-        const u = escapeHtml(input.websiteUrl);
+      if (websiteUrl && !usedSiteHtml) {
         linkRows.push(
-          `<p style="margin:4px 0;"><strong>${escapeHtml(tk("websiteLabel"))}:</strong> <a href="${u}" style="color:#fda4af;">${u}</a></p>`,
+          `<p style="margin:4px 0;"><strong>${escapeHtml(tk("websiteLabel"))}:</strong> ${anchor(websiteUrl)}</p>`,
         );
       }
-      if (input.giftRegistryUrl) {
-        const u = escapeHtml(input.giftRegistryUrl);
+      if (registryUrl && !usedRegistryHtml) {
         linkRows.push(
-          `<p style="margin:4px 0;"><strong>${escapeHtml(tk("registryLabel"))}:</strong> <a href="${u}" style="color:#fda4af;">${u}</a></p>`,
+          `<p style="margin:4px 0;"><strong>${escapeHtml(tk("registryLabel"))}:</strong> ${anchor(registryUrl)}</p>`,
         );
       }
       const imageHtml = input.imageCid
         ? `<p style="text-align:center;margin:0 0 20px;"><img src="cid:${escapeHtml(input.imageCid)}" alt="Save the Date" style="max-width:100%;border-radius:12px;"></p>`
         : "";
+      // Sem o nome do sistema: cabeçalho = nomes do casal, sem rodapé automático.
       const html = wrapHtml(
         subject,
         `${imageHtml}<p style="font-size:16px;line-height:1.6;">${bodyHtml}</p>${linkRows.join("")}`,
         locale,
-        footer,
-        header,
+        "",
+        names,
       );
       return { subject, html, text, waText };
     }

--- a/src/messages/en/actions.json
+++ b/src/messages/en/actions.json
@@ -273,6 +273,8 @@
     "noRecipients": "No guests registered.",
     "noEligibleRecipients": "No guests with a phone or email to send to.",
     "broadcastNotFound": "Broadcast not found.",
-    "noFailedRecipients": "No failures to resend."
+    "noFailedRecipients": "No failures to resend.",
+    "invalidPhone": "Invalid phone. Use +5511999990000.",
+    "invalidEmail": "Invalid email."
   }
 }

--- a/src/messages/en/dashboard.json
+++ b/src/messages/en/dashboard.json
@@ -2048,15 +2048,21 @@
       "registryLabel": "Gift registry (optional)",
       "messageLabel": "Message",
       "messagePlaceholder": "Hi, {convidados}! {nomes} are getting married...",
-      "mergeTagsHint": "Use {nomes}, {convidados}, {data} and {local} — replaced automatically. The links above are appended when filled.",
-      "save": "Save"
+      "mergeTagsHint": "Variables: {nomes}, {convidados}, {data}, {local}. Use {site} and {site-presentes} to choose where the links go; without them, links are appended at the end when filled.",
+      "save": "Save",
+      "excludeLabel": "Don't send to (by tag)",
+      "excludeHint": "Check tags to exclude those guests (e.g. groomsmen). A group is removed if any member has the tag.",
+      "excludePadrinhos": "Exclude groomsmen and bridesmaids",
+      "noTags": "No tags yet."
     },
     "test": {
       "title": "Send a test to myself",
       "subtitle": "Get the Save the Date on your own contact before the broadcast.",
       "whatsapp": "Test on WhatsApp",
       "email": "Test by email",
-      "whatsappOffline": "WhatsApp not connected. Connect it in Settings to test via WhatsApp."
+      "whatsappOffline": "WhatsApp not connected. Connect it in Settings to test via WhatsApp.",
+      "toPlaceholder": "Phone (+55...) or email (optional)",
+      "toHint": "Empty = sends to your own contact. Phone needs the country code."
     },
     "preview": {
       "title": "Preview"
@@ -2081,7 +2087,11 @@
         "PAUSED": "Paused",
         "DONE": "Done",
         "CANCELLED": "Cancelled"
-      }
+      },
+      "skipAlreadySent": "Skip who already received",
+      "viewList": "View send list",
+      "detailTitle": "Result per recipient",
+      "exportCsv": "Export CSV"
     },
     "toasts": {
       "configSaved": "Save the Date saved.",
@@ -2089,6 +2099,23 @@
       "broadcastStarted": "Sending started.",
       "resendStarted": "Resending failures.",
       "broadcastCancelled": "Sending cancelled."
+    },
+    "preList": {
+      "title": "Who will receive",
+      "channelWhatsapp": "WhatsApp",
+      "channelEmail": "Email",
+      "willReceive": "Will receive",
+      "colName": "Recipient",
+      "colChannel": "Channel",
+      "colStatus": "Status",
+      "empty": "No recipients.",
+      "reason": {
+        "NO_CONTACT": "No contact",
+        "DUPLICATE_PHONE": "Duplicate phone",
+        "EXCLUDED_TAG": "Excluded",
+        "ALREADY_SENT": "Already sent",
+        "SKIPPED": "Skipped"
+      }
     }
   }
 }

--- a/src/messages/es/actions.json
+++ b/src/messages/es/actions.json
@@ -273,6 +273,8 @@
     "noRecipients": "No hay invitados registrados.",
     "noEligibleRecipients": "No hay invitados con teléfono o correo para enviar.",
     "broadcastNotFound": "Envío no encontrado.",
-    "noFailedRecipients": "No hay fallidos para reenviar."
+    "noFailedRecipients": "No hay fallidos para reenviar.",
+    "invalidPhone": "Teléfono inválido. Usa +5511999990000.",
+    "invalidEmail": "Correo inválido."
   }
 }

--- a/src/messages/es/dashboard.json
+++ b/src/messages/es/dashboard.json
@@ -2048,15 +2048,21 @@
       "registryLabel": "Lista de regalos (opcional)",
       "messageLabel": "Mensaje",
       "messagePlaceholder": "¡Hola, {convidados}! {nomes} se van a casar...",
-      "mergeTagsHint": "Usa {nomes}, {convidados}, {data} y {local} — se reemplazan automáticamente. Los enlaces de arriba se agregan cuando se completan.",
-      "save": "Guardar"
+      "mergeTagsHint": "Variables: {nomes}, {convidados}, {data}, {local}. Usa {site} y {site-presentes} para elegir dónde van los enlaces; sin ellas, se agregan al final cuando se completan.",
+      "save": "Guardar",
+      "excludeLabel": "No enviar a (por etiqueta)",
+      "excludeHint": "Marca etiquetas para excluir a esos invitados (ej.: padrinos). Un grupo se quita si algún integrante tiene la etiqueta.",
+      "excludePadrinhos": "Excluir padrinos y madrinas",
+      "noTags": "Sin etiquetas."
     },
     "test": {
       "title": "Enviar una prueba a mí",
       "subtitle": "Recibe el Save the Date en tu propio contacto antes del envío.",
       "whatsapp": "Probar en WhatsApp",
       "email": "Probar por correo",
-      "whatsappOffline": "WhatsApp no conectado. Conéctalo en Ajustes para probar por WhatsApp."
+      "whatsappOffline": "WhatsApp no conectado. Conéctalo en Ajustes para probar por WhatsApp.",
+      "toPlaceholder": "Teléfono (+55...) o correo (opcional)",
+      "toHint": "Vacío = envía a tu propio contacto. El teléfono necesita el código de país."
     },
     "preview": {
       "title": "Vista previa"
@@ -2081,7 +2087,11 @@
         "PAUSED": "Pausado",
         "DONE": "Completado",
         "CANCELLED": "Cancelado"
-      }
+      },
+      "skipAlreadySent": "Saltar a quien ya recibió",
+      "viewList": "Ver lista de envío",
+      "detailTitle": "Resultado por destinatario",
+      "exportCsv": "Exportar CSV"
     },
     "toasts": {
       "configSaved": "Save the Date guardado.",
@@ -2089,6 +2099,23 @@
       "broadcastStarted": "Envío iniciado.",
       "resendStarted": "Reenviando fallidos.",
       "broadcastCancelled": "Envío cancelado."
+    },
+    "preList": {
+      "title": "Quién va a recibir",
+      "channelWhatsapp": "WhatsApp",
+      "channelEmail": "Correo",
+      "willReceive": "Recibirá",
+      "colName": "Destinatario",
+      "colChannel": "Canal",
+      "colStatus": "Estado",
+      "empty": "Sin destinatarios.",
+      "reason": {
+        "NO_CONTACT": "Sin contacto",
+        "DUPLICATE_PHONE": "Teléfono duplicado",
+        "EXCLUDED_TAG": "Excluido",
+        "ALREADY_SENT": "Ya recibió",
+        "SKIPPED": "Omitido"
+      }
     }
   }
 }

--- a/src/messages/pt-BR/actions.json
+++ b/src/messages/pt-BR/actions.json
@@ -273,6 +273,8 @@
     "noRecipients": "Nenhum convidado cadastrado.",
     "noEligibleRecipients": "Nenhum convidado com telefone ou e-mail para envio.",
     "broadcastNotFound": "Envio não encontrado.",
-    "noFailedRecipients": "Não há falhas para reenviar."
+    "noFailedRecipients": "Não há falhas para reenviar.",
+    "invalidPhone": "Telefone inválido. Use +5511999990000.",
+    "invalidEmail": "E-mail inválido."
   }
 }

--- a/src/messages/pt-BR/dashboard.json
+++ b/src/messages/pt-BR/dashboard.json
@@ -2048,15 +2048,21 @@
       "registryLabel": "Lista de presentes (opcional)",
       "messageLabel": "Mensagem",
       "messagePlaceholder": "Olá, {convidados}! {nomes} vão se casar...",
-      "mergeTagsHint": "Use {nomes}, {convidados}, {data} e {local} — substituídos automaticamente. Os links acima aparecem sozinhos quando preenchidos.",
-      "save": "Salvar"
+      "mergeTagsHint": "Variáveis: {nomes}, {convidados}, {data}, {local}. Use {site} e {site-presentes} para escolher onde os links aparecem; sem elas, os links entram no fim quando preenchidos.",
+      "save": "Salvar",
+      "excludeLabel": "Não enviar para (por tag)",
+      "excludeHint": "Marque tags para excluir esses convidados (ex.: padrinhos). Um grupo é removido se qualquer integrante tiver a tag.",
+      "excludePadrinhos": "Excluir padrinhos e madrinhas",
+      "noTags": "Nenhuma tag cadastrada."
     },
     "test": {
       "title": "Enviar teste para mim",
       "subtitle": "Receba o Save the Date no seu próprio contato antes do disparo.",
       "whatsapp": "Testar no WhatsApp",
       "email": "Testar por e-mail",
-      "whatsappOffline": "WhatsApp não conectado. Conecte em Ajustes para testar por WhatsApp."
+      "whatsappOffline": "WhatsApp não conectado. Conecte em Ajustes para testar por WhatsApp.",
+      "toPlaceholder": "Número (+55...) ou e-mail (opcional)",
+      "toHint": "Vazio = envia para o seu próprio contato. Telefone precisa do código do país."
     },
     "preview": {
       "title": "Pré-visualização"
@@ -2081,7 +2087,11 @@
         "PAUSED": "Pausado",
         "DONE": "Concluído",
         "CANCELLED": "Cancelado"
-      }
+      },
+      "skipAlreadySent": "Pular quem já recebeu",
+      "viewList": "Ver lista de envio",
+      "detailTitle": "Resultado por destinatário",
+      "exportCsv": "Exportar CSV"
     },
     "toasts": {
       "configSaved": "Save the Date salvo.",
@@ -2089,6 +2099,23 @@
       "broadcastStarted": "Envio iniciado.",
       "resendStarted": "Reenvio das falhas iniciado.",
       "broadcastCancelled": "Envio cancelado."
+    },
+    "preList": {
+      "title": "Quem vai receber",
+      "channelWhatsapp": "WhatsApp",
+      "channelEmail": "E-mail",
+      "willReceive": "Receberá",
+      "colName": "Destinatário",
+      "colChannel": "Canal",
+      "colStatus": "Status",
+      "empty": "Nenhum destinatário.",
+      "reason": {
+        "NO_CONTACT": "Sem contato",
+        "DUPLICATE_PHONE": "Telefone duplicado",
+        "EXCLUDED_TAG": "Excluído",
+        "ALREADY_SENT": "Já recebeu",
+        "SKIPPED": "Ignorado"
+      }
     }
   }
 }


### PR DESCRIPTION
Iteração 2 do módulo **Save the Date** (base em #64). Atende os 5 pedidos + 4 melhorias combinadas.

## Pedidos atendidos
1. **Excluir por tag (ex.: padrinhos)** e pelo flag *isPadrinho*. Regra **ANY**: um grupo sai do envio se **qualquer** integrante tiver a tag. Persistido em `EventSettings`.
2. **`{site}` e `{site-presentes}`** — o casal escolhe onde os links aparecem na mensagem; sem as variáveis, continuam anexados no fim (compatível).
3. **Teste para outro contato** — número (`+55…`) ou e-mail diferente do próprio (vazio = você mesmo).
4. **E-mail sem o nome do sistema** — cabeçalho passa a ser os nomes do casal, sem rodapé "mensagem automática".
5. **Pré-lista "Quem vai receber"** — tabela com canal e status antes de disparar.

## Melhorias incluídas
- **Lista de envio detalhada + export CSV** (resultado por destinatário).
- **Não reenviar a quem já recebeu** (toggle; dedup por `refId` entre disparos).
- **Normalização de telefone** (+55 para BR sem DDI) **preservando** internacionais (`+1`, `+34`, …) — conforme pedido.
- **Editor**: botões para inserir variáveis no cursor + contador de caracteres.

## Implementação
- Novo módulo puro `src/lib/notifications/std-message.ts` (`interpolateBaseTags`, `applySiteTags`, `normalizeMsisdn`), compartilhado entre o template e o preview do client — com testes.
- `recipients.ts` ganha exclusão por tag/padrinho, dedup de já-enviados e normalização de telefone.
- Schema aditivo: `EventSettings.saveTheDateExcludeTagIds` + `saveTheDateExcludePadrinhos` (`db push`).
- i18n pt-BR/en/es, docs (`save-the-date.md`, `banco-de-dados.md`), central de ajuda e changelog (0.7.1).

## Verificação
- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- `npm run test:run` — **560** testes ✅ (novos: `std-message`, builder com exclusão/dedup/normalização incl. `+1`/`+34` preservados)
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)