### PR TITLE
feat(tasks): barra de fase da organização com countdown (Fase B / 1.3)

### DIFF
--- a/src/app/dashboard/tasks/page.tsx
+++ b/src/app/dashboard/tasks/page.tsx
@@ -1,11 +1,14 @@
 import { getTranslations } from "next-intl/server";
 import { prisma } from "@/lib/prisma";
+import { getEventConfig, daysUntil } from "@/lib/event-config";
 import TasksClient from "./tasks-client";
 
 export const dynamic = "force-dynamic";
 
 export default async function TasksPage() {
   const t = await getTranslations("dashboard.tasks");
+  const cfg = await getEventConfig();
+  const daysToEvent = cfg.eventDate ? daysUntil(cfg.eventDate) : null;
   const [tasks, vendors, venues] = await Promise.all([
     prisma.task.findMany({
       where: { deletedAt: null },
@@ -33,7 +36,7 @@ export default async function TasksPage() {
         <h1 className="text-2xl font-bold tracking-tight text-white">{t("page.title")}</h1>
         <p className="text-sm text-zinc-500">{t("page.subtitle")}</p>
       </div>
-      <TasksClient tasks={tasks} vendors={vendors} venues={venues} />
+      <TasksClient tasks={tasks} vendors={vendors} venues={venues} daysToEvent={daysToEvent} />
     </div>
   );
 }

--- a/src/app/dashboard/tasks/tasks-client.tsx
+++ b/src/app/dashboard/tasks/tasks-client.tsx
@@ -25,6 +25,7 @@ import { useToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Pagination, usePagination } from "@/components/pagination";
 import { formatDateBR, toIsoDate } from "@/lib/format";
+import { EVENT_PHASES, getEventPhase, eventProgress } from "@/lib/event-phases";
 
 type TaskRow = {
   id: string;
@@ -64,10 +65,12 @@ export default function TasksClient({
   tasks,
   vendors,
   venues,
+  daysToEvent,
 }: {
   tasks: TaskRow[];
   vendors: RefRow[];
   venues: RefRow[];
+  daysToEvent: number | null;
 }) {
   const t = useTranslations("dashboard.tasks");
   const tc = useTranslations("common");
@@ -162,6 +165,7 @@ export default function TasksClient({
 
   return (
     <div className="space-y-4">
+      {daysToEvent !== null ? <TaskPhaseBar daysToEvent={daysToEvent} /> : null}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-wrap items-center gap-2">
           <select
@@ -659,5 +663,42 @@ function Field({
         className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
       />
     </div>
+  );
+}
+
+function TaskPhaseBar({ daysToEvent }: { daysToEvent: number }) {
+  const t = useTranslations("dashboard.tasks.phaseBar");
+  const current = getEventPhase(daysToEvent);
+  const progress = Math.round(eventProgress(daysToEvent) * 100);
+  const past = current === "past";
+  return (
+    <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold text-zinc-200">{t("title")}</h2>
+        <span className="text-xs text-zinc-400">
+          {past ? t("past") : t("daysRemaining", { days: daysToEvent })}
+        </span>
+      </div>
+      <div className="mb-2 h-2 w-full overflow-hidden rounded-full bg-zinc-800">
+        <div className="h-full rounded-full bg-rose-500 transition-all" style={{ width: `${progress}%` }} />
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {EVENT_PHASES.map((phase) => {
+          const active = phase === current;
+          return (
+            <span
+              key={phase}
+              className={`rounded-full px-2.5 py-1 text-xs transition-colors ${
+                active
+                  ? "bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/30"
+                  : "bg-zinc-800/60 text-zinc-400"
+              }`}
+            >
+              {t(`phase.${phase}`)}
+            </span>
+          );
+        })}
+      </div>
+    </section>
   );
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,14 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.7.5",
+    date: "2026-06-08",
+    highlights: [
+      "⏳ A tela de **Tarefas** ganhou uma barra de **fase da organização** (12+ meses → semana final) com a contagem regressiva até o casamento, para você saber sempre em que etapa está.",
+      "📊 Em **Insights**: novo cartão de **sobra de caixa até o evento** e **recomendações acionáveis** no health score (próximos passos concretos quando algo precisa de atenção).",
+    ],
+  },
+  {
     version: "0.7.4",
     date: "2026-06-08",
     highlights: [

--- a/src/lib/event-phases.test.ts
+++ b/src/lib/event-phases.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { getEventPhase, eventProgress, EVENT_PHASES } from "./event-phases";
+
+describe("getEventPhase", () => {
+  it("mapeia os dias restantes para a fase correta", () => {
+    expect(getEventPhase(400)).toBe("12m");
+    expect(getEventPhase(181)).toBe("12m");
+    expect(getEventPhase(180)).toBe("6m");
+    expect(getEventPhase(91)).toBe("6m");
+    expect(getEventPhase(90)).toBe("3m");
+    expect(getEventPhase(31)).toBe("3m");
+    expect(getEventPhase(30)).toBe("1m");
+    expect(getEventPhase(8)).toBe("1m");
+    expect(getEventPhase(7)).toBe("1w");
+    expect(getEventPhase(0)).toBe("1w");
+    expect(getEventPhase(-1)).toBe("past");
+  });
+
+  it("todas as fases retornáveis (exceto past) estão em EVENT_PHASES", () => {
+    for (const d of [400, 120, 60, 20, 3]) {
+      expect(EVENT_PHASES).toContain(getEventPhase(d) as (typeof EVENT_PHASES)[number]);
+    }
+  });
+});
+
+describe("eventProgress", () => {
+  it("0 quando longe (>=365), 1 no dia/passado, meio no meio do caminho", () => {
+    expect(eventProgress(365)).toBe(0);
+    expect(eventProgress(0)).toBe(1);
+    expect(eventProgress(-5)).toBe(1);
+    expect(eventProgress(182.5)).toBeCloseTo(0.5, 1);
+  });
+});

--- a/src/lib/event-phases.ts
+++ b/src/lib/event-phases.ts
@@ -1,0 +1,24 @@
+export type EventPhase = "12m" | "6m" | "3m" | "1m" | "1w" | "past";
+
+/** Fases exibidas na barra de organização, da mais distante à véspera. */
+export const EVENT_PHASES = ["12m", "6m", "3m", "1m", "1w"] as const;
+
+/**
+ * Mapeia os dias restantes até o evento para a fase de organização.
+ * Puro (sem I/O) — seguro para usar em client components.
+ */
+export function getEventPhase(daysToEvent: number): EventPhase {
+  if (daysToEvent < 0) return "past";
+  if (daysToEvent <= 7) return "1w";
+  if (daysToEvent <= 30) return "1m";
+  if (daysToEvent <= 90) return "3m";
+  if (daysToEvent <= 180) return "6m";
+  return "12m";
+}
+
+/** Progresso 0..1 ao longo da jornada de ~12 meses até o evento. */
+export function eventProgress(daysToEvent: number): number {
+  if (daysToEvent <= 0) return 1;
+  if (daysToEvent >= 365) return 0;
+  return (365 - daysToEvent) / 365;
+}

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -375,7 +375,10 @@ export const HELP_ARTICLES: HelpArticle[] = [
       { title: "Em /dashboard/tasks, clique em 'Importar templates'", body: "O sistema cria tarefas com deadlines relativos ao seu evento." },
       { title: "Responsáveis sugeridos", body: "Cada tarefa vem com um responsável-padrão (noivo, noiva, ambos, cerimonial). Edite se quiser." },
     ],
-    tips: ["Importar é **idempotente** — rodar de novo não duplica tarefas já criadas."],
+    tips: [
+      "Importar é **idempotente** — rodar de novo não duplica tarefas já criadas.",
+      "No topo da tela de Tarefas, uma barra mostra a **fase da organização** (12+ meses → semana final) e os dias restantes, calculados pela data do evento.",
+    ],
   },
 
   // ============ guests ============

--- a/src/messages/en/dashboard.json
+++ b/src/messages/en/dashboard.json
@@ -1511,6 +1511,18 @@
       "title": "Tasks",
       "subtitle": "Use the ready-made 12-month template or create standalone tasks. Exports to your calendar."
     },
+    "phaseBar": {
+      "title": "Planning phase",
+      "daysRemaining": "{days} day(s) to the event",
+      "past": "The event has passed",
+      "phase": {
+        "12m": "12+ months",
+        "6m": "6 months",
+        "3m": "3 months",
+        "1m": "1 month",
+        "1w": "Final week"
+      }
+    },
     "toast": {
       "created": "Task created",
       "updated": "Task updated",

--- a/src/messages/es/dashboard.json
+++ b/src/messages/es/dashboard.json
@@ -1511,6 +1511,18 @@
       "title": "Tareas",
       "subtitle": "Usa la plantilla lista de 12 meses o crea tareas sueltas. Se exporta al calendario."
     },
+    "phaseBar": {
+      "title": "Fase de organización",
+      "daysRemaining": "{days} día(s) hasta el evento",
+      "past": "El evento ya pasó",
+      "phase": {
+        "12m": "12+ meses",
+        "6m": "6 meses",
+        "3m": "3 meses",
+        "1m": "1 mes",
+        "1w": "Última semana"
+      }
+    },
     "toast": {
       "created": "Tarea creada",
       "updated": "Tarea actualizada",

--- a/src/messages/pt-BR/dashboard.json
+++ b/src/messages/pt-BR/dashboard.json
@@ -1511,6 +1511,18 @@
       "title": "Tarefas",
       "subtitle": "Use o template pronto de 12 meses ou crie tarefas avulsas. Exporta para o calendário."
     },
+    "phaseBar": {
+      "title": "Fase da organização",
+      "daysRemaining": "{days} dia(s) até o evento",
+      "past": "O evento já passou",
+      "phase": {
+        "12m": "12+ meses",
+        "6m": "6 meses",
+        "3m": "3 meses",
+        "1m": "1 mês",
+        "1w": "Semana final"
+      }
+    },
     "toast": {
       "created": "Tarefa criada",
       "updated": "Tarefa atualizada",


### PR DESCRIPTION
## Contexto
Item 1.3 da Onda 1. Dá ao casal a noção de **em que etapa do planejamento estão**: uma barra no topo da tela de Tarefas com a fase atual (12+ meses → semana final) e a contagem regressiva até o evento. Sem schema novo.

## O que mudou
- Helper puro [src/lib/event-phases.ts](src/lib/event-phases.ts): `getEventPhase(daysToEvent)`, `eventProgress`, `EVENT_PHASES` — sem I/O (seguro em client), testado.
- [tasks/page.tsx](src/app/dashboard/tasks/page.tsx) passa `daysToEvent` (via `getEventConfig`/`daysUntil`); `eventDate` é nullable → a barra some quando não há data.
- `TaskPhaseBar` em [tasks-client.tsx](src/app/dashboard/tasks/tasks-client.tsx) + i18n nos 3 catálogos (`dashboard.tasks.phaseBar`).
- Ajuda atualizada; changelog 0.7.5 (também documenta os cartões de Insights da #75).

## Verificação
`npm run lint` ✓ · `npm run test:run` ✓ (598) · `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)