### PR TITLE
feat(rsvp): seção de boas-vindas personalizada (Fase B / 1.2)

### DIFF
--- a/src/app/rsvp/[token]/page.tsx
+++ b/src/app/rsvp/[token]/page.tsx
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getEventConfig } from "@/lib/event-config";
 import { formatDate } from "@/i18n/format";
 import { coerceLocale, isLocale } from "@/i18n/config";
+import { RsvpLanding } from "../_components/rsvp-landing";
 import RsvpForm from "./rsvp-form";
 
 export const dynamic = "force-dynamic";
@@ -76,6 +77,7 @@ export default async function PublicRsvpPage({
           ) : null}
           .
         </p>
+        <RsvpLanding cfg={cfg} locale={locale} />
         <RsvpForm guest={guest} labels={labels} />
       </div>
       <p className="mt-6 text-center text-[11px] text-zinc-600">{t("footer")}</p>

--- a/src/app/rsvp/_components/rsvp-landing.tsx
+++ b/src/app/rsvp/_components/rsvp-landing.tsx
@@ -1,0 +1,64 @@
+import { CalendarHeart, CloudRain, Clock, ExternalLink } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { daysUntil, type EventConfig } from "@/lib/event-config";
+import type { Locale } from "@/i18n/config";
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\/\S+$/i.test(value.trim());
+}
+
+/**
+ * Seção de boas-vindas exibida acima do formulário de RSVP (individual e grupo).
+ * Mostra contagem regressiva, programação do dia, plano B (chuva) e link do site —
+ * tudo de `EventConfig`. Server component (sem estado): a contagem é do servidor.
+ */
+export async function RsvpLanding({ cfg, locale }: { cfg: EventConfig; locale: Locale }) {
+  const t = await getTranslations({ locale, namespace: "rsvp.landing" });
+  const days = cfg.eventDate ? daysUntil(cfg.eventDate) : null;
+  const showCountdown = days !== null && days >= 0;
+  const website = cfg.weddingWebsiteUrl && isHttpUrl(cfg.weddingWebsiteUrl) ? cfg.weddingWebsiteUrl : null;
+
+  if (!showCountdown && !cfg.daySchedule && !cfg.rainPlanB && !website) return null;
+
+  return (
+    <div className="mt-5 space-y-3">
+      {showCountdown ? (
+        <div className="flex items-center justify-center gap-2 rounded-2xl border border-rose-500/20 bg-rose-500/5 px-4 py-3 text-rose-200">
+          <CalendarHeart className="h-4 w-4 shrink-0" />
+          <span className="text-sm font-semibold">
+            {days === 0 ? t("today") : t("countdown", { days: days as number })}
+          </span>
+        </div>
+      ) : null}
+
+      {cfg.daySchedule ? (
+        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+          <p className="mb-1 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-zinc-400">
+            <Clock className="h-3.5 w-3.5" /> {t("schedule")}
+          </p>
+          <p className="whitespace-pre-line text-sm text-zinc-200">{cfg.daySchedule}</p>
+        </div>
+      ) : null}
+
+      {cfg.rainPlanB ? (
+        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+          <p className="mb-1 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-zinc-400">
+            <CloudRain className="h-3.5 w-3.5" /> {t("rainPlan")}
+          </p>
+          <p className="whitespace-pre-line text-sm text-zinc-200">{cfg.rainPlanB}</p>
+        </div>
+      ) : null}
+
+      {website ? (
+        <a
+          href={website}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center gap-2 rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm font-medium text-rose-200 hover:bg-rose-500/20"
+        >
+          <ExternalLink className="h-4 w-4" /> {t("website")}
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/rsvp/group/[token]/page.tsx
+++ b/src/app/rsvp/group/[token]/page.tsx
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { getEventConfig } from "@/lib/event-config";
 import { formatDate } from "@/i18n/format";
 import { coerceLocale, isLocale } from "@/i18n/config";
+import { RsvpLanding } from "../../_components/rsvp-landing";
 import GroupRsvpForm from "./group-rsvp-form";
 
 export const dynamic = "force-dynamic";
@@ -76,6 +77,7 @@ export default async function PublicGroupRsvpPage({
               })
             : t("introWithoutDate")}
         </p>
+        <RsvpLanding cfg={cfg} locale={locale} />
         <GroupRsvpForm group={group} locale={locale} messages={messages} />
       </div>
       <p className="mt-6 text-center text-[11px] text-zinc-600">{tIndividual("footer")}</p>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,13 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.7.6",
+    date: "2026-06-08",
+    highlights: [
+      "💌 A página de **RSVP** (individual e de grupo) ganhou uma seção de boas-vindas: contagem regressiva até o casamento, programação do dia, plano B em caso de chuva e link para o site dos noivos — tudo a partir das configurações do evento.",
+    ],
+  },
+  {
     version: "0.7.5",
     date: "2026-06-08",
     highlights: [

--- a/src/lib/event-config.ts
+++ b/src/lib/event-config.ts
@@ -6,6 +6,8 @@ export type EventConfig = {
   contingencyPercent: number;
   currency: string;
   coupleNames: string | null;
+  daySchedule: string | null;
+  rainPlanB: string | null;
   onboardingCompletedAt: Date | null;
   defaultLocale: Locale;
   pixKey: string | null;
@@ -40,6 +42,8 @@ export async function getEventConfig(): Promise<EventConfig> {
     contingencyPercent: settings.contingencyPercent,
     currency: settings.currency,
     coupleNames: settings.coupleNames,
+    daySchedule: settings.daySchedule,
+    rainPlanB: settings.rainPlanB,
     onboardingCompletedAt: settings.onboardingCompletedAt,
     defaultLocale: coerceLocale(settings.defaultLocale),
     pixKey: settings.pixKey,
@@ -76,6 +80,8 @@ export async function updateEventConfig(
       contingencyPercent: input.contingencyPercent ?? undefined,
       currency: input.currency ?? undefined,
       coupleNames: input.coupleNames ?? undefined,
+      daySchedule: input.daySchedule === undefined ? undefined : input.daySchedule,
+      rainPlanB: input.rainPlanB === undefined ? undefined : input.rainPlanB,
       onboardingCompletedAt:
         input.onboardingCompletedAt === undefined ? undefined : input.onboardingCompletedAt,
       defaultLocale: input.defaultLocale ?? undefined,
@@ -113,6 +119,8 @@ export async function updateEventConfig(
     contingencyPercent: updated.contingencyPercent,
     currency: updated.currency,
     coupleNames: updated.coupleNames,
+    daySchedule: updated.daySchedule,
+    rainPlanB: updated.rainPlanB,
     onboardingCompletedAt: updated.onboardingCompletedAt,
     defaultLocale: coerceLocale(updated.defaultLocale),
     pixKey: updated.pixKey,

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -400,12 +400,15 @@ export const HELP_ARTICLES: HelpArticle[] = [
       },
       {
         title: "Convidado abre o link",
-        body: "Vê 'Oi NOME!' + formulário para confirmar (ou não) presença, +1s e restrição alimentar.",
+        body: "Vê uma página de boas-vindas (contagem regressiva, programação do dia, plano B de chuva e link do site, se você preencher) + formulário para confirmar presença, +1s e restrição alimentar.",
       },
       {
         title: "Você acompanha em /dashboard/guests",
         body: "Status (INVITED → CONFIRMED/DECLINED/MAYBE) atualiza em tempo real.",
       },
+    ],
+    tips: [
+      "A seção de boas-vindas usa data, programação e plano B do evento (Ajustes/onboarding). Sem esses campos, ela some graciosamente.",
     ],
     warnings: ["Token vazado? Regenere via Prisma Studio ou abra issue."],
   },

--- a/src/messages/en/rsvp.json
+++ b/src/messages/en/rsvp.json
@@ -43,5 +43,12 @@
       "missingAnswers": "Please reply for all {count} guests."
     },
     "success": "Responses saved for {count} guest(s). Thank you!"
+  },
+  "landing": {
+    "countdown": "{days, plural, one {# day} other {# days}} to go until the big day!",
+    "today": "It's today! 🎉",
+    "schedule": "Schedule",
+    "rainPlan": "Plan B (rain)",
+    "website": "Visit our website"
   }
 }

--- a/src/messages/es/rsvp.json
+++ b/src/messages/es/rsvp.json
@@ -43,5 +43,12 @@
       "missingAnswers": "Responde por todos los {count} invitados."
     },
     "success": "Respuestas guardadas para {count} invitado(s). ¡Gracias!"
+  },
+  "landing": {
+    "countdown": "¡Faltan {days, plural, one {# día} other {# días}} para el gran día!",
+    "today": "¡Es hoy! 🎉",
+    "schedule": "Programa",
+    "rainPlan": "Plan B (lluvia)",
+    "website": "Visita nuestro sitio"
   }
 }

