### PR TITLE
feat(grupos): busca, filtros, ordenação, paginação e aviso de contato

### DIFF
--- a/docs/modulos.md
+++ b/docs/modulos.md
@@ -124,6 +124,15 @@ comportamentos principais.
 - Renomear o grupo propaga o novo nome ao espelho `groupName` de todos os membros.
 - Resposta de RSVP do grupo notifica os gestores com status real
   (`CONFIRMED` / `DECLINED` / `PARTIAL`), não mais um genérico "Respondeu".
+- **Tela com busca, filtros, ordenação e paginação** (12 por página):
+  - Filtros: sem contato, com pendência, todos confirmaram, sem integrantes.
+  - Ordenação: nome, nº de pessoas, nº de pendências.
+  - Indicadores no topo: grupos, pessoas agrupadas, com pendência, sem contato.
+- **Aviso de alcance no card:** badge "sem contato — não recebe Save the Date" ou
+  "usará contato de {integrante}" (fallback), espelhando a regra de
+  [recipients.ts](../src/lib/notifications/recipients.ts) via o helper puro
+  `summarizeGroup` ([group-summary.ts](../src/app/dashboard/guests/groups/group-summary.ts)).
+  Botão WhatsApp (`wa.me`) e export CSV da lista de grupos.
 
 ---
 

--- a/src/app/dashboard/guests/groups/group-summary.test.ts
+++ b/src/app/dashboard/guests/groups/group-summary.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { summarizeGroup, type SummarizableGroup, type GroupMemberRef } from "./group-summary";
+
+const member = (over: Partial<GroupMemberRef> = {}): GroupMemberRef => ({
+  id: "m1",
+  name: "Ana",
+  phone: null,
+  email: null,
+  rsvpStatus: "INVITED",
+  ...over,
+});
+
+const group = (over: Partial<SummarizableGroup> = {}): SummarizableGroup => ({
+  contactPhone: null,
+  contactEmail: null,
+  guests: [],
+  ...over,
+});
+
+describe("summarizeGroup", () => {
+  it("counts confirmed, declined and pending members", () => {
+    const s = summarizeGroup(
+      group({
+        guests: [
+          member({ id: "1", rsvpStatus: "CONFIRMED" }),
+          member({ id: "2", rsvpStatus: "DECLINED" }),
+          member({ id: "3", rsvpStatus: "INVITED" }),
+          member({ id: "4", rsvpStatus: "MAYBE" }),
+        ],
+      }),
+    );
+    expect(s.memberCount).toBe(4);
+    expect(s.confirmed).toBe(1);
+    expect(s.declined).toBe(1);
+    expect(s.pending).toBe(2);
+  });
+
+  it("uses the group's own contact when present (no fallback)", () => {
+    const s = summarizeGroup(
+      group({ contactPhone: "11999990000", guests: [member({ phone: "11888880000" })] }),
+    );
+    expect(s.effectivePhone).toBe("+5511999990000");
+    expect(s.willReceive).toBe(true);
+    expect(s.usesFallback).toBe(false);
+    expect(s.fallbackName).toBeNull();
+  });
+
+  it("falls back to the first member with a valid phone", () => {
+    const s = summarizeGroup(
+      group({
+        guests: [
+          member({ id: "1", name: "Ana", phone: "abc" }),
+          member({ id: "2", name: "Beto", phone: "11999990000" }),
+        ],
+      }),
+    );
+    expect(s.effectivePhone).toBe("+5511999990000");
+    expect(s.usesFallback).toBe(true);
+    expect(s.fallbackName).toBe("Beto");
+    expect(s.willReceive).toBe(true);
+  });
+
+  it("falls back to a member's email when there is no phone anywhere", () => {
+    const s = summarizeGroup(
+      group({ guests: [member({ name: "Ana", email: "ana@example.com" })] }),
+    );
+    expect(s.effectivePhone).toBeNull();
+    expect(s.effectiveEmail).toBe("ana@example.com");
+    expect(s.usesFallback).toBe(true);
+    expect(s.fallbackName).toBe("Ana");
+  });
+
+  it("flags groups that nobody can receive", () => {
+    const s = summarizeGroup(group({ guests: [member({ phone: "123", email: null })] }));
+    expect(s.willReceive).toBe(false);
+    expect(s.effectivePhone).toBeNull();
+    expect(s.effectiveEmail).toBeNull();
+    expect(s.usesFallback).toBe(false);
+  });
+
+  it("treats an empty group as unreachable", () => {
+    const s = summarizeGroup(group({}));
+    expect(s.memberCount).toBe(0);
+    expect(s.willReceive).toBe(false);
+  });
+});

