### PR TITLE
feat(gifts): lançar presente em dinheiro como receita ou caixa

### DIFF
--- a/docs/modulos.md
+++ b/docs/modulos.md
@@ -142,6 +142,15 @@ comportamentos principais.
 - Tipo: `CASH` ou `ITEM`.
 - Status: `RECEIVED` / `THANKED`.
 - Suporta múltiplos presentes por convidado.
+- **Lançar nas finanças** (presentes `CASH`): converte o valor em `Income`
+  (fonte `GIFT`, status `RECEIVED`) **ou** `Asset` (caixa/reserva), escolhendo
+  descrição e data. A operação é atômica (`$transaction`) e idempotente — grava
+  `Gift.processedAt` via `updateMany ... { processedAt: null }`, fechando a
+  corrida de dupla conversão. Audita `CONVERT_TO_FINANCE`.
+- **Anti dupla contagem:** marcar o Pix como recebido com "Adicionar ao caixa"
+  também grava `processedAt`; uma vez lançado por qualquer caminho, o outro não
+  duplica o valor. Indicadores na lista: **"Em dinheiro a lançar"** (soma dos
+  `CASH` com `processedAt = null`) e selo **"Lançado"**.
 
 ---
 

--- a/docs/pix.md
+++ b/docs/pix.md
@@ -28,7 +28,12 @@ Botão de QR na lista de presentes abre `/dashboard/gifts/{id}/pix`. A página:
 Após o convidado pagar, o casal abre o presente e clica **"Marcar como recebido"** (action `markGiftAsPixReceived`):
 
 - Seta `Gift.pixPaidAt` e `status = RECEIVED`.