--- a/src/messages/pt-BR/rsvp.json
+++ b/src/messages/pt-BR/rsvp.json
@@ -43,5 +43,12 @@
       "missingAnswers": "Responda por todos os {count} convidados."
     },
     "success": "Respostas registradas para {count} convidado(s). Obrigado!"
+  },
+  "landing": {
+    "countdown": "Faltam {days, plural, one {# dia} other {# dias}} para o grande dia!",
+    "today": "É hoje! 🎉",
+    "schedule": "Programação",
+    "rainPlan": "Plano B (chuva)",
+    "website": "Visite nosso site"
   }
 }


### PR DESCRIPTION
## Contexto
Item 1.2 da Onda 1. Enriquece a página pública de RSVP (individual e de grupo) com uma seção de boas-vindas acima do formulário, criando conexão e dando contexto ao convidado. Sem `db push` (colunas já existem).

## O que mudou
- `event-config` passa a expor `daySchedule` e `rainPlanB` (colunas existentes em `EventSettings`).
- Componente server compartilhado [rsvp-landing.tsx](src/app/rsvp/_components/rsvp-landing.tsx): contagem regressiva até o evento, programação do dia, plano B (chuva) e botão para o site dos noivos. Some graciosamente quando não há dados; valida que a URL é http(s); o texto é escapado pelo React.
- Encaixado em [/rsvp/[token]](src/app/rsvp/[token]/page.tsx) e [/rsvp/group/[token]](src/app/rsvp/group/[token]/page.tsx).
- i18n nos 3 catálogos (`rsvp.landing`) com plural ICU dos dias; ajuda e changelog (0.7.6).

## Verificação
`npm run lint` ✓ · `npm run test:run` ✓ (604) · `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)