--- a/src/app/dashboard/guests/groups/group-summary.ts
+++ b/src/app/dashboard/guests/groups/group-summary.ts
@@ -1,0 +1,77 @@
+import { toValidMsisdn } from "@/lib/notifications/std-message";
+
+export type GroupMemberRef = {
+  id: string;
+  name: string;
+  phone: string | null;
+  email: string | null;
+  rsvpStatus: string;
+};
+
+export type SummarizableGroup = {
+  contactPhone: string | null;
+  contactEmail: string | null;
+  guests: GroupMemberRef[];
+};
+
+export type GroupSummary = {
+  memberCount: number;
+  confirmed: number;
+  declined: number;
+  /** Integrantes que ainda não confirmaram nem recusaram. */
+  pending: number;
+  /** Telefone E.164 enviável (do grupo, ou fallback do 1º integrante). */
+  effectivePhone: string | null;
+  /** E-mail (do grupo, ou fallback do 1º integrante). */
+  effectiveEmail: string | null;
+  /** Há algum canal alcançável para o Save the Date? */
+  willReceive: boolean;
+  /** O contato veio de um integrante (grupo sem contato próprio)? */
+  usesFallback: boolean;
+  /** Nome do integrante usado como fallback (quando `usesFallback`). */
+  fallbackName: string | null;
+};
+
+/**
+ * Resume um grupo para a tela de Grupos. A resolução de contato espelha
+ * exatamente `buildSaveTheDateRecipients` (src/lib/notifications/recipients.ts):
+ * usa o contato do grupo e, na ausência, cai para o primeiro integrante com
+ * telefone válido / e-mail — para que o aviso "sem contato" do card reflita o
+ * que o disparo realmente faria.
+ */
+export function summarizeGroup(group: SummarizableGroup): GroupSummary {
+  const members = group.guests;
+  const memberCount = members.length;
+  const confirmed = members.filter((m) => m.rsvpStatus === "CONFIRMED").length;
+  const declined = members.filter((m) => m.rsvpStatus === "DECLINED").length;
+  const pending = memberCount - confirmed - declined;
+
+  const ownPhone = toValidMsisdn(group.contactPhone);
+  const ownEmail = group.contactEmail?.trim() ? group.contactEmail : null;
+
+  const fallbackPhoneMember = ownPhone
+    ? null
+    : members.find((m) => toValidMsisdn(m.phone)) ?? null;
+  const fallbackEmailMember = ownEmail
+    ? null
+    : members.find((m) => m.email?.trim()) ?? null;
+
+  const effectivePhone = ownPhone ?? toValidMsisdn(fallbackPhoneMember?.phone);
+  const effectiveEmail = ownEmail ?? fallbackEmailMember?.email ?? null;
+  const willReceive = Boolean(effectivePhone || effectiveEmail);
+
+  const fallbackMember = fallbackPhoneMember ?? fallbackEmailMember;
+  const usesFallback = willReceive && !ownPhone && !ownEmail && fallbackMember !== null;
+
+  return {
+    memberCount,
+    confirmed,
+    declined,
+    pending,
+    effectivePhone,
+    effectiveEmail,
+    willReceive,
+    usesFallback,
+    fallbackName: usesFallback ? (fallbackMember?.name ?? null) : null,
+  };
+}

