### PR TITLE
feat(notifications): lembrete automático de RSVP (Fase B / item 1.1)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -164,8 +164,13 @@ Authorization: Bearer <CRON_SECRET>
 1. Busca pagamentos com `dueDate` em ≤ 3 dias ou já vencidos.
 2. Busca tarefas com `deadline` em ≤ 2 dias ou já vencidas.
 3. Para cada um, dispara `notify("PAYMENT_DUE"|"PAYMENT_OVERDUE"|"TASK_DUE"|"TASK_OVERDUE")`
-   por email e WhatsApp.
-4. Grava resultado em `NotificationLog` (idempotente por dia).
+   por email e WhatsApp (destinatários: equipe — `ADMIN/GROOM/BRIDE/PLANNER`).
+4. **Lembrete de RSVP (opcional, guest-facing):** quando `EventSettings.rsvpReminderEnabled`
+   está ligado, cutuca convidados/grupos ainda `INVITED` convidados há ≥ `rsvpReminderDays`
+   (padrão 7), com contato alcançável (telefone do grupo ou, na falta, do 1º integrante;
+   senão e-mail). Dispara `RSVP_REMINDER` / `RSVP_REMINDER_GROUP` com o link de RSVP.
+   Deduplica por telefone (grupo tem prioridade) e respeita a idempotência por dia.
+5. Grava resultado em `NotificationLog` (idempotente por dia: `kind + refType + refId + data BRT`).
 
 **Retorna:**
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,6 +90,8 @@ model EventSettings {
   saveTheDateFileName    String?
   saveTheDateExcludeTagIds   String?
   saveTheDateExcludePadrinhos Boolean @default(false)
+  rsvpReminderEnabled    Boolean   @default(false)
+  rsvpReminderDays       Int       @default(7)
   updatedAt              DateTime  @updatedAt
 }
 