-- Opcionalmente cria `Asset` com o valor para entrar no caixa.
+- Opcionalmente cria `Asset` com o valor para entrar no caixa. Quando cria o
+  `Asset`, também grava `Gift.processedAt` (marca "lançado nas finanças"). Se o
+  presente já foi lançado — por aqui ou pela ação **"Lançar nas finanças"**
+  (`convertGiftCashToIncomeOrAsset`, que vira `Income` ou `Asset`) — o `Asset`
+  **não** é recriado, evitando dupla contagem. Nesse caso o painel mostra o
+  aviso em vez da caixa "Adicionar ao caixa".
 
 > Pix estático **não tem callback automático**. O sistema não sabe que o pagamento ocorreu até o casal marcar manualmente. Se quiser baixa automática, seria necessário integrar com MercadoPago ou similar — fora do escopo da v0.3.0.
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -536,6 +536,7 @@ model Gift {
   thankedAt         DateTime?
   isHoneymoonShare  Boolean  @default(false)
   pixPaidAt         DateTime?
+  processedAt       DateTime?
   notes             String?
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt

--- a/src/app/actions/giftActions.test.ts
+++ b/src/app/actions/giftActions.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { prismaMock } from "@/test-utils/prisma";
 import {
+  convertGiftCashToIncomeOrAsset,
   createGift,
   deleteGift,
+  markGiftAsPixReceived,
   markGiftThanked,
   updateGift,
 } from "./giftActions";
@@ -10,6 +12,31 @@ import {
 beforeEach(() => {
   vi.spyOn(console, "error").mockImplementation(() => {});
 });
+
+function setupTransaction() {
+  prismaMock.$transaction.mockImplementation(async (fnOrArr: unknown) => {
+    if (typeof fnOrArr === "function") {
+      return (fnOrArr as (tx: typeof prismaMock) => unknown)(prismaMock);
+    }
+    return [];
+  });
+}
+
+const cashGift = {
+  id: "g1",
+  guestId: null,
+  giverName: "Tia Ana",
+  type: "CASH",
+  amount: 300,
+  description: null,
+  status: "RECEIVED",
+  receivedAt: new Date("2026-01-01T00:00:00.000Z"),
+  thankedAt: null,
+  isHoneymoonShare: false,
+  pixPaidAt: null,
+  processedAt: null,
+  notes: null,
+};
 
 describe("createGift", () => {
   it("salva CASH com amount default 0 quando não informado", async () => {
@@ -83,5 +110,116 @@ describe("deleteGift", () => {
       where: { id: "g1", deletedAt: null },
       data: { deletedAt: expect.any(Date) },
     });
+  });
+});
+
+describe("convertGiftCashToIncomeOrAsset", () => {
+  it("rejeita presente que não é CASH", async () => {
+    prismaMock.gift.findFirst.mockResolvedValue({ ...cashGift, type: "ITEM", amount: null } as never);
+    const r = await convertGiftCashToIncomeOrAsset({ giftId: "g1", recordType: "INCOME", title: "Presente" });
+    expect(r.success).toBe(false);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejeita valor <= 0", async () => {
+    prismaMock.gift.findFirst.mockResolvedValue({ ...cashGift, amount: 0 } as never);
+    const r = await convertGiftCashToIncomeOrAsset({ giftId: "g1", recordType: "INCOME", title: "Presente" });
+    expect(r.success).toBe(false);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejeita presente já lançado (processedAt setado)", async () => {
+    prismaMock.gift.findFirst.mockResolvedValue({ ...cashGift, processedAt: new Date() } as never);
+    const r = await convertGiftCashToIncomeOrAsset({ giftId: "g1", recordType: "ASSET", title: "Presente" });
+    expect(r.success).toBe(false);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejeita título vazio (Zod)", async () => {
+    const r = await convertGiftCashToIncomeOrAsset({ giftId: "g1", recordType: "INCOME", title: "  " });
+    expect(r.success).toBe(false);
+    expect(prismaMock.gift.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("cria Income com fonte GIFT e marca processedAt atomicamente", async () => {
+    prismaMock.gift.findFirst.mockResolvedValue({ ...cashGift } as never);
+    prismaMock.gift.updateMany.mockResolvedValue({ count: 1 } as never);
+    prismaMock.income.create.mockResolvedValue({ id: "inc1" } as never);
+    setupTransaction();
+
+    const r = await convertGiftCashToIncomeOrAsset({
+      giftId: "g1",
+      recordType: "INCOME",
+      title: "Presente da Tia Ana",
+      date: "2026-02-10",
+    });
+
+    expect(r.success).toBe(true);
+    const claim = prismaMock.gift.updateMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    };
+    expect(claim.where).toMatchObject({ id: "g1", deletedAt: null, processedAt: null });
+    expect(claim.data.processedAt).toBeInstanceOf(Date);
+
+    const incomeData = (prismaMock.income.create.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+    expect(incomeData.source).toBe("GIFT");
+    expect(incomeData.status).toBe("RECEIVED");
+    expect(incomeData.amount).toBe(300);
+    expect(incomeData.givenByName).toBe("Tia Ana");
+    expect(incomeData.receivedAt).toBeInstanceOf(Date);
+    expect(prismaMock.asset.create).not.toHaveBeenCalled();
+  });
+
+  it("cria Asset quando recordType=ASSET", async () => {
+    prismaMock.gift.findFirst.mockResolvedValue({ ...cashGift } as never);
+    prismaMock.gift.updateMany.mockResolvedValue({ count: 1 } as never);
+    prismaMock.asset.create.mockResolvedValue({ id: "a1" } as never);
+    setupTransaction();
+
+    const r = await convertGiftCashToIncomeOrAsset({ giftId: "g1", recordType: "ASSET", title: "Caixa" });
+    expect(r.success).toBe(true);
+    const assetData = (prismaMock.asset.create.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+    expect(assetData.amount).toBe(300);
+    expect(assetData.date).toBeInstanceOf(Date);
+    expect(prismaMock.income.create).not.toHaveBeenCalled();
+  });
+
+  it("falha (corrida) quando o claim atômico retorna count 0", async () => {
+    prismaMock.gift.findFirst.mockResolvedValue({ ...cashGift } as never);
+    prismaMock.gift.updateMany.mockResolvedValue({ count: 0 } as never);
+    setupTransaction();
+
+    const r = await convertGiftCashToIncomeOrAsset({ giftId: "g1", recordType: "INCOME", title: "Presente" });
+    expect(r.success).toBe(false);
+    expect(prismaMock.income.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("markGiftAsPixReceived — guarda anti dupla contagem", () => {
+  it("não cria Asset quando o presente já foi lançado, mas seta pixPaidAt", async () => {
+    prismaMock.gift.findFirst.mockResolvedValue({ ...cashGift, processedAt: new Date() } as never);
+    prismaMock.gift.update.mockResolvedValue({} as never);
+    setupTransaction();
+
+    const r = await markGiftAsPixReceived("g1", true);
+    expect(r.success).toBe(true);
+    expect(prismaMock.asset.create).not.toHaveBeenCalled();
+    const updateData = (prismaMock.gift.update.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+    expect(updateData.pixPaidAt).toBeInstanceOf(Date);
+    expect(updateData.processedAt).toBeUndefined();
+  });
+
+  it("cria Asset e seta processedAt quando ainda não processado", async () => {
+    prismaMock.gift.findFirst.mockResolvedValue({ ...cashGift } as never);
+    prismaMock.gift.update.mockResolvedValue({} as never);
+    prismaMock.asset.create.mockResolvedValue({ id: "a1" } as never);
+    setupTransaction();
+
+    const r = await markGiftAsPixReceived("g1", true);
+    expect(r.success).toBe(true);
+    expect(prismaMock.asset.create).toHaveBeenCalledTimes(1);
+    const updateData = (prismaMock.gift.update.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+    expect(updateData.processedAt).toBeInstanceOf(Date);
   });
 });

--- a/src/app/actions/giftActions.ts
+++ b/src/app/actions/giftActions.ts
@@ -162,23 +162,27 @@ export async function markGiftAsPixReceived(
     if (gift.pixPaidAt) return { success: false, error: t("pixAlreadyReceived") };
 
     const now = new Date();
+    // Só cria o Asset (e marca como lançado nas finanças) se ainda não houver
+    // sido processado por aqui ou pela conversão dedicada — evita dupla contagem.
+    const willCreateAsset = alsoCreateAsset && !!gift.amount && gift.amount > 0 && !gift.processedAt;
     await prisma.$transaction(async (tx: TxClient) => {
       await tx.gift.update({
         where: { id: giftId },
         data: {
           pixPaidAt: now,
           status: "RECEIVED",
+          ...(willCreateAsset ? { processedAt: now } : {}),
         },
       });
 
-      if (alsoCreateAsset && gift.amount && gift.amount > 0) {
+      if (willCreateAsset) {
         await tx.asset.create({
           data: {
             title: t("assetTitle", {
               giver: gift.giverName ?? t("assetGuestFallback"),
               honeymoon: gift.isHoneymoonShare ? t("assetHoneymoonSuffix") : "",
             }),
-            amount: gift.amount,
+            amount: gift.amount!,
             date: now,
             notes: t("assetNotes", { id: gift.id }),
           },
@@ -188,14 +192,98 @@ export async function markGiftAsPixReceived(
 
     await audit("Gift", giftId, "MARK_PIX_RECEIVED", {
       amount: gift.amount,
-      alsoCreateAsset,
+      alsoCreateAsset: willCreateAsset,
     });
 
     revalidatePath("/dashboard/gifts");
-    if (alsoCreateAsset) revalidatePath("/dashboard/assets");
+    if (willCreateAsset) revalidatePath("/dashboard/assets");
     return { success: true };
   } catch (err) {
     console.error("[markGiftAsPixReceived]", err);
     return { success: false, error: t("errorMarkingPix") };
+  }
+}
+
+const GiftConvertSchema = z.object({
+  giftId: z.string().min(1).max(64),
+  recordType: z.enum(["INCOME", "ASSET"]),
+  title: z.string().trim().min(1).max(120),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
+
+export type GiftConvertInput = z.input<typeof GiftConvertSchema>;
+
+/**
+ * Converte um presente em dinheiro (CASH) num lançamento financeiro: Receita
+ * (`Income`, fonte GIFT) ou Caixa (`Asset`). Idempotente por `processedAt` —
+ * a marcação é atômica dentro da transação (`updateMany` com `processedAt: null`)
+ * para fechar a corrida de dupla conversão. Não toca em `pixPaidAt`.
+ */
+export async function convertGiftCashToIncomeOrAsset(input: GiftConvertInput): Promise<ActionResult> {
+  const t = await getTranslations("actions.gift");
+  const denied = await denyIfNoFinance();
+  if (denied) return denied;
+  const parsed = GiftConvertSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: zodErrorMessage(parsed.error, await getTranslations("common")) };
+  }
+  try {
+    const gift = await prisma.gift.findFirst({
+      where: { id: parsed.data.giftId, deletedAt: null },
+    });
+    if (!gift) return { success: false, error: t("notFound") };
+    if (gift.type !== "CASH") return { success: false, error: t("convertNotCash") };
+    if (!gift.amount || gift.amount <= 0) return { success: false, error: t("convertNoAmount") };
+    if (gift.processedAt) return { success: false, error: t("convertAlreadyProcessed") };
+
+    const amount = gift.amount;
+    const when = parsed.data.date ? new Date(`${parsed.data.date}T12:00:00.000Z`) : new Date();
+    const recordType = parsed.data.recordType;
+
+    await prisma.$transaction(async (tx: TxClient) => {
+      const claim = await tx.gift.updateMany({
+        where: { id: gift.id, deletedAt: null, processedAt: null },
+        data: { processedAt: new Date() },
+      });
+      if (claim.count === 0) throw new Error("ALREADY_PROCESSED");
+
+      if (recordType === "INCOME") {
+        await tx.income.create({
+          data: {
+            title: parsed.data.title,
+            source: "GIFT",
+            amount,
+            status: "RECEIVED",
+            receivedAt: when,
+            givenByName: gift.giverName,
+            notes: t("convertNotes", { id: gift.id }),
+          },
+        });
+      } else {
+        await tx.asset.create({
+          data: {
+            title: parsed.data.title,
+            amount,
+            date: when,
+            notes: t("convertNotes", { id: gift.id }),
+          },
+        });
+      }
+    });
+
+    await audit("Gift", gift.id, "CONVERT_TO_FINANCE", { recordType, amount });
+
+    revalidatePath("/dashboard/gifts");
+    revalidatePath(recordType === "INCOME" ? "/dashboard/income" : "/dashboard/assets");
+    return { success: true };
+  } catch (err) {
+    if (err instanceof Error && err.message === "ALREADY_PROCESSED") {
+      return { success: false, error: t("convertAlreadyProcessed") };
+    }
+    console.error("[convertGiftCashToIncomeOrAsset]", err);
+    return { success: false, error: t("convertError") };
   }
 }

--- a/src/app/dashboard/gifts/[id]/pix/page.tsx
+++ b/src/app/dashboard/gifts/[id]/pix/page.tsx
@@ -76,6 +76,7 @@ export default async function GiftPixPage({
         giverName={gift.giverName}
         formattedAmount={amount ? formatCurrency(amount, cfg.currency) : null}
         pixPaidAt={gift.pixPaidAt}
+        processedAt={gift.processedAt}
         brCode={brCode}
         qrDataUrl={qrDataUrl}
         missingFields={missingFields}

--- a/src/app/dashboard/gifts/[id]/pix/pix-panel.tsx
+++ b/src/app/dashboard/gifts/[id]/pix/pix-panel.tsx
@@ -14,6 +14,7 @@ export default function PixPanel({
   giverName,
   formattedAmount,
   pixPaidAt,
+  processedAt,
   brCode,
   qrDataUrl,
   missingFields,
@@ -23,6 +24,7 @@ export default function PixPanel({
   giverName: string | null;
   formattedAmount: string | null;
   pixPaidAt: Date | null;
+  processedAt: Date | null;
   brCode: string | null;
   qrDataUrl: string | null;
   missingFields: string[];
@@ -32,7 +34,7 @@ export default function PixPanel({
   const router = useRouter();
   const toast = useToast();
   const [busy, setBusy] = useState(false);
-  const [createAsset, setCreateAsset] = useState(true);
+  const [createAsset, setCreateAsset] = useState(!processedAt);
   const [, startTransition] = useTransition();
 
   function copy() {
@@ -141,15 +143,19 @@ export default function PixPanel({
           <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
             <h2 className="mb-2 text-sm font-semibold text-zinc-100">{t("pix.confirm.title")}</h2>
             <p className="mb-3 text-xs text-zinc-400">{t("pix.confirm.hint")}</p>
-            <label className="mb-3 flex items-center gap-2 text-xs text-zinc-300">
-              <input
-                type="checkbox"
-                checked={createAsset}
-                onChange={(e) => setCreateAsset(e.target.checked)}
-                className="h-4 w-4 rounded border-zinc-700 bg-zinc-800"
-              />
-              {t("pix.confirm.addToAsset")}
-            </label>
+            {processedAt ? (
+              <p className="mb-3 text-xs text-sky-300">{t("pix.confirm.alreadyProcessed")}</p>
+            ) : (
+              <label className="mb-3 flex items-center gap-2 text-xs text-zinc-300">
+                <input
+                  type="checkbox"
+                  checked={createAsset}
+                  onChange={(e) => setCreateAsset(e.target.checked)}
+                  className="h-4 w-4 rounded border-zinc-700 bg-zinc-800"
+                />
+                {t("pix.confirm.addToAsset")}
+              </label>
+            )}
             <button
               type="button"
               onClick={handleMarkReceived}

--- a/src/app/dashboard/gifts/gifts-client.tsx
+++ b/src/app/dashboard/gifts/gifts-client.tsx
@@ -3,8 +3,9 @@
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { CheckCircle2, Gift as GiftIcon, Heart, Loader2, Pencil, Plus, QrCode, Trash2 } from "lucide-react";
+import { CheckCircle2, Gift as GiftIcon, Heart, Landmark, Loader2, Pencil, Plus, QrCode, Trash2 } from "lucide-react";
 import {
+  convertGiftCashToIncomeOrAsset,
   createGift,
   deleteGift,
   markGiftThanked,
@@ -27,6 +28,7 @@ type GiftRow = {
   thankedAt: Date | null;
   isHoneymoonShare: boolean;
   pixPaidAt: Date | null;
+  processedAt: Date | null;
   notes: string | null;
   guest: { id: string; name: string } | null;
 };
@@ -40,6 +42,8 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<GiftRow | null>(null);
   const [deleting, setDeleting] = useState<GiftRow | null>(null);
+  const [converting, setConverting] = useState<GiftRow | null>(null);
+  const [convertBusy, setConvertBusy] = useState(false);
   const [filter, setFilter] = useState<"ALL" | "PENDING_THANK">("ALL");
   const [busy, setBusy] = useState(false);
   const [updatingBusy, setUpdatingBusy] = useState(false);
@@ -53,10 +57,14 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
   const { pageItems, page, totalPages, total, from, to, setPage } = usePagination(filtered, 20);
 
   const totals = useMemo(() => {
-    const cash = gifts.filter((g) => g.type === "CASH").reduce((s, g) => s + (g.amount ?? 0), 0);
+    const cashGifts = gifts.filter((g) => g.type === "CASH");
+    const cash = cashGifts.reduce((s, g) => s + (g.amount ?? 0), 0);
+    const cashPending = cashGifts
+      .filter((g) => !g.processedAt && (g.amount ?? 0) > 0)
+      .reduce((s, g) => s + (g.amount ?? 0), 0);
     const items = gifts.filter((g) => g.type === "ITEM").length;
     const pending = gifts.filter((g) => g.status !== "THANKED").length;
-    return { cash, items, pending };
+    return { cash, cashPending, items, pending };
   }, [gifts]);
 
   function handleCreate(formData: FormData) {
@@ -105,11 +113,26 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
       } else toast.error(t("toast.failed"), r.error);
     });
   }
+  function handleConvert(input: { giftId: string; recordType: "INCOME" | "ASSET"; title: string; date: string }) {
+    setConvertBusy(true);
+    startTransition(async () => {
+      try {
+        const r = await convertGiftCashToIncomeOrAsset(input);
+        if (r.success) {
+          toast.success(t("toast.converted"));
+          setConverting(null);
+        } else toast.error(t("toast.failed"), r.error);
+      } finally {
+        setConvertBusy(false);
+      }
+    });
+  }
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard label={t("stats.cashTotal")} value={formatCurrency(totals.cash)} accent="emerald" />
+        <StatCard label={t("stats.cashPending")} value={formatCurrency(totals.cashPending)} accent="amber" />
         <StatCard label={t("stats.itemsReceived")} value={String(totals.items)} />
         <StatCard label={t("stats.pendingThank")} value={String(totals.pending)} accent="amber" />
       </div>
@@ -180,10 +203,26 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
                           {t("badge.pixReceived")}
                         </span>
                       ) : null}
+                      {g.processedAt ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-sky-500/10 px-1.5 py-0.5 text-[10px] text-sky-300">
+                          <Landmark className="h-2.5 w-2.5" /> {t("badge.processed")}
+                        </span>
+                      ) : null}
                     </div>
                   </div>
                 ) : null}
                 <div className="flex items-center gap-1">
+                  {g.type === "CASH" && (g.amount ?? 0) > 0 && !g.processedAt ? (
+                    <button
+                      type="button"
+                      onClick={() => setConverting(g)}
+                      aria-label={t("actions.convert")}
+                      title={t("actions.convert")}
+                      className="rounded-lg p-1.5 text-zinc-400 hover:bg-sky-500/10 hover:text-sky-300"
+                    >
+                      <Landmark className="h-4 w-4" />
+                    </button>
+                  ) : null}
                   {g.type === "CASH" ? (
                     <Link
                       href={`/dashboard/gifts/${g.id}/pix`}
@@ -253,6 +292,15 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
         />
       )}
 
+      {converting ? (
+        <ConvertModal
+          gift={converting}
+          isBusy={convertBusy}
+          onClose={() => setConverting(null)}
+          onConvert={handleConvert}
+        />
+      ) : null}
+
       <ConfirmDialog
         open={!!deleting}
         title={t("delete.title")}
@@ -262,6 +310,91 @@ export default function GiftsClient({ gifts, guests }: { gifts: GiftRow[]; guest
         onConfirm={handleDelete}
         onCancel={() => setDeleting(null)}
       />
+    </div>
+  );
+}
+
+function ConvertModal({
+  gift,
+  isBusy,
+  onClose,
+  onConvert,
+}: {
+  gift: GiftRow;
+  isBusy: boolean;
+  onClose: () => void;
+  onConvert: (input: { giftId: string; recordType: "INCOME" | "ASSET"; title: string; date: string }) => void;
+}) {
+  const t = useTranslations("dashboard.gifts");
+  const tc = useTranslations("common");
+  const giver = gift.guest?.name ?? gift.giverName ?? t("convert.guestFallback");
+  const [recordType, setRecordType] = useState<"INCOME" | "ASSET">("INCOME");
+  const [title, setTitle] = useState(t("convert.defaultTitle", { giver }));
+  const [date, setDate] = useState(toIsoDate(new Date(gift.receivedAt)));
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    onConvert({ giftId: gift.id, recordType, title: title.trim(), date });
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 bg-black/60 backdrop-blur-sm sm:items-center">
+      <div className="my-4 w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
+        <h2 className="text-lg font-semibold text-white">{t("convert.title")}</h2>
+        <p className="mt-1 text-xs text-zinc-400">{t("convert.intro")}</p>
+        <form onSubmit={submit} className="mt-4 space-y-3">
+          <div className="flex items-center justify-between rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2">
+            <span className="text-xs uppercase tracking-wide text-zinc-500">{t("convert.amountLabel")}</span>
+            <span className="text-base font-semibold text-emerald-300">{formatCurrency(gift.amount ?? 0)}</span>
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("convert.recordType")}</label>
+            <select
+              value={recordType}
+              onChange={(e) => setRecordType(e.target.value as "INCOME" | "ASSET")}
+              className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none"
+            >
+              <option value="INCOME">{t("convert.asIncome")}</option>
+              <option value="ASSET">{t("convert.asAsset")}</option>
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("convert.titleField")}</label>
+            <input
+              type="text"
+              value={title}
+              maxLength={120}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-zinc-400">{t("convert.dateField")}</label>
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="w-full rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200 outline-none focus:border-rose-500/50"
+            />
+          </div>
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-xl bg-zinc-800 py-2 text-sm font-medium text-white hover:bg-zinc-700"
+            >
+              {tc("actions.cancel")}
+            </button>
+            <button
+              type="submit"
+              disabled={isBusy || title.trim().length === 0}
+              className="flex flex-1 items-center justify-center rounded-xl bg-rose-600 py-2 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
+            >
+              {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : t("convert.submit")}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -22,6 +22,7 @@ export type AuditAction =
   | "REORDER"
   | "RSVP_GROUP_RESPOND"
   | "MARK_PIX_RECEIVED"
+  | "CONVERT_TO_FINANCE"
   | "BACKUP_EXPORT"
   | "BACKUP_RESTORE"
   | "UPLOAD"

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,14 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.7.7",
+    date: "2026-06-08",
+    highlights: [
+      "🎁 **Presentes em dinheiro** agora podem ser **lançados nas finanças** com um clique: vire **Receita** (entrada) ou **Caixa/reserva**, escolhendo descrição e data. O presente fica marcado como *lançado* para não ser contado duas vezes.",
+      "💡 Na lista de presentes, novo indicador **'Em dinheiro a lançar'** mostra quanto ainda não virou Receita/Caixa, e um selo **'Lançado'** identifica os já contabilizados.",
+    ],
+  },
+  {
     version: "0.7.6",
     date: "2026-06-08",
     highlights: [

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -441,6 +441,19 @@ export const HELP_ARTICLES: HelpArticle[] = [
       { title: "Marque 'Agradecido'", body: "Quando enviar a nota de agradecimento, atualize `thankedAt`." },
     ],
   },
+  {
+    id: "gift-convert-finance",
+    title: "Lançar presente em dinheiro nas finanças",
+    category: "gifts",
+    keywords: ["presente", "dinheiro", "receita", "caixa", "asset", "income", "lançar", "finanças"],
+    icon: Gift,
+    summary: "Transforme um presente em dinheiro numa Receita ou no Caixa, sem contar duas vezes.",
+    steps: [
+      { title: "Use o botão 'Lançar nas finanças'", body: "No card do presente em dinheiro (ícone de banco), abra o lançamento." },
+      { title: "Escolha o destino", body: "Receita (entrada) — fonte 'Presente em dinheiro' — ou Caixa/reserva (Asset). Ajuste descrição e data." },
+      { title: "Lançado uma única vez", body: "O presente recebe o selo 'Lançado' e some da lista 'Em dinheiro a lançar'. Marcar o Pix com 'Adicionar ao caixa' também conta como lançado — o sistema não duplica." },
+    ],
+  },
 
   // ============ honeymoon-trousseau ============
   {

--- a/src/messages/en/actions.json
+++ b/src/messages/en/actions.json
@@ -58,7 +58,12 @@
     "assetTitle": "Pix from {giver}{honeymoon}",
     "assetGuestFallback": "guest",
     "assetHoneymoonSuffix": " (honeymoon contribution)",
-    "assetNotes": "Generated from gift #{id}"
+    "assetNotes": "Generated from gift #{id}",
+    "convertNotCash": "Only cash gifts can be posted to finances",
+    "convertNoAmount": "Set an amount greater than zero on the gift before posting",
+    "convertAlreadyProcessed": "This gift has already been posted to finances",
+    "convertNotes": "Posted from gift #{id}",
+    "convertError": "Error posting gift to finances"
   },
   "goal": {
     "notFound": "Goal not found",

--- a/src/messages/en/dashboard.json
+++ b/src/messages/en/dashboard.json
@@ -44,6 +44,7 @@
     },
     "stats": {
       "cashTotal": "Total in cash",
+      "cashPending": "Cash to post",
       "itemsReceived": "Items received",
       "pendingThank": "Awaiting thank-you"
     },
@@ -62,11 +63,13 @@
     "badge": {
       "thanked": "Thanked",
       "honeymoon": "honeymoon",
-      "pixReceived": "Pix received"
+      "pixReceived": "Pix received",
+      "processed": "Posted"
     },
     "actions": {
       "new": "New gift",
       "generatePix": "Generate Pix QR",
+      "convert": "Post to finances",
       "toggleThank": "Toggle thank-you",
       "markThanked": "Mark as thanked",
       "unmarkThanked": "Unmark thanked"
@@ -92,7 +95,21 @@
       "removed": "Gift removed",
       "thanked": "Marked as thanked",
       "unthanked": "Unmarked",
+      "converted": "Gift posted to finances",
       "failed": "Failed"
+    },
+    "convert": {
+      "title": "Post gift to finances",
+      "intro": "Record this amount as Income or in your Cash balance. The gift is marked as posted to avoid double-counting.",
+      "recordType": "Post as",
+      "asIncome": "Income (inflow)",
+      "asAsset": "Cash / reserve",
+      "titleField": "Entry description",
+      "dateField": "Date",
+      "amountLabel": "Amount",
+      "submit": "Post",
+      "defaultTitle": "Gift from {giver}",
+      "guestFallback": "guest"
     },
     "pix": {
       "back": "Back",
@@ -127,6 +144,7 @@
         "title": "Confirm receipt",
         "hint": "After verifying the payment in your account, mark it as received.",
         "addToAsset": "Add amount to cash (Asset)",
+        "alreadyProcessed": "This gift was already posted to finances — it won't be duplicated.",
         "saving": "Saving...",
         "markReceived": "Mark as received"
       },

--- a/src/messages/es/actions.json
+++ b/src/messages/es/actions.json
@@ -58,7 +58,12 @@
     "assetTitle": "Pix de {giver}{honeymoon}",
     "assetGuestFallback": "invitado",
     "assetHoneymoonSuffix": " (aporte luna de miel)",
-    "assetNotes": "Generado a partir del regalo #{id}"
+    "assetNotes": "Generado a partir del regalo #{id}",
+    "convertNotCash": "Solo los regalos en efectivo pueden registrarse en finanzas",
+    "convertNoAmount": "Indica un importe mayor que cero en el regalo antes de registrarlo",
+    "convertAlreadyProcessed": "Este regalo ya fue registrado en finanzas",
+    "convertNotes": "Registrado a partir del regalo #{id}",
+    "convertError": "Error al registrar el regalo en finanzas"
   },
   "goal": {
     "notFound": "Meta no encontrada",

--- a/src/messages/es/dashboard.json
+++ b/src/messages/es/dashboard.json
@@ -44,6 +44,7 @@
     },
     "stats": {
       "cashTotal": "Total en dinero",
+      "cashPending": "En dinero por registrar",
       "itemsReceived": "Artículos recibidos",
       "pendingThank": "Pendiente de agradecer"
     },
@@ -62,11 +63,13 @@
     "badge": {
       "thanked": "Agradecido",
       "honeymoon": "luna de miel",
-      "pixReceived": "Pix recibido"
+      "pixReceived": "Pix recibido",
+      "processed": "Registrado"
     },
     "actions": {
       "new": "Nuevo regalo",
       "generatePix": "Generar QR Pix",
+      "convert": "Registrar en finanzas",
       "toggleThank": "Alternar agradecimiento",
       "markThanked": "Marcar como agradecido",
       "unmarkThanked": "Desmarcar agradecido"
@@ -92,7 +95,21 @@
       "removed": "Regalo eliminado",
       "thanked": "Marcado como agradecido",
       "unthanked": "Desmarcado",
+      "converted": "Regalo registrado en finanzas",
       "failed": "Error"
+    },
+    "convert": {
+      "title": "Registrar regalo en finanzas",
+      "intro": "Registra este importe como Ingreso o en tu Caja. El regalo queda marcado como registrado para evitar contarlo dos veces.",
+      "recordType": "Registrar como",
+      "asIncome": "Ingreso (entrada)",
+      "asAsset": "Caja / reserva",
+      "titleField": "Descripción del registro",
+      "dateField": "Fecha",
+      "amountLabel": "Importe",
+      "submit": "Registrar",
+      "defaultTitle": "Regalo de {giver}",
+      "guestFallback": "invitado"
     },
     "pix": {
       "back": "Volver",
@@ -127,6 +144,7 @@
         "title": "Confirmar recepción",
         "hint": "Después de verificar el pago en tu cuenta, márcalo como recibido.",
         "addToAsset": "Agregar importe a caja (Asset)",
+        "alreadyProcessed": "Este regalo ya fue registrado en finanzas — no se duplicará.",
         "saving": "Guardando...",
         "markReceived": "Marcar como recibido"
       },

--- a/src/messages/pt-BR/actions.json
+++ b/src/messages/pt-BR/actions.json
@@ -58,7 +58,12 @@
     "assetTitle": "Pix de {giver}{honeymoon}",
     "assetGuestFallback": "convidado",
     "assetHoneymoonSuffix": " (cota lua de mel)",
-    "assetNotes": "Gerado a partir do presente #{id}"
+    "assetNotes": "Gerado a partir do presente #{id}",
+    "convertNotCash": "Apenas presentes em dinheiro podem ser lançados nas finanças",
+    "convertNoAmount": "Informe um valor maior que zero no presente antes de lançar",
+    "convertAlreadyProcessed": "Este presente já foi lançado nas finanças",
+    "convertNotes": "Lançado a partir do presente #{id}",
+    "convertError": "Erro ao lançar presente nas finanças"
   },
   "goal": {
     "notFound": "Meta não encontrada",

--- a/src/messages/pt-BR/dashboard.json
+++ b/src/messages/pt-BR/dashboard.json
@@ -44,6 +44,7 @@
     },
     "stats": {
       "cashTotal": "Total em dinheiro",
+      "cashPending": "Em dinheiro a lançar",
       "itemsReceived": "Itens recebidos",
       "pendingThank": "Aguardando agradecer"
     },
@@ -62,11 +63,13 @@
     "badge": {
       "thanked": "Agradecido",
       "honeymoon": "lua de mel",
-      "pixReceived": "Pix recebido"
+      "pixReceived": "Pix recebido",
+      "processed": "Lançado"
     },
     "actions": {
       "new": "Novo presente",
       "generatePix": "Gerar QR Pix",
+      "convert": "Lançar nas finanças",
       "toggleThank": "Alternar agradecimento",
       "markThanked": "Marcar como agradecido",
       "unmarkThanked": "Desmarcar agradecido"
@@ -92,7 +95,21 @@
       "removed": "Presente removido",
       "thanked": "Marcado como agradecido",
       "unthanked": "Desmarcado",
+      "converted": "Presente lançado nas finanças",
       "failed": "Falha"
+    },
+    "convert": {
+      "title": "Lançar presente nas finanças",
+      "intro": "Registre este valor como Receita ou no Caixa. O presente fica marcado como lançado, evitando recontagem.",
+      "recordType": "Lançar como",
+      "asIncome": "Receita (entrada)",
+      "asAsset": "Caixa / reserva",
+      "titleField": "Descrição do lançamento",
+      "dateField": "Data",
+      "amountLabel": "Valor",
+      "submit": "Lançar",
+      "defaultTitle": "Presente de {giver}",
+      "guestFallback": "convidado"
     },
     "pix": {
       "back": "Voltar",
@@ -127,6 +144,7 @@
         "title": "Confirmar recebimento",
         "hint": "Após verificar o pagamento na sua conta, marque como recebido.",
         "addToAsset": "Adicionar valor ao caixa (Asset)",
+        "alreadyProcessed": "Este presente já foi lançado nas finanças — não será duplicado.",
         "saving": "Salvando...",
         "markReceived": "Marcar como recebido"
       },


### PR DESCRIPTION
## Resumo

Item **1.5** do roadmap (Onda 1): **Presente CASH → Receita/Asset em 1 clique**.

Permite transformar um presente em dinheiro num lançamento financeiro de verdade, sem recontagem:

- Nova ação `convertGiftCashToIncomeOrAsset({ giftId, recordType, title, date })`:
  - `INCOME` → cria `Income` (fonte `GIFT`, status `RECEIVED`, `givenByName` do doador).
  - `ASSET` → cria `Asset` (caixa/reserva).
  - Guarda contra reconversão: marca `Gift.processedAt` **atomicamente** dentro da `$transaction` (`updateMany` com `processedAt: null` + checagem de `count`), fechando a corrida de dupla conversão.
  - Audita `CONVERT_TO_FINANCE`.
- **Anti dupla contagem entre os dois fluxos:** `markGiftAsPixReceived` agora grava `processedAt` ao criar o `Asset` e pula a criação se o presente já foi lançado (pelo convert ou por um Pix anterior). O painel de Pix exibe aviso no lugar da opção "Adicionar ao caixa" quando já lançado.

## UI
- Botão **"Lançar nas finanças"** (ícone de banco) no card do presente em dinheiro ainda não lançado.
- Selo **"Lançado"** nos já contabilizados.
- Novo indicador de stats **"Em dinheiro a lançar"** (soma dos `CASH` com `processedAt = null`).
- Modal com escolha Receita/Caixa, descrição (pré-preenchida com o doador) e data.

## Schema
- `Gift.processedAt DateTime?` (aditivo) — aplicado via `prisma db push`.

## i18n
- `actions.gift.convert*` e `dashboard.gifts.{convert,stats.cashPending,badge.processed,actions.convert,toast.converted,pix.confirm.alreadyProcessed}` nos **3 catálogos** (pt-BR/en/es). Paridade de chaves verificada.

## Testes
- 8 novos testes em `giftActions.test.ts` (rejeições, criação de Income/Asset, claim atômico, corrida com `count 0`, e o guard de `markGiftAsPixReceived`). Suíte: **613 passando**.

## Docs
- `docs/modulos.md`, `docs/pix.md`, central de ajuda (`help-content.ts`) e changelog `0.7.7`.

## Verificação
- ✅ `npm run lint`
- ✅ `npm run build`
- ✅ `npm run test:run` (613)

🤖 Generated with [Claude Code](https://claude.com/claude-code)