--- a/src/app/dashboard/guests/groups/groups-client.tsx
+++ b/src/app/dashboard/guests/groups/groups-client.tsx
@@ -4,15 +4,31 @@ import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { ArrowLeft, Plus, Link2, Trash2, Edit3, Users, CheckCircle2, X } from "lucide-react";
+import {
+  ArrowLeft,
+  Plus,
+  Link2,
+  Trash2,
+  Edit3,
+  Users,
+  CheckCircle2,
+  X,
+  Search,
+  Download,
+  MessageCircle,
+  PhoneOff,
+  UserCheck,
+} from "lucide-react";
 import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Pagination, usePagination } from "@/components/pagination";
 import {
   createGuestGroup,
   deleteGuestGroup,
   setGroupMembers,
   updateGuestGroup,
 } from "@/app/actions/guestGroupActions";
+import { summarizeGroup, type GroupSummary } from "./group-summary";
 
 type GuestRef = {
   id: string;
@@ -20,6 +36,9 @@ type GuestRef = {
   groupId: string | null;
   rsvpStatus: string;
 };
+
+type GroupFilter = "ALL" | "NO_CONTACT" | "PENDING" | "ALL_CONFIRMED" | "EMPTY";
+type GroupSort = "NAME" | "SIZE" | "PENDING";
 
 type Group = {
   id: string;
@@ -50,6 +69,9 @@ export default function GroupsClient({
   const [managingMembersOf, setManagingMembersOf] = useState<Group | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<Group | null>(null);
   const [busy, setBusy] = useState(false);
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<GroupFilter>("ALL");
+  const [sort, setSort] = useState<GroupSort>("NAME");
   const [, startTransition] = useTransition();
 
   const [prevGroupsProp, setPrevGroupsProp] = useState(initialGroups);
@@ -61,6 +83,87 @@ export default function GroupsClient({
   if (allGuests !== prevGuestsProp) {
     setPrevGuestsProp(allGuests);
     setGuests(allGuests);
+  }
+
+  const summaries = useMemo(() => {
+    const map = new Map<string, GroupSummary>();
+    for (const g of groups) map.set(g.id, summarizeGroup(g));
+    return map;
+  }, [groups]);
+
+  const stats = useMemo(() => {
+    let people = 0;
+    let noContact = 0;
+    let pending = 0;
+    for (const g of groups) {
+      const s = summaries.get(g.id)!;
+      people += s.memberCount;
+      if (!s.willReceive) noContact += 1;
+      if (s.pending > 0) pending += 1;
+    }
+    return { total: groups.length, people, noContact, pending };
+  }, [groups, summaries]);
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    const rows = groups.filter((g) => {
+      const s = summaries.get(g.id)!;
+      if (filter === "NO_CONTACT" && s.willReceive) return false;
+      if (filter === "PENDING" && s.pending === 0) return false;
+      if (filter === "ALL_CONFIRMED" && !(s.memberCount > 0 && s.pending === 0 && s.declined === 0))
+        return false;
+      if (filter === "EMPTY" && s.memberCount > 0) return false;
+      if (term && !`${g.name} ${g.contactName ?? ""}`.toLowerCase().includes(term)) return false;
+      return true;
+    });
+    const sorted = [...rows];
+    sorted.sort((a, b) => {
+      const sa = summaries.get(a.id)!;
+      const sb = summaries.get(b.id)!;
+      if (sort === "SIZE") return sb.memberCount - sa.memberCount || a.name.localeCompare(b.name);
+      if (sort === "PENDING") return sb.pending - sa.pending || a.name.localeCompare(b.name);
+      return a.name.localeCompare(b.name);
+    });
+    return sorted;
+  }, [groups, summaries, search, filter, sort]);
+
+  const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(filtered, 12);
+
+  function exportCsv() {
+    const header = [
+      t("csv.name"),
+      t("csv.contact"),
+      t("csv.phone"),
+      t("csv.email"),
+      t("csv.people"),
+      t("csv.confirmed"),
+      t("csv.pending"),
+      t("csv.declined"),
+      t("csv.willReceive"),
+    ].join(",");
+    const rows = filtered.map((g) => {
+      const s = summaries.get(g.id)!;
+      return [
+        g.name,
+        g.contactName ?? "",
+        s.effectivePhone ?? "",
+        s.effectiveEmail ?? "",
+        s.memberCount,
+        s.confirmed,
+        s.pending,
+        s.declined,
+        s.willReceive ? t("csv.yes") : t("csv.no"),
+      ]
+        .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+        .join(",");
+    });
+    const blob = new Blob([`${header}\n${rows.join("\n")}`], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${t("csv.fileName")}-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
   }
 
   function copyLink(token: string) {
@@ -140,14 +243,26 @@ export default function GroupsClient({
           <h1 className="text-xl font-semibold text-zinc-100 md:text-2xl">{t("title")}</h1>
           <p className="text-sm text-zinc-400">{t("subtitle")}</p>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowCreate(true)}
-          className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500"
-        >
-          <Plus className="h-4 w-4" />
-          {t("newGroup")}
-        </button>
+        <div className="flex items-center gap-2">
+          {groups.length > 0 ? (
+            <button
+              type="button"
+              onClick={exportCsv}
+              className="inline-flex items-center gap-2 rounded-lg border border-zinc-700 px-3 py-2 text-sm font-medium text-zinc-200 hover:bg-zinc-800"
+            >
+              <Download className="h-4 w-4" />
+              {t("exportCsv")}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => setShowCreate(true)}
+            className="inline-flex items-center gap-2 rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-500"
+          >
+            <Plus className="h-4 w-4" />
+            {t("newGroup")}
+          </button>
+        </div>
       </header>
 
       {groups.length === 0 ? (
@@ -156,76 +271,165 @@ export default function GroupsClient({
           <p className="text-sm text-zinc-400">{t("empty")}</p>
         </div>
       ) : (
-        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {groups.map((g) => {
-            const confirmed = g.guests.filter((m) => m.rsvpStatus === "CONFIRMED").length;
-            const declined = g.guests.filter((m) => m.rsvpStatus === "DECLINED").length;
-            const pending = g.guests.length - confirmed - declined;
-            return (
-              <li
-                key={g.id}
-                className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4"
+        <>
+          <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <StatTile label={t("stats.total")} value={stats.total} />
+            <StatTile label={t("stats.people")} value={stats.people} />
+            <StatTile label={t("stats.pending")} value={stats.pending} accent="amber" />
+            <StatTile label={t("stats.noContact")} value={stats.noContact} accent="rose" />
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="relative flex-1">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500" />
+              <input
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t("search.placeholder")}
+                className="w-full rounded-xl border border-zinc-800 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
+              />
+            </div>
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value as GroupSort)}
+              aria-label={t("sort.label")}
+              className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
+            >
+              <option value="NAME">{t("sort.name")}</option>
+              <option value="SIZE">{t("sort.size")}</option>
+              <option value="PENDING">{t("sort.pending")}</option>
+            </select>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {(["ALL", "NO_CONTACT", "PENDING", "ALL_CONFIRMED", "EMPTY"] as GroupFilter[]).map((f) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => setFilter(f)}
+                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                  filter === f
+                    ? "border-rose-500/30 bg-rose-500/10 text-rose-300"
+                    : "border-zinc-800 bg-zinc-950 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+                }`}
               >
-                <header className="mb-2 flex items-start justify-between gap-2">
-                  <div className="min-w-0">
-                    <h2 className="truncate text-base font-semibold text-zinc-100">{g.name}</h2>
-                    {g.contactName ? (
-                      <p className="text-xs text-zinc-500">{t("card.contact", { name: g.contactName })}</p>
+                {t(`filter.${f}`)}
+              </button>
+            ))}
+          </div>
+
+          {filtered.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-zinc-700 p-8 text-center">
+              <Search className="mx-auto mb-3 h-8 w-8 text-zinc-500" />
+              <p className="text-sm text-zinc-400">{t("emptyFiltered")}</p>
+            </div>
+          ) : (
+            <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {pageItems.map((g) => {
+                const s = summaries.get(g.id)!;
+                return (
+                  <li key={g.id} className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+                    <header className="mb-2 flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <h2 className="truncate text-base font-semibold text-zinc-100">{g.name}</h2>
+                        {g.contactName ? (
+                          <p className="text-xs text-zinc-500">{t("card.contact", { name: g.contactName })}</p>
+                        ) : null}
+                        {s.effectivePhone || s.effectiveEmail ? (
+                          <p className="truncate text-xs text-zinc-500">
+                            {s.effectivePhone ?? s.effectiveEmail}
+                          </p>
+                        ) : null}
+                      </div>
+                      <span className="shrink-0 rounded bg-zinc-800 px-2 py-0.5 text-[10px] text-zinc-400">
+                        {t("card.people", { count: s.memberCount })}
+                      </span>
+                    </header>
+
+                    {!s.willReceive ? (
+                      <p className="mb-2 inline-flex items-center gap-1 rounded bg-rose-500/10 px-2 py-1 text-[10px] text-rose-300">
+                        <PhoneOff className="h-3 w-3" />
+                        {t("card.willNotReceive")}
+                      </p>
+                    ) : s.usesFallback ? (
+                      <p className="mb-2 inline-flex items-center gap-1 rounded bg-amber-500/10 px-2 py-1 text-[10px] text-amber-300">
+                        <UserCheck className="h-3 w-3" />
+                        {t("card.usesFallback", { name: s.fallbackName ?? "" })}
+                      </p>
                     ) : null}
-                  </div>
-                  <span className="rounded bg-zinc-800 px-2 py-0.5 text-[10px] text-zinc-400">
-                    {t("card.people", { count: g.guests.length })}
-                  </span>
-                </header>
-                <div className="mb-3 grid grid-cols-3 gap-1 text-center text-[10px]">
-                  <span className="rounded bg-emerald-500/10 px-1.5 py-1 text-emerald-300">
-                    {t("card.yes", { count: confirmed })}
-                  </span>
-                  <span className="rounded bg-amber-500/10 px-1.5 py-1 text-amber-300">
-                    {t("card.pending", { count: pending })}
-                  </span>
-                  <span className="rounded bg-rose-500/10 px-1.5 py-1 text-rose-300">
-                    {t("card.no", { count: declined })}
-                  </span>
-                </div>
-                <div className="flex flex-wrap gap-1.5">
-                  <button
-                    type="button"
-                    onClick={() => copyLink(g.rsvpToken)}
-                    className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
-                  >
-                    <Link2 className="h-3.5 w-3.5" />
-                    {t("card.copyLink")}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setManagingMembersOf(g)}
-                    className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
-                  >
-                    <Users className="h-3.5 w-3.5" />
-                    {t("card.members")}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setEditing(g)}
-                    className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
-                  >
-                    <Edit3 className="h-3.5 w-3.5" />
-                    {tc("actions.edit")}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setConfirmDelete(g)}
-                    className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-rose-300 hover:bg-rose-500/10"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                    {tc("actions.delete")}
-                  </button>
-                </div>
-              </li>
-            );
-          })}
-        </ul>
+
+                    <div className="mb-3 grid grid-cols-3 gap-1 text-center text-[10px]">
+                      <span className="rounded bg-emerald-500/10 px-1.5 py-1 text-emerald-300">
+                        {t("card.yes", { count: s.confirmed })}
+                      </span>
+                      <span className="rounded bg-amber-500/10 px-1.5 py-1 text-amber-300">
+                        {t("card.pending", { count: s.pending })}
+                      </span>
+                      <span className="rounded bg-rose-500/10 px-1.5 py-1 text-rose-300">
+                        {t("card.no", { count: s.declined })}
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      <button
+                        type="button"
+                        onClick={() => copyLink(g.rsvpToken)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
+                      >
+                        <Link2 className="h-3.5 w-3.5" />
+                        {t("card.copyLink")}
+                      </button>
+                      {s.effectivePhone ? (
+                        <a
+                          href={`https://wa.me/${s.effectivePhone.replace(/\D+/g, "")}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 rounded-lg border border-emerald-700/50 px-2 py-1.5 text-xs text-emerald-300 hover:bg-emerald-500/10"
+                        >
+                          <MessageCircle className="h-3.5 w-3.5" />
+                          {t("card.whatsapp")}
+                        </a>
+                      ) : null}
+                      <button
+                        type="button"
+                        onClick={() => setManagingMembersOf(g)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
+                      >
+                        <Users className="h-3.5 w-3.5" />
+                        {t("card.members")}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setEditing(g)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-zinc-200 hover:bg-zinc-800"
+                      >
+                        <Edit3 className="h-3.5 w-3.5" />
+                        {tc("actions.edit")}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setConfirmDelete(g)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-2 py-1.5 text-xs text-rose-300 hover:bg-rose-500/10"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        {tc("actions.delete")}
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <Pagination
+            page={page}
+            totalPages={totalPages}
+            total={total}
+            from={from}
+            to={to}
+            onPageChange={setPage}
+          />
+        </>
       )}
 
       {showCreate ? (
@@ -494,6 +698,25 @@ function MembersDialog({
           </div>
         </footer>
       </div>
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent?: "amber" | "rose";
+}) {
+  const accentClass =
+    accent === "amber" ? "text-amber-300" : accent === "rose" ? "text-rose-300" : "text-zinc-100";
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4">
+      <p className="text-xs uppercase tracking-wider text-zinc-500">{label}</p>
+      <p className={`mt-1 text-2xl font-bold ${accentClass}`}>{value}</p>
     </div>
   );
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,15 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.7.3",
+    date: "2026-06-08",
+    highlights: [
+      "👨‍👩‍👧‍👦 A tela de **Grupos** ganhou **busca, filtros, ordenação e paginação** — muito mais fácil de navegar quando há muitas famílias.",
+      "🚦 Novo filtro **'Sem contato'** e aviso no card mostram quais grupos **não receberiam o Save the Date** (ou de qual integrante o contato será usado).",
+      "📊 Indicadores no topo (grupos, pessoas agrupadas, com pendência, sem contato), **botão WhatsApp** direto no card e **export CSV** da lista de grupos.",
+    ],
+  },
+  {
     version: "0.7.2",
     date: "2026-06-08",
     highlights: [

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -823,6 +823,8 @@ export const HELP_ARTICLES: HelpArticle[] = [
     ],
     tips: [
       "RSVP individual continua funcionando — o link de grupo é alternativa, não substituto.",
+      "Use o filtro 'Sem contato' para achar rapidamente os grupos que ficariam de fora do Save the Date — o card avisa quando vai usar o contato de um integrante (fallback) ou quando ninguém tem contato.",
+      "A tela tem busca (por nome do grupo ou contato), ordenação (nome / nº de pessoas / pendências) e paginação. Dá para exportar a lista de grupos em CSV.",
       "Cada convidado pode estar em apenas um grupo. Escolher o grupo pelo seletor já vincula o convidado de verdade (entra no RSVP coletivo e no Save the Date).",
       "Renomeou o grupo? O novo nome é propagado automaticamente para todos os integrantes.",
       "Importou um CSV com a coluna 'Grupo' preenchida? Os grupos são criados automaticamente (e os existentes reaproveitados pelo nome) — basta abrir o grupo depois para preencher contato e copiar o link.",

--- a/src/messages/en/dashboard.json
+++ b/src/messages/en/dashboard.json
@@ -297,7 +297,45 @@
       "title": "Groups / Families",
       "subtitle": "Create groups to generate a single RSVP link per family.",
       "newGroup": "New group",
+      "exportCsv": "Export CSV",
       "empty": "No groups yet.",
+      "emptyFiltered": "No groups match your search/filter.",
+      "search": {
+        "placeholder": "Search by group name or contact..."
+      },
+      "filter": {
+        "ALL": "All",
+        "NO_CONTACT": "No contact",
+        "PENDING": "Has pending",
+        "ALL_CONFIRMED": "All confirmed",
+        "EMPTY": "No members"
+      },
+      "sort": {
+        "label": "Sort",
+        "name": "Name (A–Z)",
+        "size": "Most people",
+        "pending": "Most pending"
+      },
+      "stats": {
+        "total": "Groups",
+        "people": "Grouped people",
+        "pending": "Has pending",
+        "noContact": "No contact"
+      },
+      "csv": {
+        "name": "Group",
+        "contact": "Contact",
+        "phone": "Phone",
+        "email": "Email",
+        "people": "People",
+        "confirmed": "Confirmed",
+        "pending": "Pending",
+        "declined": "Declined",
+        "willReceive": "Receives Save the Date",
+        "yes": "Yes",
+        "no": "No",
+        "fileName": "groups"
+      },
       "card": {
         "contact": "Contact: {name}",
         "people": "{count, plural, one {# person} other {# people}}",
@@ -305,7 +343,10 @@
         "pending": "{count} pending",
         "no": "{count} no",
         "copyLink": "Copy link",
-        "members": "Members"
+        "members": "Members",
+        "whatsapp": "WhatsApp",
+        "willNotReceive": "No contact — won't receive Save the Date",
+        "usesFallback": "Will use {name}'s contact"
       },
       "form": {
         "createTitle": "New group",

--- a/src/messages/es/dashboard.json
+++ b/src/messages/es/dashboard.json
@@ -297,7 +297,45 @@
       "title": "Grupos / Familias",
       "subtitle": "Crea grupos para generar un único enlace de RSVP por familia.",
       "newGroup": "Nuevo grupo",
+      "exportCsv": "Exportar CSV",
       "empty": "Ningún grupo registrado.",
+      "emptyFiltered": "Ningún grupo coincide con la búsqueda/filtro.",
+      "search": {
+        "placeholder": "Buscar por nombre del grupo o contacto..."
+      },
+      "filter": {
+        "ALL": "Todos",
+        "NO_CONTACT": "Sin contacto",
+        "PENDING": "Con pendiente",
+        "ALL_CONFIRMED": "Todos confirmaron",
+        "EMPTY": "Sin miembros"
+      },
+      "sort": {
+        "label": "Ordenar",
+        "name": "Nombre (A–Z)",
+        "size": "Más personas",
+        "pending": "Más pendientes"
+      },
+      "stats": {
+        "total": "Grupos",
+        "people": "Personas agrupadas",
+        "pending": "Con pendiente",
+        "noContact": "Sin contacto"
+      },
+      "csv": {
+        "name": "Grupo",
+        "contact": "Contacto",
+        "phone": "Teléfono",
+        "email": "Email",
+        "people": "Personas",
+        "confirmed": "Confirmados",
+        "pending": "Pendientes",
+        "declined": "Rechazados",
+        "willReceive": "Recibe Save the Date",
+        "yes": "Sí",
+        "no": "No",
+        "fileName": "grupos"
+      },
       "card": {
         "contact": "Contacto: {name}",
         "people": "{count, plural, one {# persona} other {# personas}}",
@@ -305,7 +343,10 @@
         "pending": "{count} pendiente",
         "no": "{count} no",
         "copyLink": "Copiar enlace",
-        "members": "Miembros"
+        "members": "Miembros",
+        "whatsapp": "WhatsApp",
+        "willNotReceive": "Sin contacto — no recibe Save the Date",
+        "usesFallback": "Usará el contacto de {name}"
       },
       "form": {
         "createTitle": "Nuevo grupo",

--- a/src/messages/pt-BR/dashboard.json
+++ b/src/messages/pt-BR/dashboard.json
@@ -297,7 +297,45 @@
       "title": "Grupos / Famílias",
       "subtitle": "Crie grupos para gerar um único link de RSVP por família.",
       "newGroup": "Novo grupo",
+      "exportCsv": "Exportar CSV",
       "empty": "Nenhum grupo cadastrado.",
+      "emptyFiltered": "Nenhum grupo encontrado para a busca/filtro.",
+      "search": {
+        "placeholder": "Buscar por nome do grupo ou contato..."
+      },
+      "filter": {
+        "ALL": "Todos",
+        "NO_CONTACT": "Sem contato",
+        "PENDING": "Com pendência",
+        "ALL_CONFIRMED": "Todos confirmaram",
+        "EMPTY": "Sem integrantes"
+      },
+      "sort": {
+        "label": "Ordenar",
+        "name": "Nome (A–Z)",
+        "size": "Mais pessoas",
+        "pending": "Mais pendências"
+      },
+      "stats": {
+        "total": "Grupos",
+        "people": "Pessoas agrupadas",
+        "pending": "Com pendência",
+        "noContact": "Sem contato"
+      },
+      "csv": {
+        "name": "Grupo",
+        "contact": "Contato",
+        "phone": "Telefone",
+        "email": "Email",
+        "people": "Pessoas",
+        "confirmed": "Confirmados",
+        "pending": "Pendentes",
+        "declined": "Recusados",
+        "willReceive": "Recebe Save the Date",
+        "yes": "Sim",
+        "no": "Não",
+        "fileName": "grupos"
+      },
       "card": {
         "contact": "Contato: {name}",
         "people": "{count} pessoas",
@@ -305,7 +343,10 @@
         "pending": "{count} pendente",
         "no": "{count} não",
         "copyLink": "Copiar link",
-        "members": "Membros"
+        "members": "Membros",
+        "whatsapp": "WhatsApp",
+        "willNotReceive": "Sem contato — não recebe Save the Date",
+        "usesFallback": "Usará contato de {name}"
       },
       "form": {
         "createTitle": "Novo grupo",


### PR DESCRIPTION
## Contexto

A tela de Grupos (`/dashboard/guests/groups`) era apenas uma grade de cards — sem busca, filtro, paginação nem indicadores. Além disso, após a correção do Save the Date (fallback para contato de integrante), faltava **visibilidade**: o usuário não enxergava quais grupos ficariam de fora do envio.

## O que mudou

Mesma ergonomia da tela de Convidados, **reutilizando** `usePagination`/`Pagination`, busca, chips, `StatTile` e o padrão de export CSV — **sem nova query** (os dados já chegavam ao client).

- **Busca** (nome do grupo + contato) e **paginação** (12/página).
- **Filtros**: Todos · Sem contato · Com pendência · Todos confirmaram · Sem integrantes.
- **Ordenação**: nome · nº de pessoas · nº de pendências.
- **Stats no topo**: grupos, pessoas agrupadas, com pendência, sem contato.
- **Cards enriquecidos**: contato efetivo, badge vermelho *"sem contato — não recebe Save the Date"* ou âmbar *"usará contato de {integrante}"* (fallback), e botão **WhatsApp** (`wa.me`).
- **Export CSV** da lista de grupos.

## Qualidade

Helper puro [`summarizeGroup`](src/app/dashboard/guests/groups/group-summary.ts) que **espelha exatamente** a regra de [`recipients.ts`](src/lib/notifications/recipients.ts) (via `toValidMsisdn`) — assim o aviso "sem contato" no card reflete fielmente o que o Save the Date faria. Coberto por 6 testes unitários.

## Sincronização
- i18n nos **3 catálogos** (pt-BR/en/es).
- `docs/modulos.md`, `src/lib/help-content.ts`, `src/lib/changelog.ts` (entrada 0.7.3).

## Verificação
- `npm run lint` ✓
- `npm run test:run` ✓ (572 testes, 6 novos de `summarizeGroup`)
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)