--- a/src/app/actions/settingsActions.ts
+++ b/src/app/actions/settingsActions.ts
@@ -22,6 +22,11 @@ const SettingsSchema = z.object({
   contingencyPercent: z.coerce.number().min(0).max(100),
   currency: z.enum(["BRL", "USD", "EUR"]).default("BRL"),
   coupleNames: optStr(120),
+  rsvpReminderEnabled: z.preprocess(
+    (v) => v === "on" || v === true || v === "true",
+    z.boolean().default(false),
+  ),
+  rsvpReminderDays: z.coerce.number().int().min(1).max(90).default(7),
 });
 
 const PixSettingsSchema = z.object({
@@ -53,6 +58,8 @@ export async function updateSettings(
       contingencyPercent: parsed.data.contingencyPercent,
       currency: parsed.data.currency,
       coupleNames: parsed.data.coupleNames,
+      rsvpReminderEnabled: parsed.data.rsvpReminderEnabled,
+      rsvpReminderDays: parsed.data.rsvpReminderDays,
     });
     await audit("EventSettings", "singleton", "UPDATE", {
       eventDate: parsed.data.eventDate,

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -7,6 +7,8 @@ import { timingSafeEquals } from "@/lib/timing-safe";
 import { getClientIp, rateLimit } from "@/lib/rate-limit";
 import { computeAdjustedAmount } from "@/lib/payment-adjustment";
 import { coerceLocale } from "@/i18n/config";
+import { getEventConfig } from "@/lib/event-config";
+import { selectRsvpReminderTargets } from "@/lib/notifications/rsvp-reminder";
 
 export const dynamic = "force-dynamic";
 
@@ -29,6 +31,7 @@ type Summary = {
   paymentsOverdue: number;
   tasksDue: number;
   tasksOverdue: number;
+  rsvpReminders: number;
   skippedAlreadyNotified: number;
 };
 
@@ -58,6 +61,7 @@ export async function GET(req: Request): Promise<NextResponse> {
     paymentsOverdue: 0,
     tasksDue: 0,
     tasksOverdue: 0,
+    rsvpReminders: 0,
     skippedAlreadyNotified: 0,
   };
 
@@ -72,7 +76,7 @@ export async function GET(req: Request): Promise<NextResponse> {
         select: { id: true, name: true, email: true, phone: true, locale: true },
       }),
       loadNotifiedTodaySet(
-        ["PAYMENT_DUE", "PAYMENT_OVERDUE", "TASK_DUE", "TASK_OVERDUE"],
+        ["PAYMENT_DUE", "PAYMENT_OVERDUE", "TASK_DUE", "TASK_OVERDUE", "RSVP_REMINDER", "RSVP_REMINDER_GROUP"],
         today,
       ),
       prisma.payment.findMany({
@@ -202,6 +206,83 @@ export async function GET(req: Request): Promise<NextResponse> {
       ),
     );
     summary.tasksOverdue += 1;
+  }
+
+  // Lembrete de RSVP (guest-facing) — opcional, só quando o casal habilita.
+  const cfg = await getEventConfig();
+  if (cfg.rsvpReminderEnabled) {
+    const baseUrl =
+      process.env.APP_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3005";
+    const days = Math.max(1, cfg.rsvpReminderDays);
+    const [groups, ungroupedGuests] = await Promise.all([
+      prisma.guestGroup.findMany({
+        where: { deletedAt: null },
+        select: {
+          id: true,
+          name: true,
+          contactName: true,
+          contactPhone: true,
+          contactEmail: true,
+          rsvpToken: true,
+          createdAt: true,
+          guests: {
+            where: { deletedAt: null },
+            orderBy: { name: "asc" },
+            select: { name: true, phone: true, email: true, rsvpStatus: true },
+          },
+        },
+      }),
+      prisma.guest.findMany({
+        where: { deletedAt: null, groupId: null, rsvpStatus: "INVITED" },
+        select: {
+          id: true,
+          name: true,
+          phone: true,
+          email: true,
+          language: true,
+          rsvpStatus: true,
+          rsvpToken: true,
+          createdAt: true,
+        },
+      }),
+    ]);
+
+    const targets = selectRsvpReminderTargets({
+      groups,
+      guests: ungroupedGuests,
+      days,
+      today,
+      defaultLocale: cfg.defaultLocale,
+      alreadySent: sentSet,
+    });
+
+    for (const target of targets) {
+      const rsvpUrl =
+        target.refType === "GuestGroup"
+          ? `${baseUrl}/rsvp/group/${target.token}`
+          : `${baseUrl}/rsvp/${target.token}`;
+      const renderInput =
+        target.kind === "RSVP_REMINDER_GROUP"
+          ? {
+              kind: "RSVP_REMINDER_GROUP" as const,
+              userName: target.name,
+              memberNames: target.memberNames,
+              rsvpUrl,
+              daysInvitedSince: target.daysInvitedSince,
+            }
+          : {
+              kind: "RSVP_REMINDER" as const,
+              userName: target.name,
+              rsvpUrl,
+              daysInvitedSince: target.daysInvitedSince,
+            };
+      await notify(
+        { email: target.email, phone: target.phone, locale: target.locale },
+        renderInput,
+        { refType: target.refType, refId: target.refId },
+      );
+      summary.rsvpReminders += 1;
+    }
   }
 
   return NextResponse.json({ ok: true, summary });

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -80,6 +80,8 @@ export default async function SettingsPage() {
           contingencyPercent: cfg.contingencyPercent,
           currency: cfg.currency,
           coupleNames: cfg.coupleNames ?? "",
+          rsvpReminderEnabled: cfg.rsvpReminderEnabled,
+          rsvpReminderDays: cfg.rsvpReminderDays,
         }}
         pixSettings={{
           pixKey: cfg.pixKey ?? "",

--- a/src/app/dashboard/settings/settings-client.tsx
+++ b/src/app/dashboard/settings/settings-client.tsx
@@ -62,6 +62,8 @@ type Initial = {
   contingencyPercent: number;
   currency: string;
   coupleNames: string;
+  rsvpReminderEnabled: boolean;
+  rsvpReminderDays: number;
 };
 
 type PixSettings = {
@@ -356,6 +358,24 @@ function EventTab({
             type="number"
             step="0.1"
             defaultValue={String(initial.contingencyPercent)}
+          />
+          <label className="flex items-center gap-2 self-end pb-2 text-sm text-zinc-300 sm:col-span-2">
+            <input
+              type="checkbox"
+              name="rsvpReminderEnabled"
+              defaultChecked={initial.rsvpReminderEnabled}
+              className="accent-rose-500"
+            />
+            {t("event.rsvpReminderEnabled")}
+          </label>
+          <p className="-mt-2 text-xs text-zinc-500 sm:col-span-2">{t("event.rsvpReminderHint")}</p>
+          <Field
+            name="rsvpReminderDays"
+            label={t("event.rsvpReminderDays")}
+            type="number"
+            min="1"
+            max="90"
+            defaultValue={String(initial.rsvpReminderDays)}
           />
           <div className="sm:col-span-2">
             <button
@@ -2130,6 +2150,8 @@ function Field({
   type = "text",
   required,
   step,
+  min,
+  max,
   defaultValue,
   placeholder,
   pattern,
@@ -2139,6 +2161,8 @@ function Field({
   type?: string;
   required?: boolean;
   step?: string;
+  min?: string;
+  max?: string;
   defaultValue?: string;
   placeholder?: string;
   pattern?: string;
@@ -2151,6 +2175,8 @@ function Field({
         name={name}
         required={required}
         step={step}
+        min={min}
+        max={max}
         defaultValue={defaultValue}
         placeholder={placeholder}
         pattern={pattern}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,15 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.7.4",
+    date: "2026-06-08",
+    highlights: [
+      "📬 Novo **lembrete automático de RSVP**: o sistema pode cutucar por WhatsApp/e-mail os convidados que ainda não responderam, com o link de confirmação. Ative em Configurações › Evento e escolha após quantos dias do convite lembrar.",
+      "👨‍👩‍👧 Para famílias/grupos, o lembrete vai para o contato do grupo (ou, na falta, de um integrante) e cita quem ainda falta confirmar — sem mandar duas vezes para o mesmo número.",
+      "📊 Bastidores: novas projeções financeiras reutilizáveis (quanto sobra até o evento, ritmo de meta, previsão de estouro) que vão alimentar os próximos cartões de Insights.",
+    ],
+  },
+  {
     version: "0.7.3",
     date: "2026-06-08",
     highlights: [

--- a/src/lib/event-config.ts
+++ b/src/lib/event-config.ts
@@ -20,6 +20,8 @@ export type EventConfig = {
   saveTheDateFileName: string | null;
   saveTheDateExcludeTagIds: string | null;
   saveTheDateExcludePadrinhos: boolean;
+  rsvpReminderEnabled: boolean;
+  rsvpReminderDays: number;
 };
 
 export async function getEventConfig(): Promise<EventConfig> {
@@ -52,6 +54,8 @@ export async function getEventConfig(): Promise<EventConfig> {
     saveTheDateFileName: settings.saveTheDateFileName,
     saveTheDateExcludeTagIds: settings.saveTheDateExcludeTagIds,
     saveTheDateExcludePadrinhos: settings.saveTheDateExcludePadrinhos,
+    rsvpReminderEnabled: settings.rsvpReminderEnabled,
+    rsvpReminderDays: settings.rsvpReminderDays,
   };
 }
 
@@ -97,6 +101,10 @@ export async function updateEventConfig(
         input.saveTheDateExcludePadrinhos === undefined
           ? undefined
           : input.saveTheDateExcludePadrinhos,
+      rsvpReminderEnabled:
+        input.rsvpReminderEnabled === undefined ? undefined : input.rsvpReminderEnabled,
+      rsvpReminderDays:
+        input.rsvpReminderDays === undefined ? undefined : input.rsvpReminderDays,
     },
   });
 
@@ -119,6 +127,8 @@ export async function updateEventConfig(
     saveTheDateFileName: updated.saveTheDateFileName,
     saveTheDateExcludeTagIds: updated.saveTheDateExcludeTagIds,
     saveTheDateExcludePadrinhos: updated.saveTheDateExcludePadrinhos,
+    rsvpReminderEnabled: updated.rsvpReminderEnabled,
+    rsvpReminderDays: updated.rsvpReminderDays,
   };
 }
 

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -823,6 +823,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
     ],
     tips: [
       "RSVP individual continua funcionando — o link de grupo é alternativa, não substituto.",
+      "Ligue o 'Lembrete automático de RSVP' em Configurações › Evento para cutucar por WhatsApp/e-mail quem ainda não respondeu após X dias do convite (com o link de confirmação). Para grupos, vai ao contato do grupo citando quem falta.",
       "Use o filtro 'Sem contato' para achar rapidamente os grupos que ficariam de fora do Save the Date — o card avisa quando vai usar o contato de um integrante (fallback) ou quando ninguém tem contato.",
       "A tela tem busca (por nome do grupo ou contato), ordenação (nome / nº de pessoas / pendências) e paginação. Dá para exportar a lista de grupos em CSV.",
       "Cada convidado pode estar em apenas um grupo. Escolher o grupo pelo seletor já vincula o convidado de verdade (entra no RSVP coletivo e no Save the Date).",

--- a/src/lib/notifications/rsvp-reminder.test.ts
+++ b/src/lib/notifications/rsvp-reminder.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectRsvpReminderTargets,
+  type RsvpReminderGroupRow,
+  type RsvpReminderGuestRow,
+} from "./rsvp-reminder";
+
+const DAY = 86_400_000;
+const TODAY = new Date(Date.UTC(2026, 5, 8));
+const OLD = new Date(TODAY.getTime() - 30 * DAY); // 30 dias atrás (elegível)
+const RECENT = new Date(TODAY.getTime() - 2 * DAY); // recente (não elegível p/ days=7)
+
+function run(
+  groups: RsvpReminderGroupRow[],
+  guests: RsvpReminderGuestRow[],
+  alreadySent: string[] = [],
+  days = 7,
+) {
+  return selectRsvpReminderTargets({
+    groups,
+    guests,
+    days,
+    today: TODAY,
+    defaultLocale: "pt-BR",
+    alreadySent: new Set(alreadySent),
+  });
+}
+
+const guest = (over: Partial<RsvpReminderGuestRow> = {}): RsvpReminderGuestRow => ({
+  id: "g1",
+  name: "Ana",
+  phone: "11999990000",
+  email: null,
+  language: null,
+  rsvpStatus: "INVITED",
+  rsvpToken: "tok-ana",
+  createdAt: OLD,
+  ...over,
+});
+
+const group = (over: Partial<RsvpReminderGroupRow> = {}): RsvpReminderGroupRow => ({
+  id: "grp1",
+  name: "Família Silva",
+  contactName: null,
+  contactPhone: "1188888000",
+  contactEmail: null,
+  rsvpToken: "tok-grp",
+  createdAt: OLD,
+  guests: [{ name: "Beto", phone: null, email: null, rsvpStatus: "INVITED" }],
+  ...over,
+});
+
+describe("selectRsvpReminderTargets", () => {
+  it("inclui convidado avulso INVITED, antigo, com telefone válido", () => {
+    const out = run([], [guest({ phone: "11999990000" })]);
+    expect(out).toHaveLength(1);
+    expect(out[0].refType).toBe("Guest");
+    expect(out[0].kind).toBe("RSVP_REMINDER");
+    expect(out[0].phone).toBe("+5511999990000");
+    expect(out[0].daysInvitedSince).toBe(30);
+  });
+
+  it("ignora convidado convidado recentemente (< days)", () => {
+    expect(run([], [guest({ createdAt: RECENT })])).toHaveLength(0);
+  });
+
+  it("ignora convidado que já respondeu", () => {
+    expect(run([], [guest({ rsvpStatus: "CONFIRMED" })])).toHaveLength(0);
+  });
+
+  it("ignora quem não tem contato algum", () => {
+    expect(run([], [guest({ phone: null, email: null })])).toHaveLength(0);
+  });
+
+  it("respeita o conjunto alreadySent", () => {
+    expect(run([], [guest({ id: "g1" })], ["RSVP_REMINDER:Guest:g1"])).toHaveLength(0);
+  });
+
+  it("inclui grupo com membro pendente usando o contato do grupo", () => {
+    const out = run([group({ contactPhone: "1188888000" })], []);
+    expect(out).toHaveLength(1);
+    expect(out[0].refType).toBe("GuestGroup");
+    expect(out[0].phone).toBe("+551188888000");
+    expect(out[0].memberNames).toBe("Beto");
+  });
+
+  it("grupo sem contato cai para o telefone do 1º integrante", () => {
+    const out = run([
+      group({
+        contactPhone: null,
+        contactEmail: null,
+        guests: [
+          { name: "Beto", phone: "abc", email: null, rsvpStatus: "INVITED" },
+          { name: "Carla", phone: "11977770000", email: null, rsvpStatus: "INVITED" },
+        ],
+      }),
+    ], []);
+    expect(out).toHaveLength(1);
+    expect(out[0].phone).toBe("+5511977770000");
+    expect(out[0].memberNames).toBe("Beto e Carla");
+  });
+
+  it("ignora grupo sem ninguém pendente", () => {
+    const out = run([
+      group({ guests: [{ name: "Beto", phone: null, email: null, rsvpStatus: "CONFIRMED" }] }),
+    ], []);
+    expect(out).toHaveLength(0);
+  });
+
+  it("deduplica telefone entre grupo e avulso (grupo tem prioridade)", () => {
+    const out = run(
+      [group({ contactPhone: "+5511999990000" })],
+      [guest({ id: "g1", phone: "5511999990000" })],
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].refType).toBe("GuestGroup");
+  });
+
+  it("usa o locale do convidado quando definido", () => {
+    const out = run([], [guest({ language: "es" })]);
+    expect(out[0].locale).toBe("es");
+  });
+});

--- a/src/lib/notifications/rsvp-reminder.ts
+++ b/src/lib/notifications/rsvp-reminder.ts
@@ -1,0 +1,145 @@
+import { coerceLocale, type Locale } from "@/i18n/config";
+import { toValidMsisdn } from "./std-message";
+import { joinNames } from "./recipients";
+
+const MS_PER_DAY = 86_400_000;
+
+export type RsvpReminderGroupRow = {
+  id: string;
+  name: string;
+  contactName: string | null;
+  contactPhone: string | null;
+  contactEmail: string | null;
+  rsvpToken: string;
+  createdAt: Date;
+  guests: { name: string; phone: string | null; email: string | null; rsvpStatus: string }[];
+};
+
+export type RsvpReminderGuestRow = {
+  id: string;
+  name: string;
+  phone: string | null;
+  email: string | null;
+  language: string | null;
+  rsvpStatus: string;
+  rsvpToken: string;
+  createdAt: Date;
+};
+
+export type RsvpReminderTarget = {
+  refType: "Guest" | "GuestGroup";
+  refId: string;
+  kind: "RSVP_REMINDER" | "RSVP_REMINDER_GROUP";
+  /** Nome usado na saudação (convidado, ou contato/nome do grupo). */
+  name: string;
+  /** Para grupo: integrantes pendentes citados; para avulso: o próprio nome. */
+  memberNames: string;
+  /** Telefone E.164 enviável (do grupo, ou fallback do 1º integrante). */
+  phone: string | null;
+  email: string | null;
+  /** Token de RSVP (individual ou de grupo) para montar o link. */
+  token: string;
+  locale: Locale;
+  daysInvitedSince: number;
+};
+
+function digits(value: string | null): string {
+  return (value ?? "").replace(/\D+/g, "");
+}
+
+function daysSince(from: Date, today: Date): number {
+  return Math.max(1, Math.round((today.getTime() - from.getTime()) / MS_PER_DAY));
+}
+
+function firstEmail(rows: { email: string | null }[]): string | null {
+  return rows.find((r) => r.email && r.email.trim())?.email ?? null;
+}
+
+/**
+ * Seleciona quem deve receber o lembrete de RSVP. Considera convidados/grupos
+ * convidados (`INVITED`) há pelo menos `days` dias, com contato alcançável,
+ * espelhando a resolução de contato do Save the Date (grupo, senão 1º integrante).
+ *
+ * Determinístico e sem I/O: o caller carrega as linhas e passa `today`,
+ * `defaultLocale` e o conjunto `alreadySent` (`${kind}:${refType}:${refId}`).
+ * Deduplica por telefone normalizado, com os grupos tendo prioridade sobre os
+ * convidados avulsos (evita mandar duas vezes para o mesmo número da família).
+ */
+export function selectRsvpReminderTargets(input: {
+  groups: RsvpReminderGroupRow[];
+  guests: RsvpReminderGuestRow[];
+  days: number;
+  today: Date;
+  defaultLocale: Locale;
+  alreadySent: Set<string>;
+}): RsvpReminderTarget[] {
+  const threshold = new Date(input.today.getTime() - input.days * MS_PER_DAY);
+  const out: RsvpReminderTarget[] = [];
+  const seenPhones = new Set<string>();
+
+  for (const g of input.groups) {
+    if (g.createdAt.getTime() > threshold.getTime()) continue;
+    const pending = g.guests.filter((m) => m.rsvpStatus === "INVITED");
+    if (pending.length === 0) continue;
+
+    const fallbackPhoneMember = g.guests.find((m) => toValidMsisdn(m.phone));
+    const phone = toValidMsisdn(g.contactPhone) ?? toValidMsisdn(fallbackPhoneMember?.phone ?? null);
+    const email = (g.contactEmail?.trim() ? g.contactEmail : null) ?? firstEmail(g.guests);
+    if (!phone && !email) continue;
+
+    const key = `RSVP_REMINDER_GROUP:GuestGroup:${g.id}`;
+    if (input.alreadySent.has(key)) continue;
+
+    const d = digits(phone);
+    if (d) {
+      if (seenPhones.has(d)) continue;
+      seenPhones.add(d);
+    }
+
+    out.push({
+      refType: "GuestGroup",
+      refId: g.id,
+      kind: "RSVP_REMINDER_GROUP",
+      name: g.contactName?.trim() || g.name,
+      memberNames: joinNames(pending.map((m) => m.name)),
+      phone,
+      email,
+      token: g.rsvpToken,
+      locale: input.defaultLocale,
+      daysInvitedSince: daysSince(g.createdAt, input.today),
+    });
+  }
+
+  for (const guest of input.guests) {
+    if (guest.rsvpStatus !== "INVITED") continue;
+    if (guest.createdAt.getTime() > threshold.getTime()) continue;
+
+    const phone = toValidMsisdn(guest.phone);
+    const email = guest.email?.trim() ? guest.email : null;
+    if (!phone && !email) continue;
+
+    const key = `RSVP_REMINDER:Guest:${guest.id}`;
+    if (input.alreadySent.has(key)) continue;
+
+    const d = digits(phone);
+    if (d) {
+      if (seenPhones.has(d)) continue;
+      seenPhones.add(d);
+    }
+
+    out.push({
+      refType: "Guest",
+      refId: guest.id,
+      kind: "RSVP_REMINDER",
+      name: guest.name,
+      memberNames: guest.name,
+      phone,
+      email,
+      token: guest.rsvpToken,
+      locale: guest.language ? coerceLocale(guest.language) : input.defaultLocale,
+      daysInvitedSince: daysSince(guest.createdAt, input.today),
+    });
+  }
+
+  return out;
+}

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -13,6 +13,8 @@ export type NotificationKind =
   | "TASK_OVERDUE"
   | "GUEST_RSVP"
   | "SAVE_THE_DATE"
+  | "RSVP_REMINDER"
+  | "RSVP_REMINDER_GROUP"
   | "SYSTEM_WHATSAPP_DOWN"
   | "SYSTEM_WHATSAPP_RECOVERED";
 
@@ -92,6 +94,19 @@ export type RenderInput =
       giftRegistryUrl?: string | null;
       customMessage?: string | null;
       imageCid?: string | null;
+    } & WithLocale)
+  | ({
+      kind: "RSVP_REMINDER";
+      userName: string;
+      rsvpUrl: string;
+      daysInvitedSince: number;
+    } & WithLocale)
+  | ({
+      kind: "RSVP_REMINDER_GROUP";
+      userName: string;
+      memberNames: string;
+      rsvpUrl: string;
+      daysInvitedSince: number;
     } & WithLocale)
   | ({
       kind: "SYSTEM_WHATSAPP_DOWN";
@@ -692,6 +707,64 @@ ${errorLine}`;
       );
       const text = `${tk("text")}\n${downtime}\n\n${input.settingsUrl}`;
       const waText = `*${header}*\n\n${text}`;
+      return { subject, html, text, waText };
+    }
+
+    case "RSVP_REMINDER": {
+      const tk = (key: string, values?: Record<string, string | number | Date>) =>
+        t(`RSVP_REMINDER.${key}`, values);
+      const url = escapeHtml(input.rsvpUrl);
+      const days = input.daysInvitedSince;
+      const subject = tk("subject");
+      const html = wrapHtml(
+        subject,
+        `<p>${greetingHtml}</p>
+<p>${escapeHtml(tk("intro", { days }))}</p>
+<p><a href="${url}" style="display:inline-block;background:#e11d48;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;">${escapeHtml(tk("cta"))}</a></p>`,
+        locale,
+        footer,
+        header,
+      );
+      const text = `${greetingText}
+
+${tk("intro", { days })}
+
+${tk("cta")}: ${input.rsvpUrl}`;
+      const waText = `*${tk("waTitle")}*
+
+${greetingText}
+
+${tk("waIntro", { days })}
+${input.rsvpUrl}`;
+      return { subject, html, text, waText };
+    }
+
+    case "RSVP_REMINDER_GROUP": {
+      const tk = (key: string, values?: Record<string, string | number | Date>) =>
+        t(`RSVP_REMINDER_GROUP.${key}`, values);
+      const url = escapeHtml(input.rsvpUrl);
+      const days = input.daysInvitedSince;
+      const subject = tk("subject");
+      const html = wrapHtml(
+        subject,
+        `<p>${greetingHtml}</p>
+<p>${escapeHtml(tk("intro", { members: input.memberNames, days }))}</p>
+<p><a href="${url}" style="display:inline-block;background:#e11d48;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;">${escapeHtml(tk("cta"))}</a></p>`,
+        locale,
+        footer,
+        header,
+      );
+      const text = `${greetingText}
+
+${tk("intro", { members: input.memberNames, days })}
+
+${tk("cta")}: ${input.rsvpUrl}`;
+      const waText = `*${tk("waTitle")}*
+
+${greetingText}
+
+${tk("waIntro", { members: escapeWaMarkdown(input.memberNames), days })}
+${input.rsvpUrl}`;
       return { subject, html, text, waText };
     }
   }

--- a/src/messages/en/dashboard.json
+++ b/src/messages/en/dashboard.json
@@ -1251,6 +1251,9 @@
       "currencyUSD": "Dollar (USD)",
       "currencyEUR": "Euro (EUR)",
       "contingency": "Contingency (%)",
+      "rsvpReminderEnabled": "Send automatic RSVP reminder",
+      "rsvpReminderHint": "Nudges invited guests who haven't responded via WhatsApp/email. Only sends if you enable it.",
+      "rsvpReminderDays": "Remind after (days since invite)",
       "save": "Save",
       "toast": {
         "saved": "Settings saved",

--- a/src/messages/en/notifications.json
+++ b/src/messages/en/notifications.json
@@ -139,5 +139,19 @@
     "signoff": "The formal invitation is coming soon. With love, {names}.",
     "websiteLabel": "Wedding website",
     "registryLabel": "Gift registry"
+  },
+  "RSVP_REMINDER": {
+    "subject": "Reminder: confirm your attendance",
+    "intro": "You received the invitation {days, plural, one {# day} other {# days}} ago and haven't confirmed your attendance yet. Can you confirm now?",
+    "cta": "Confirm attendance",
+    "waTitle": "📋 RSVP reminder",
+    "waIntro": "You received the invitation {days, plural, one {# day} other {# days}} ago and haven't confirmed yet. Tap the link to confirm your attendance:"
+  },
+  "RSVP_REMINDER_GROUP": {
+    "subject": "Reminder: confirm attendance",
+    "intro": "Still pending: {members}. The invitation was sent {days, plural, one {# day} other {# days}} ago. Can you confirm now?",
+    "cta": "Confirm group attendance",
+    "waTitle": "📋 RSVP reminder",
+    "waIntro": "Still pending: {members} (invitation sent {days, plural, one {# day} other {# days}} ago). Tap the link to confirm:"
   }
 }

--- a/src/messages/es/dashboard.json
+++ b/src/messages/es/dashboard.json
@@ -1251,6 +1251,9 @@
       "currencyUSD": "Dólar (USD)",
       "currencyEUR": "Euro (EUR)",
       "contingency": "Contingencia (%)",
+      "rsvpReminderEnabled": "Enviar recordatorio de RSVP automático",
+      "rsvpReminderHint": "Recuerda por WhatsApp/correo a los invitados que aún no respondieron. Solo envía si lo activas.",
+      "rsvpReminderDays": "Recordar después de (días desde la invitación)",
       "save": "Guardar",
       "toast": {
         "saved": "Configuración guardada",

--- a/src/messages/es/notifications.json
+++ b/src/messages/es/notifications.json
@@ -139,5 +139,19 @@
     "signoff": "Pronto enviaremos la invitación oficial. Con cariño, {names}.",
     "websiteLabel": "Sitio de los novios",
     "registryLabel": "Lista de regalos"
+  },
+  "RSVP_REMINDER": {
+    "subject": "Recordatorio: confirma tu asistencia",
+    "intro": "Recibiste la invitación hace {days, plural, one {# día} other {# días}} y aún no has confirmado tu asistencia. ¿Puedes confirmar ahora?",
+    "cta": "Confirmar asistencia",
+    "waTitle": "📋 Recordatorio de RSVP",
+    "waIntro": "Recibiste la invitación hace {days, plural, one {# día} other {# días}} y aún no has confirmado. Toca el enlace para confirmar tu asistencia:"
+  },
+  "RSVP_REMINDER_GROUP": {
+    "subject": "Recordatorio: confirmen la asistencia",
+    "intro": "Aún faltan confirmar: {members}. La invitación se envió hace {days, plural, one {# día} other {# días}}. ¿Pueden confirmar ahora?",
+    "cta": "Confirmar asistencia del grupo",
+    "waTitle": "📋 Recordatorio de RSVP",
+    "waIntro": "Aún faltan confirmar: {members} (invitación enviada hace {days, plural, one {# día} other {# días}}). Toca el enlace para confirmar:"
   }
 }

--- a/src/messages/pt-BR/dashboard.json
+++ b/src/messages/pt-BR/dashboard.json
@@ -1251,6 +1251,9 @@
       "currencyUSD": "Dólar (USD)",
       "currencyEUR": "Euro (EUR)",
       "contingency": "Contingência (%)",
+      "rsvpReminderEnabled": "Enviar lembrete de RSVP automático",
+      "rsvpReminderHint": "Cutuca por WhatsApp/e-mail os convidados convidados que ainda não responderam. Só envia se você ativar.",
+      "rsvpReminderDays": "Lembrar após (dias do convite)",
       "save": "Salvar",
       "toast": {
         "saved": "Configurações salvas",

--- a/src/messages/pt-BR/notifications.json
+++ b/src/messages/pt-BR/notifications.json
@@ -139,5 +139,19 @@
     "signoff": "Em breve enviaremos o convite oficial. Com carinho, {names}.",
     "websiteLabel": "Site dos noivos",
     "registryLabel": "Lista de presentes"
+  },
+  "RSVP_REMINDER": {
+    "subject": "Lembrete: confirme sua presença",
+    "intro": "Você recebeu o convite há {days, plural, one {# dia} other {# dias}} e ainda não confirmou sua presença. Pode confirmar agora?",
+    "cta": "Confirmar presença",
+    "waTitle": "📋 Lembrete de RSVP",
+    "waIntro": "Você recebeu o convite há {days, plural, one {# dia} other {# dias}} e ainda não confirmou. Toque no link para confirmar sua presença:"
+  },
+  "RSVP_REMINDER_GROUP": {
+    "subject": "Lembrete: confirmem a presença",
+    "intro": "Ainda faltam confirmar: {members}. O convite foi enviado há {days, plural, one {# dia} other {# dias}}. Podem confirmar agora?",
+    "cta": "Confirmar presença do grupo",
+    "waTitle": "📋 Lembrete de RSVP",
+    "waIntro": "Ainda faltam confirmar: {members} (convite enviado há {days, plural, one {# dia} other {# dias}}). Toque no link para confirmar:"
   }
 }


### PR DESCRIPTION
## Contexto
Item **1.1** do roadmap (quick win de alto impacto), construído sobre a infra de notificações. Lembra automaticamente os convidados que ainda não responderam ao RSVP. **Opt-in** (default OFF) para nunca enviar a convidados sem o casal ativar.

Design e bordas validados por workflow de design + verificação adversarial (dedup por telefone no run, ordem determinística do fallback, escaping HTML/WhatsApp, fuso BRT na idempotência).

## O que mudou
- **Schema (aditivo)**: `EventSettings.rsvpReminderEnabled` (default `false`) + `rsvpReminderDays` (default `7`); refletidos em `event-config.ts`.
- **Seletor puro** [`selectRsvpReminderTargets`](src/lib/notifications/rsvp-reminder.ts): seleciona `INVITED` convidados há ≥ N dias com contato alcançável, espelha o fallback de contato do Save the Date (grupo → 1º integrante com telefone/e-mail) e **deduplica por telefone** (grupo tem prioridade). 10 testes.
- **Templates** `RSVP_REMINDER` e `RSVP_REMINDER_GROUP` (HTML escapado integralmente; nomes escapados no WhatsApp) + i18n nos **3 catálogos** com plural ICU dos dias.
- **Cron** ([reminders/route.ts](src/app/api/cron/reminders/route.ts)): bloco gated por `rsvpReminderEnabled`, idempotência por dia estendida aos novos kinds, link via `APP_URL`/`NEXTAUTH_URL`.
- **UI**: toggle + nº de dias em **Configurações › Evento**.
- Docs (`docs/api.md`), ajuda e changelog (0.7.4).

## Verificação
`npm run lint` ✓ · `npm run test:run` ✓ (582 testes, +10) · `npm run build` ✓ · `prisma db push` aplicado.

Teste manual: ativar em Settings → `GET /api/cron/reminders` com `Authorization: Bearer $CRON_SECRET` → convidados `INVITED` antigos recebem o lembrete (idempotente por dia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)