### PR TITLE
feat(insights): assistente de IA (Gemini) com narrativa financeira opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,3 +95,29 @@ WHATSAPP_AUTOSTART="true"
 # Intervalo (ms) entre cada mensagem da fila de Save the Date.
 # Throttle anti-bloqueio do WhatsApp. Padrão: 4000 (4s).
 BROADCAST_INTERVAL_MS="4000"
+
+
+# === IA (Google Gemini) — OPCIONAL ===========================
+#
+# Recurso de IA 100% DESLIGADO por padrão. Só liga quando há
+# GEMINI_API_KEY definida E o casal ativa em Ajustes › Casamento.
+# Ao ligar, dados do casamento são enviados ao Google para gerar
+# resumos/sugestões. Sem chave, os botões de IA nem aparecem.
+#
+# Gere uma chave em https://aistudio.google.com/apikey
+# ------------------------------------------------------------
+
+# Chave da API do Google Gemini. Vazia = IA desligada.
+GEMINI_API_KEY=""
+
+# Modelo usado (padrão: gemini-2.5-flash). Para alto volume,
+# gemini-2.5-flash-lite é mais barato.
+GEMINI_MODEL="gemini-2.5-flash"
+
+# Timeout por chamada (ms) e teto de tokens de saída.
+GEMINI_TIMEOUT_MS="20000"
+GEMINI_MAX_OUTPUT_TOKENS="2048"
+
+# Rate limit por usuário+recurso: máx. de chamadas por janela (ms).
+AI_RATE_MAX="20"
+AI_RATE_WINDOW_MS="300000"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ confirmou a presença.
 - 💍 **Painel do Dia D** (cronograma, plano B chuva, contatos críticos, check-in)
 - 🪑 **Mapa de assentos** — arraste convidados confirmados para as mesas e reordene as mesas pela alça; capacidade considera +1s
 - 📊 **Insights** financeiros (health score, heatmap, detector de creep)
+- 🤖 **Assistente de IA** (Google Gemini) — **opcional, desligado por padrão**: resumo em linguagem natural da saúde financeira nos Insights
 - 📨 **Notificações por email + WhatsApp** (Baileys) — no idioma do destinatário, com aviso aos noivos quando um convidado responde o RSVP e painel de diagnóstico de envios (Ajustes › Notificações)
 - 🌐 **Multi-idioma** (pt-BR, inglês, espanhol) — escolhido por usuário e respeitado em emails/WhatsApp/RSVP
 - 🔐 **2FA TOTP**, reset por email/WhatsApp, audit log
@@ -118,6 +119,7 @@ Abra <http://localhost:3005> no navegador.
 | Modelo de dados (Prisma) | [docs/banco-de-dados.md](docs/banco-de-dados.md) |
 | Endpoints da API | [docs/api.md](docs/api.md) |
 | Notificações (email + WhatsApp) | [docs/notificacoes.md](docs/notificacoes.md) |
+| IA (Google Gemini) — opcional, opt-in | [docs/ia.md](docs/ia.md) |
 | Internacionalização (i18n) | [docs/i18n.md](docs/i18n.md) |
 | Segurança e 2FA | [docs/seguranca.md](docs/seguranca.md) |
 | Backup e restauração | [docs/backup-restore.md](docs/backup-restore.md) |
@@ -194,7 +196,9 @@ Para agentes de IA (Claude Code, Gemini Code, Cursor, etc.), leia
 - **Sem cloud obrigatória.** SQLite local. Você decide se hospeda na
   nuvem ou no PC de casa.
 - **Sem telemetria.** Zero "phone home". Zero analytics. O projeto não
-  envia nada para lugar nenhum.
+  envia nada para lugar nenhum — **exceto** se você ativar a IA opcional
+  (Google Gemini), que envia dados do casamento ao provedor **apenas quando
+  ligada**. Desligada por padrão. Veja [docs/ia.md](docs/ia.md).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Se você é um casal querendo apenas usar o sistema, comece pelo
 | Tópico | Documento |
 |---|---|
 | Notificações (email + WhatsApp) | [notificacoes.md](notificacoes.md) |
+| IA (Google Gemini) — opcional, opt-in | [ia.md](ia.md) |
 | Internacionalização (i18n) | [i18n.md](i18n.md) |
 | Segurança e 2FA | [seguranca.md](seguranca.md) |
 | Roles e permissões | [permissoes.md](permissoes.md) |

--- a/docs/ia.md
+++ b/docs/ia.md
@@ -1,0 +1,90 @@
+# IA (Google Gemini)
+
+Camada opcional de IA generativa. **Desligada por padrão** e construída com
+opt-in em dois níveis, revisão humana obrigatória e degradação graciosa.
+
+## Opt-in em dois níveis
+
+A IA só funciona quando **ambos** estão ligados:
+
+1. **Chave de API (servidor)** — variável `GEMINI_API_KEY`. Sem chave,
+   `isAiEnabled()` é `false`, as Server Actions recusam e **a UI nem renderiza
+   os botões de IA**.
+2. **Toggle do casal (banco)** — `EventSettings.aiEnabled`, em
+   **Ajustes › Casamento**. Consentimento explícito de enviar dados à nuvem.
+
+O gate efetivo é `aiFeatureEnabled()` = `isAiEnabled() && EventSettings.aiEnabled`
+([src/lib/ai/aiAccess.ts](../src/lib/ai/aiAccess.ts)).
+
+## Variáveis de ambiente
+
+| Variável | Padrão | Função |
+|---|---|---|
+| `GEMINI_API_KEY` | — | Chave da API. Vazia = IA desligada. |
+| `GEMINI_MODEL` | `gemini-2.5-flash` | Modelo. `gemini-2.5-flash-lite` p/ alto volume. |
+| `GEMINI_TIMEOUT_MS` | `20000` | Timeout por chamada. |
+| `GEMINI_MAX_OUTPUT_TOKENS` | `2048` | Teto de tokens de saída. |
+| `AI_RATE_MAX` | `20` | Máx. de chamadas por janela (por usuário+recurso). |
+| `AI_RATE_WINDOW_MS` | `300000` | Janela do rate limit (5 min). |
+
+> ⚠️ A família `gemini-2.0-*` foi descontinuada (jun/2026). Use `gemini-2.5-*`.
+> Confirme os modelos disponíveis na conta — eles giram rápido.
+
+## Arquitetura
+
+SDK: [`@google/genai`](https://www.npmjs.com/package/@google/genai) (o antigo
+`@google/generative-ai` está depreciado). Camada em
+[src/lib/ai/](../src/lib/ai/):
+
+| Arquivo | Papel |
+|---|---|
+| `config.ts` | `isAiEnabled()`, `getAiConfig()`, `getAiModel()` (lê env). |
+| `client.ts` | `getAiClient()` — singleton do `GoogleGenAI`. |
+| `errors.ts` | `AiResult<T>` discriminado + `AiErrorCode`. |
+| `rate-limit.ts` | `checkAiRateLimit(userId, resource)`. |
+| `generate.ts` | `generateText` / `generateStructured` — **nunca lançam**. |
+| `prompts.ts` | Construtores de prompt (puros; dados do usuário delimitados). |
+| `schemas.ts` | Zod de saída das gerações estruturadas. |
+| `log.ts` | `recordAiGeneration()` → tabela `AiGeneration` (sem PII bruta). |
+| `aiAccess.ts` | `aiFeatureEnabled()` — gate dos dois níveis. |
+
+Todos com `import "server-only"` (exceto tipos/schemas puros). A `GEMINI_API_KEY`
+nunca sai do servidor — a invocação é **exclusivamente via Server Actions**
+([src/app/actions/aiActions.ts](../src/app/actions/aiActions.ts)).
+
+## Invariantes
+
+- **Nunca lança.** A camada devolve `AiResult` (`{ ok: false, code }` em falha);
+  a rota nunca quebra, só vira toast.
+- **Revisão humana.** Actions de IA **não persistem** no domínio — devolvem o
+  texto; o casal revisa (selo "Gerado por IA" + aviso) e só então salva pela
+  action de domínio existente.
+- **Anti prompt-injection.** Prompts montados server-side; dados do usuário
+  entram como bloco delimitado, nunca como instrução.
+- **IA jamais na rota pública `/rsvp/[token]`** (sem auth).
+- **Sem PII em log.** `console.error` só com `resource`; `AiGeneration.outputPreview`
+  truncado e `null` para features com PII.
+
+## Auditoria
+
+Cada geração grava em `AuditLog` (`entity: "AiGeneration"`, `action: "AI_GENERATE"`)
+e na tabela `AiGeneration` (resource, model, status, tokens, preview truncado).
+
+## Features
+
+| Feature | Tela | Tipo |
+|---|---|---|
+| Narrativa de Insights | `/dashboard/insights` | Geração de texto (read-only) |
+
+Próximas ondas (roadmap): redação de mensagens (fornecedor/RSVP/agradecimento),
+geração estruturada (orçamento, lua de mel, enxoval, timeline do dia), extração
+de contrato PDF (multimodal) e chatbot de ajuda (RAG).
+
+## Testar
+
+- **Sem `GEMINI_API_KEY`**: app sobe normal, nenhum botão de IA aparece.
+- **Com chave + `aiEnabled`**: botão em Insights gera a narrativa; erro de
+  rede/timeout vira toast sem quebrar a página.
+- **Unit**: [src/lib/ai/](../src/lib/ai/) com o cliente Gemini mockado
+  (`vi.mock("@google/genai")` resolve via alias `server-only` no
+  [vitest.config.ts](../vitest.config.ts)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@google/genai": "^2.8.0",
         "@libsql/client": "^0.17.3",
         "@prisma/adapter-libsql": "^6.19.3",
         "@prisma/client": "^6.19.3",
@@ -1071,6 +1072,30 @@
       "license": "MIT",
       "dependencies": {
         "@formatjs/fast-memoize": "3.1.5"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.8.0.tgz",
+      "integrity": "sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hapi/boom": {
@@ -4368,6 +4393,12 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "license": "MIT"
@@ -5181,6 +5212,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "dev": true,
@@ -5578,6 +5618,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary": {
       "version": "0.3.0",
       "license": "MIT",
@@ -5684,6 +5733,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-indexof-polyfill": {
       "version": "1.0.2",
@@ -6427,6 +6482,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/effect": {
       "version": "3.21.0",
       "devOptional": true,
@@ -7136,6 +7200,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "devOptional": true,
@@ -7419,6 +7489,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "dev": true,
@@ -7580,6 +7678,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -7750,6 +7874,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/icu-minify": {
@@ -8349,6 +8486,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "dev": true,
@@ -8425,6 +8571,27 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -9657,6 +9824,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "7.0.1",
       "license": "MIT",
@@ -10401,6 +10581,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@google/genai": "^2.8.0",
     "@libsql/client": "^0.17.3",
     "@prisma/adapter-libsql": "^6.19.3",
     "@prisma/client": "^6.19.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,6 +92,7 @@ model EventSettings {
   saveTheDateExcludePadrinhos Boolean @default(false)
   rsvpReminderEnabled    Boolean   @default(false)
   rsvpReminderDays       Int       @default(7)
+  aiEnabled              Boolean   @default(false)
   updatedAt              DateTime  @updatedAt
 }
 
@@ -587,5 +588,22 @@ model AuditLog {
 
   @@index([entity, entityId])
   @@index([createdAt])
+  @@index([userId, createdAt])
+}
+
+// Registro de metadados de cada geração de IA (sem PII bruta).
+// `outputPreview` é truncado e fica null para features que lidam com PII.
+model AiGeneration {
+  id            String   @id @default(cuid())
+  userId        String?
+  resource      String
+  model         String
+  status        String
+  inputTokens   Int?
+  outputTokens  Int?
+  outputPreview String?
+  createdAt     DateTime @default(now())
+
+  @@index([resource, createdAt])
   @@index([userId, createdAt])
 }

--- a/src/app/actions/aiActions.test.ts
+++ b/src/app/actions/aiActions.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/test-utils/prisma";
+
+const aiFeatureEnabledMock = vi.fn();
+const generateTextMock = vi.fn();
+const loadSnapshotMock = vi.fn();
+const recordAiGenerationMock = vi.fn();
+
+vi.mock("@/lib/ai/aiAccess", () => ({ aiFeatureEnabled: () => aiFeatureEnabledMock() }));
+vi.mock("@/lib/ai/generate", () => ({
+  generateText: (...args: unknown[]) => generateTextMock(...args),
+}));
+vi.mock("@/lib/reports/insights-snapshot", () => ({
+  loadInsightsSnapshot: () => loadSnapshotMock(),
+}));
+vi.mock("@/lib/ai/log", () => ({
+  recordAiGeneration: (...args: unknown[]) => recordAiGenerationMock(...args),
+}));
+vi.mock("@/auth", () => ({ auth: vi.fn(async () => ({ user: { id: "u1" } })) }));
+
+import { generateInsightsNarrative } from "./aiActions";
+
+const SNAP = {
+  eventDate: new Date("2026-11-15T00:00:00Z"),
+  contingencyPercent: 10,
+  currency: "BRL",
+  coupleNames: "Ana & Beto",
+  totals: { budget: 100, contracted: 70, paid: 40, cash: 35 },
+  daysToEvent: 120,
+  leftover: 5,
+  cashflow: [],
+  worstMonthlyBalance: -2,
+  health: {
+    score: 72,
+    breakdown: [{ label: "Cobertura", weight: 0.25, rawValue: 0.7, normalized: 0.7 }],
+    alerts: [],
+    recommendations: [],
+  },
+  creep: [],
+  heatmap: [],
+  sCurve: [],
+  burndown: [],
+  waterfall: [],
+};
+
+beforeEach(() => {
+  aiFeatureEnabledMock.mockReset();
+  generateTextMock.mockReset();
+  loadSnapshotMock.mockReset();
+  recordAiGenerationMock.mockReset();
+  recordAiGenerationMock.mockResolvedValue(undefined);
+  prismaMock.auditLog.create.mockResolvedValue({} as never);
+});
+
+describe("generateInsightsNarrative", () => {
+  it("recusa quando a IA está desabilitada (gate)", async () => {
+    aiFeatureEnabledMock.mockResolvedValue(false);
+    const r = await generateInsightsNarrative();
+    expect(r.success).toBe(false);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
+  it("erro quando o evento não tem data", async () => {
+    aiFeatureEnabledMock.mockResolvedValue(true);
+    loadSnapshotMock.mockResolvedValue(null);
+    const r = await generateInsightsNarrative();
+    expect(r.success).toBe(false);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
+  it("retorna a narrativa no sucesso e registra status OK", async () => {
+    aiFeatureEnabledMock.mockResolvedValue(true);
+    loadSnapshotMock.mockResolvedValue(SNAP);
+    generateTextMock.mockResolvedValue({
+      ok: true,
+      data: "Vocês estão no caminho certo.",
+      usage: { inputTokens: 1, outputTokens: 2 },
+    });
+    const r = await generateInsightsNarrative();
+    expect(r).toEqual({ success: true, data: "Vocês estão no caminho certo." });
+    expect(recordAiGenerationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "OK", resource: "insights.narrative" }),
+    );
+  });
+
+  it("mapeia código de erro e registra o status correspondente", async () => {
+    aiFeatureEnabledMock.mockResolvedValue(true);
+    loadSnapshotMock.mockResolvedValue(SNAP);
+    generateTextMock.mockResolvedValue({ ok: false, code: "TIMEOUT" });
+    const r = await generateInsightsNarrative();
+    expect(r.success).toBe(false);
+    expect(recordAiGenerationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "TIMEOUT" }),
+    );
+  });
+});

--- a/src/app/actions/aiActions.ts
+++ b/src/app/actions/aiActions.ts
@@ -1,0 +1,92 @@
+"use server";
+
+import { getLocale, getTranslations } from "next-intl/server";
+import { auth } from "@/auth";
+import { denyIfNoFinance } from "@/lib/finance-access";
+import { formatCurrency } from "@/lib/format";
+import { coerceLocale } from "@/i18n/config";
+import { aiFeatureEnabled } from "@/lib/ai/aiAccess";
+import { getAiModel } from "@/lib/ai/config";
+import { generateText } from "@/lib/ai/generate";
+import { recordAiGeneration } from "@/lib/ai/log";
+import { buildInsightsNarrativePrompt } from "@/lib/ai/prompts";
+import { loadInsightsSnapshot } from "@/lib/reports/insights-snapshot";
+import { audit } from "@/lib/audit";
+import type { ActionResult } from "@/types";
+
+const RESOURCE = "insights.narrative";
+
+/**
+ * Gera uma narrativa em linguagem natural sobre a saúde financeira do casamento,
+ * a partir dos mesmos indicadores da tela de Insights. Read-only: não persiste no
+ * domínio — o casal lê/copia o texto (sempre rotulado como gerado por IA).
+ */
+export async function generateInsightsNarrative(): Promise<ActionResult<string>> {
+  const t = await getTranslations("actions.ai");
+
+  const denied = await denyIfNoFinance();
+  if (denied) return denied;
+
+  if (!(await aiFeatureEnabled())) {
+    return { success: false, error: t("disabled") };
+  }
+
+  const session = await auth();
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) return { success: false, error: t("disabled") };
+
+  const snapshot = await loadInsightsSnapshot();
+  if (!snapshot) return { success: false, error: t("noEventDate") };
+
+  const locale = coerceLocale(await getLocale());
+  const fmt = (v: number) => formatCurrency(v, snapshot.currency, locale);
+
+  const { system, user } = buildInsightsNarrativePrompt({
+    locale,
+    coupleNames: snapshot.coupleNames,
+    daysToEvent: snapshot.daysToEvent,
+    healthScore: snapshot.health.score,
+    money: {
+      budget: fmt(snapshot.totals.budget),
+      contracted: fmt(snapshot.totals.contracted),
+      paid: fmt(snapshot.totals.paid),
+      cash: fmt(snapshot.totals.cash),
+      leftover: fmt(snapshot.leftover),
+      worstMonthlyBalance: fmt(snapshot.worstMonthlyBalance),
+    },
+    breakdown: snapshot.health.breakdown.map((b) => ({ label: b.label, pct: b.normalized })),
+    alerts: snapshot.health.alerts,
+    topCreep: snapshot.creep
+      .filter((c) => c.delta > 0)
+      .slice(0, 5)
+      .map((c) => ({ category: c.category, deltaLabel: fmt(c.delta), pct: c.pct })),
+  });
+
+  const res = await generateText(user, {
+    userId,
+    resource: RESOURCE,
+    locale,
+    system,
+    temperature: 0.4,
+  });
+
+  const model = getAiModel();
+
+  if (!res.ok) {
+    await recordAiGeneration({ userId, resource: RESOURCE, model, status: res.code });
+    await audit("AiGeneration", "singleton", "AI_GENERATE", { resource: RESOURCE, status: res.code });
+    return { success: false, error: t(`errors.${res.code}`) };
+  }
+
+  await recordAiGeneration({
+    userId,
+    resource: RESOURCE,
+    model,
+    status: "OK",
+    usage: res.usage,
+    outputPreview: res.data,
+  });
+  await audit("AiGeneration", "singleton", "AI_GENERATE", { resource: RESOURCE, status: "OK" });
+
+  return { success: true, data: res.data };
+}

--- a/src/app/actions/settingsActions.ts
+++ b/src/app/actions/settingsActions.ts
@@ -27,6 +27,10 @@ const SettingsSchema = z.object({
     z.boolean().default(false),
   ),
   rsvpReminderDays: z.coerce.number().int().min(1).max(90).default(7),
+  aiEnabled: z.preprocess(
+    (v) => v === "on" || v === true || v === "true",
+    z.boolean().default(false),
+  ),
 });
 
 const PixSettingsSchema = z.object({
@@ -60,6 +64,7 @@ export async function updateSettings(
       coupleNames: parsed.data.coupleNames,
       rsvpReminderEnabled: parsed.data.rsvpReminderEnabled,
       rsvpReminderDays: parsed.data.rsvpReminderDays,
+      aiEnabled: parsed.data.aiEnabled,
     });
     await audit("EventSettings", "singleton", "UPDATE", {
       eventDate: parsed.data.eventDate,

--- a/src/app/dashboard/insights/insights-client.tsx
+++ b/src/app/dashboard/insights/insights-client.tsx
@@ -28,6 +28,8 @@ import type { BurndownPoint } from "@/lib/reports/task-burndown";
 import { SCurve } from "@/components/charts/s-curve";
 import { Burndown } from "@/components/charts/burndown";
 import { Waterfall } from "@/components/charts/waterfall";
+import { AiGenerateButton } from "@/components/ai/ai-generate-button";
+import { generateInsightsNarrative } from "@/app/actions/aiActions";
 
 type Props = {
   eventDate: Date;
@@ -43,6 +45,7 @@ type Props = {
   sCurve: PaymentCurvePoint[];
   burndown: BurndownPoint[];
   waterfall: WaterfallBar[];
+  aiEnabled: boolean;
 };
 
 export default function InsightsClient({
@@ -58,11 +61,13 @@ export default function InsightsClient({
   sCurve,
   burndown,
   waterfall,
+  aiEnabled,
 }: Props) {
   const t = useTranslations("dashboard.insights");
   return (
     <div className="space-y-6">
       <HealthCard health={health} />
+      {aiEnabled ? <AiNarrativeCard /> : null}
       <LiquidityCard leftover={leftover} budget={totals.budget} />
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
@@ -109,6 +114,17 @@ export default function InsightsClient({
 
       <HeatmapCard heatmap={heatmap} eventDate={eventDate} daysToEvent={daysToEvent} />
     </div>
+  );
+}
+
+function AiNarrativeCard() {
+  const t = useTranslations("dashboard.insights.ai");
+  return (
+    <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6">
+      <h2 className="text-lg font-semibold text-zinc-100">{t("title")}</h2>
+      <p className="mb-4 mt-1 text-xs text-zinc-500">{t("description")}</p>
+      <AiGenerateButton action={generateInsightsNarrative} namespace="dashboard.insights.ai" />
+    </section>
   );
 }
 

--- a/src/app/dashboard/insights/page.tsx
+++ b/src/app/dashboard/insights/page.tsx
@@ -1,19 +1,8 @@
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
-import { prisma } from "@/lib/prisma";
-import { getEventConfig, daysUntil } from "@/lib/event-config";
-import { resolveCategoryColor, resolveCategoryLabel } from "@/lib/categories";
 import { requireFinanceAccess } from "@/lib/finance-access";
-import {
-  buildCategoryWaterfall,
-  buildMonthlyCashflow,
-  buildPaymentHeatmap,
-  computeCategoryCreep,
-  computeHealthScore,
-  projectLeftoverUntilEvent,
-} from "@/lib/cashflow";
-import { buildPaymentSCurve } from "@/lib/reports/payment-curve";
-import { buildTaskBurndown } from "@/lib/reports/task-burndown";
+import { aiFeatureEnabled } from "@/lib/ai/aiAccess";
+import { loadInsightsSnapshot } from "@/lib/reports/insights-snapshot";
 import InsightsClient from "./insights-client";
 
 export const dynamic = "force-dynamic";
@@ -22,119 +11,10 @@ export default async function InsightsPage() {
   await requireFinanceAccess();
   const t = await getTranslations("dashboard.insights");
 
-  const cfg = await getEventConfig();
-  if (!cfg.eventDate) redirect("/dashboard/onboarding");
+  const snapshot = await loadInsightsSnapshot();
+  if (!snapshot) redirect("/dashboard/onboarding");
 
-  const eventDate = cfg.eventDate;
-  const [vendors, payments, assets, incomes, tasks] = await Promise.all([
-    prisma.vendor.findMany({
-      where: { deletedAt: null },
-      include: { budgetItems: { where: { deletedAt: null } } },
-    }),
-    prisma.payment.findMany({
-      where: { deletedAt: null },
-      include: { vendor: { select: { id: true, name: true } } },
-      orderBy: { dueDate: "asc" },
-    }),
-    prisma.asset.findMany({ where: { deletedAt: null } }),
-    prisma.income.findMany({ where: { deletedAt: null } }),
-    prisma.task.findMany({ where: { deletedAt: null } }),
-  ]);
-
-  const totalBudget = vendors.reduce(
-    (s, v) =>
-      s +
-      v.budgetItems.reduce(
-        (sum, b) => sum + (b.actualValue ?? b.estimatedValue),
-        0,
-      ),
-    0,
-  );
-  const contracted = vendors.filter((v) => v.status === "CONTRACTED" || v.status === "FINALIZED");
-  const totalContracted = contracted.reduce(
-    (s, v) =>
-      s +
-      v.budgetItems.reduce(
-        (sum, b) => sum + (b.actualValue ?? b.estimatedValue),
-        0,
-      ),
-    0,
-  );
-  const totalPaid = payments
-    .filter((p) => p.status === "PAID")
-    .reduce((s, p) => s + p.amount, 0);
-  const totalCash = assets.reduce((s, a) => s + a.amount, 0);
-
-  const today = new Date();
-  const cashflow = buildMonthlyCashflow({
-    startingCash: totalCash,
-    eventDate: eventDate,
-    today,
-    incomes,
-    payments: payments.filter((p) => p.status === "PENDING"),
-  });
-
-  const worstMonthlyBalance = cashflow.length
-    ? Math.min(...cashflow.map((c) => c.ending))
-    : totalCash;
-
-  const tasksDone = tasks.filter((t) => t.status === "DONE").length;
-  const tasksOverdue = tasks.filter(
-    (t) => t.status !== "DONE" && t.deadline && new Date(t.deadline) < today,
-  ).length;
-
-  const daysToEvent = daysUntil(eventDate, today);
-  const health = computeHealthScore({
-    totalBudget,
-    totalContracted,
-    totalPaid,
-    totalCash,
-    daysToEvent,
-    totalTasks: tasks.length,
-    tasksDone,
-    tasksOverdue,
-    worstMonthlyBalance,
-  });
-
-  const creep = computeCategoryCreep(vendors, resolveCategoryColor, resolveCategoryLabel).filter(
-    (c) => c.estimated > 0,
-  );
-
-  const heatStart = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
-  const heatmap = buildPaymentHeatmap(
-    payments.filter((p) => p.status === "PENDING"),
-    heatStart,
-    eventDate,
-  );
-
-  const sCurve = buildPaymentSCurve(
-    payments.map((p) => ({
-      amount: p.amount,
-      dueDate: p.dueDate,
-      paidAt: p.paidAt,
-      status: p.status,
-    })),
-    cfg.contingencyPercent,
-  );
-
-  const burndown = buildTaskBurndown(
-    tasks.map((t) => ({
-      status: t.status,
-      createdAt: t.createdAt,
-      deadline: t.deadline,
-      completedAt: t.completedAt,
-    })),
-    eventDate,
-    today,
-  );
-
-  const waterfall = buildCategoryWaterfall(creep);
-
-  const leftover = projectLeftoverUntilEvent({
-    totalAssets: totalCash,
-    remainingBudget: totalBudget - totalPaid,
-    contingencyAmount: Math.round(totalContracted * (cfg.contingencyPercent / 100)),
-  });
+  const aiEnabled = await aiFeatureEnabled();
 
   return (
     <div className="space-y-6">
@@ -143,24 +23,20 @@ export default async function InsightsPage() {
         <p className="text-sm text-zinc-500">{t("header.subtitle")}</p>
       </div>
       <InsightsClient
-        eventDate={eventDate}
-        contingencyPercent={cfg.contingencyPercent}
-        totals={{
-          budget: totalBudget,
-          contracted: totalContracted,
-          paid: totalPaid,
-          cash: totalCash,
-        }}
-        daysToEvent={daysToEvent}
-        leftover={leftover}
-        cashflow={cashflow}
-        worstMonthlyBalance={worstMonthlyBalance}
-        health={health}
-        creep={creep}
-        heatmap={heatmap}
-        sCurve={sCurve}
-        burndown={burndown}
-        waterfall={waterfall}
+        eventDate={snapshot.eventDate}
+        contingencyPercent={snapshot.contingencyPercent}
+        totals={snapshot.totals}
+        daysToEvent={snapshot.daysToEvent}
+        leftover={snapshot.leftover}
+        cashflow={snapshot.cashflow}
+        worstMonthlyBalance={snapshot.worstMonthlyBalance}
+        health={snapshot.health}
+        creep={snapshot.creep}
+        heatmap={snapshot.heatmap}
+        sCurve={snapshot.sCurve}
+        burndown={snapshot.burndown}
+        waterfall={snapshot.waterfall}
+        aiEnabled={aiEnabled}
       />
     </div>
   );

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { getEventConfig } from "@/lib/event-config";
+import { isAiEnabled } from "@/lib/ai/config";
 import { getSecuritySettings } from "@/lib/security-settings";
 import { canManageUsers } from "@/lib/permissions";
 import { toIsoDate } from "@/lib/format";
@@ -119,6 +120,8 @@ export default async function SettingsPage() {
           coupleNames: cfg.coupleNames ?? "",
           rsvpReminderEnabled: cfg.rsvpReminderEnabled,
           rsvpReminderDays: cfg.rsvpReminderDays,
+          aiEnabled: cfg.aiEnabled,
+          aiConfigured: isAiEnabled(),
         }}
         pixSettings={{
           pixKey: cfg.pixKey ?? "",

--- a/src/app/dashboard/settings/settings-client.tsx
+++ b/src/app/dashboard/settings/settings-client.tsx
@@ -65,6 +65,8 @@ type Initial = {
   coupleNames: string;
   rsvpReminderEnabled: boolean;
   rsvpReminderDays: number;
+  aiEnabled: boolean;
+  aiConfigured: boolean;
 };
 
 type PixSettings = {
@@ -540,6 +542,18 @@ function EventTab({
             max="90"
             defaultValue={String(initial.rsvpReminderDays)}
           />
+          <label className="flex items-center gap-2 self-end pb-2 text-sm text-zinc-300 sm:col-span-2">
+            <input
+              type="checkbox"
+              name="aiEnabled"
+              defaultChecked={initial.aiEnabled}
+              className="accent-rose-500"
+            />
+            {t("event.aiEnabled")}
+          </label>
+          <p className="-mt-2 text-xs text-zinc-500 sm:col-span-2">
+            {initial.aiConfigured ? t("event.aiEnabledHint") : t("event.aiNotConfigured")}
+          </p>
           <div className="sm:col-span-2">
             <button
               type="submit"

--- a/src/components/ai/ai-generate-button.tsx
+++ b/src/components/ai/ai-generate-button.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+import { Check, Copy, Loader2, RefreshCw, Sparkles } from "lucide-react";
+import { useToast } from "@/components/toast";
+import type { ActionResult } from "@/types";
+
+type Props = {
+  /** Thunk que chama a Server Action de IA. Callers com parâmetros usam closure. */
+  action: () => Promise<ActionResult<string>>;
+  /** Namespace i18n com as chaves específicas da feature: `button`, `generating`. */
+  namespace: string;
+  /** Chamado quando o usuário aceita o texto (ex.: jogar num campo de domínio). */
+  onAccept?: (text: string) => void;
+};
+
+/**
+ * Botão reutilizável "Gerar com IA": dispara a action, mostra loading e
+ * apresenta o resultado num bloco editável/copiável com selo "Gerado por IA" e
+ * aviso de revisão. O texto NUNCA é persistido aqui — o usuário revisa antes.
+ */
+export function AiGenerateButton({ action, namespace, onAccept }: Props) {
+  const t = useTranslations(namespace);
+  const tc = useTranslations("common.ai");
+  const toast = useToast();
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  function run() {
+    startTransition(async () => {
+      const r = await action();
+      if (r.success) {
+        setResult(r.data ?? "");
+        setCopied(false);
+      } else {
+        toast.error(tc("failed"), r.error);
+      }
+    });
+  }
+
+  async function copy() {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error(tc("failed"));
+    }
+  }
+
+  if (result === null) {
+    return (
+      <button
+        type="button"
+        onClick={run}
+        disabled={pending}
+        className="inline-flex items-center gap-2 rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-2 text-sm font-medium text-rose-200 transition-colors hover:bg-rose-500/20 disabled:opacity-50"
+      >
+        {pending ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Sparkles className="h-4 w-4" />
+        )}
+        {pending ? t("generating") : t("button")}
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-rose-500/20 bg-rose-500/5 p-4">
+      <div className="mb-2 inline-flex items-center gap-1.5 rounded-full border border-rose-500/30 bg-rose-500/10 px-2 py-0.5 text-xs font-medium text-rose-200">
+        <Sparkles className="h-3 w-3" />
+        {tc("generatedBadge")}
+      </div>
+      <p className="whitespace-pre-wrap text-sm leading-relaxed text-zinc-200">{result}</p>
+      <p className="mt-3 text-xs text-zinc-500">{tc("reviewNotice")}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={copy}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-200 hover:bg-zinc-800"
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          {copied ? tc("copied") : tc("copy")}
+        </button>
+        <button
+          type="button"
+          onClick={run}
+          disabled={pending}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-200 hover:bg-zinc-800 disabled:opacity-50"
+        >
+          {pending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="h-3.5 w-3.5" />
+          )}
+          {tc("regenerate")}
+        </button>
+        {onAccept ? (
+          <button
+            type="button"
+            onClick={() => onAccept(result)}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-200 hover:bg-rose-500/20"
+          >
+            {tc("use")}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/ai/aiAccess.ts
+++ b/src/lib/ai/aiAccess.ts
@@ -1,0 +1,14 @@
+import "server-only";
+import { getEventConfig } from "@/lib/event-config";
+import { isAiEnabled } from "./config";
+
+// Gate efetivo da IA, combinando os dois níveis de opt-in:
+//   1. master switch por env (GEMINI_API_KEY) — isAiEnabled()
+//   2. toggle por casal (EventSettings.aiEnabled)
+// Use em Server Components (passe o boolean resolvido como prop ao client) e em
+// Server Actions, antes de oferecer qualquer ação de IA.
+export async function aiFeatureEnabled(): Promise<boolean> {
+  if (!isAiEnabled()) return false;
+  const cfg = await getEventConfig();
+  return cfg.aiEnabled;
+}

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -1,0 +1,21 @@
+import "server-only";
+import { GoogleGenAI } from "@google/genai";
+import { getAiConfig } from "./config";
+
+// Singleton em globalThis (mesmo padrão de notifications/email.ts). Recriado se a
+// chave mudar em runtime. `null` quando a IA está desligada.
+
+type AiGlobals = {
+  _aiClient?: GoogleGenAI;
+  _aiClientKey?: string;
+};
+const g = globalThis as unknown as AiGlobals;
+
+export function getAiClient(): GoogleGenAI | null {
+  const cfg = getAiConfig();
+  if (!cfg) return null;
+  if (g._aiClient && g._aiClientKey === cfg.apiKey) return g._aiClient;
+  g._aiClient = new GoogleGenAI({ apiKey: cfg.apiKey });
+  g._aiClientKey = cfg.apiKey;
+  return g._aiClient;
+}

--- a/src/lib/ai/config.test.ts
+++ b/src/lib/ai/config.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getAiConfig, getAiModel, isAiEnabled } from "./config";
+
+const ORIGINAL = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL };
+});
+
+describe("isAiEnabled", () => {
+  it("é false sem GEMINI_API_KEY", () => {
+    delete process.env.GEMINI_API_KEY;
+    expect(isAiEnabled()).toBe(false);
+  });
+
+  it("é true com GEMINI_API_KEY", () => {
+    process.env.GEMINI_API_KEY = "k";
+    expect(isAiEnabled()).toBe(true);
+  });
+});
+
+describe("getAiConfig", () => {
+  it("retorna null sem chave", () => {
+    delete process.env.GEMINI_API_KEY;
+    expect(getAiConfig()).toBeNull();
+  });
+
+  it("usa defaults quando há chave e sem overrides", () => {
+    process.env.GEMINI_API_KEY = "k";
+    delete process.env.GEMINI_MODEL;
+    delete process.env.GEMINI_TIMEOUT_MS;
+    delete process.env.GEMINI_MAX_OUTPUT_TOKENS;
+    expect(getAiConfig()).toEqual({
+      apiKey: "k",
+      model: "gemini-2.5-flash",
+      timeoutMs: 20_000,
+      maxOutputTokens: 2048,
+    });
+  });
+
+  it("honra overrides de env", () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.GEMINI_MODEL = "gemini-2.5-flash-lite";
+    process.env.GEMINI_TIMEOUT_MS = "5000";
+    process.env.GEMINI_MAX_OUTPUT_TOKENS = "512";
+    expect(getAiConfig()).toEqual({
+      apiKey: "k",
+      model: "gemini-2.5-flash-lite",
+      timeoutMs: 5000,
+      maxOutputTokens: 512,
+    });
+  });
+
+  it("cai para default quando env numérico é inválido", () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.GEMINI_TIMEOUT_MS = "abc";
+    process.env.GEMINI_MAX_OUTPUT_TOKENS = "-3";
+    const cfg = getAiConfig();
+    expect(cfg?.timeoutMs).toBe(20_000);
+    expect(cfg?.maxOutputTokens).toBe(2048);
+  });
+});
+
+describe("getAiModel", () => {
+  it("default sem env", () => {
+    delete process.env.GEMINI_MODEL;
+    expect(getAiModel()).toBe("gemini-2.5-flash");
+  });
+
+  it("usa GEMINI_MODEL quando definido", () => {
+    process.env.GEMINI_MODEL = "gemini-2.5-pro";
+    expect(getAiModel()).toBe("gemini-2.5-pro");
+  });
+});

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+// Master switch da IA: o recurso só existe quando há GEMINI_API_KEY no ambiente.
+// Sem chave, `isAiEnabled()` é false, a camada recusa e a UI não renderiza botões.
+
+export type AiConfig = {
+  apiKey: string;
+  model: string;
+  timeoutMs: number;
+  maxOutputTokens: number;
+};
+
+const DEFAULT_MODEL = "gemini-2.5-flash";
+const DEFAULT_TIMEOUT_MS = 20_000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+export function isAiEnabled(): boolean {
+  return Boolean(process.env.GEMINI_API_KEY);
+}
+
+export function getAiModel(): string {
+  return process.env.GEMINI_MODEL?.trim() || DEFAULT_MODEL;
+}
+
+/** Configuração resolvida do provedor, ou `null` quando a IA está desligada. Nunca lança. */
+export function getAiConfig(): AiConfig | null {
+  const apiKey = process.env.GEMINI_API_KEY?.trim();
+  if (!apiKey) return null;
+  return {
+    apiKey,
+    model: getAiModel(),
+    timeoutMs: parsePositiveInt(process.env.GEMINI_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+    maxOutputTokens: parsePositiveInt(
+      process.env.GEMINI_MAX_OUTPUT_TOKENS,
+      DEFAULT_MAX_OUTPUT_TOKENS,
+    ),
+  };
+}

--- a/src/lib/ai/errors.ts
+++ b/src/lib/ai/errors.ts
@@ -1,0 +1,20 @@
+// Tipos puros do resultado de uma chamada de IA. A camada `ai/` NUNCA lança —
+// sempre devolve um `AiResult` discriminado para o caller decidir a UX.
+// Sem `server-only`: tipos podem ser importados por testes e tipos compartilhados.
+
+export type AiErrorCode =
+  | "DISABLED" // sem GEMINI_API_KEY (master switch desligado)
+  | "RATE_LIMITED" // estourou o bucket por usuário+recurso
+  | "TIMEOUT" // abortado por AbortSignal (timeout interno ou externo)
+  | "INVALID_OUTPUT" // saída estruturada não passou no Zod / JSON inválido
+  | "BLOCKED" // bloqueado por safety/recitation (finishReason)
+  | "PROVIDER_ERROR"; // erro de rede/API ou resposta vazia
+
+export type AiUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+};
+
+export type AiResult<T> =
+  | { ok: true; data: T; usage?: AiUsage }
+  | { ok: false; code: AiErrorCode };

--- a/src/lib/ai/generate.test.ts
+++ b/src/lib/ai/generate.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
+
+const getAiClientMock = vi.fn();
+const isAiEnabledMock = vi.fn();
+const getAiConfigMock = vi.fn();
+const checkRateMock = vi.fn();
+
+vi.mock("./client", () => ({ getAiClient: () => getAiClientMock() }));
+vi.mock("./config", () => ({
+  isAiEnabled: () => isAiEnabledMock(),
+  getAiConfig: () => getAiConfigMock(),
+}));
+vi.mock("./rate-limit", () => ({ checkAiRateLimit: () => checkRateMock() }));
+
+import { generateText, generateStructured } from "./generate";
+
+type FakeResponse = {
+  text?: string;
+  candidates?: Array<{ finishReason?: string }>;
+  usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
+};
+
+function clientReturning(response: FakeResponse) {
+  return { models: { generateContent: vi.fn().mockResolvedValue(response) } };
+}
+
+function clientThrowing(err: Error) {
+  return { models: { generateContent: vi.fn().mockRejectedValue(err) } };
+}
+
+beforeEach(() => {
+  isAiEnabledMock.mockReturnValue(true);
+  getAiConfigMock.mockReturnValue({
+    apiKey: "k",
+    model: "gemini-2.5-flash",
+    timeoutMs: 20_000,
+    maxOutputTokens: 2048,
+  });
+  checkRateMock.mockReturnValue({ ok: true, resetAt: 0 });
+  getAiClientMock.mockReset();
+});
+
+describe("generateText", () => {
+  it("retorna texto e uso no sucesso", async () => {
+    getAiClientMock.mockReturnValue(
+      clientReturning({
+        text: "tudo certo",
+        candidates: [{ finishReason: "STOP" }],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 3 },
+      }),
+    );
+    const r = await generateText("p", { userId: "u", resource: "r" });
+    expect(r).toEqual({ ok: true, data: "tudo certo", usage: { inputTokens: 5, outputTokens: 3 } });
+  });
+
+  it("DISABLED quando a IA está desligada", async () => {
+    isAiEnabledMock.mockReturnValue(false);
+    const r = await generateText("p", { userId: "u", resource: "r" });
+    expect(r).toEqual({ ok: false, code: "DISABLED" });
+  });
+
+  it("RATE_LIMITED quando estoura o bucket", async () => {
+    checkRateMock.mockReturnValue({ ok: false, resetAt: 0 });
+    const r = await generateText("p", { userId: "u", resource: "r" });
+    expect(r).toEqual({ ok: false, code: "RATE_LIMITED" });
+  });
+
+  it("BLOCKED quando finishReason é de segurança", async () => {
+    getAiClientMock.mockReturnValue(
+      clientReturning({ text: "x", candidates: [{ finishReason: "SAFETY" }] }),
+    );
+    const r = await generateText("p", { userId: "u", resource: "r" });
+    expect(r).toEqual({ ok: false, code: "BLOCKED" });
+  });
+
+  it("PROVIDER_ERROR quando texto vazio", async () => {
+    getAiClientMock.mockReturnValue(
+      clientReturning({ text: "", candidates: [{ finishReason: "STOP" }] }),
+    );
+    const r = await generateText("p", { userId: "u", resource: "r" });
+    expect(r).toEqual({ ok: false, code: "PROVIDER_ERROR" });
+  });
+
+  it("TIMEOUT quando a chamada aborta", async () => {
+    const err = new Error("aborted");
+    err.name = "TimeoutError";
+    getAiClientMock.mockReturnValue(clientThrowing(err));
+    const r = await generateText("p", { userId: "u", resource: "r" });
+    expect(r).toEqual({ ok: false, code: "TIMEOUT" });
+  });
+
+  it("PROVIDER_ERROR em erro genérico", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getAiClientMock.mockReturnValue(clientThrowing(new Error("boom")));
+    const r = await generateText("p", { userId: "u", resource: "r" });
+    expect(r).toEqual({ ok: false, code: "PROVIDER_ERROR" });
+  });
+});
+
+describe("generateStructured", () => {
+  const schema = z.object({ n: z.number() });
+
+  it("parseia e valida JSON", async () => {
+    getAiClientMock.mockReturnValue(
+      clientReturning({ text: '{"n":1}', candidates: [{ finishReason: "STOP" }] }),
+    );
+    const r = await generateStructured("p", schema, { userId: "u", resource: "r" });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data).toEqual({ n: 1 });
+  });
+
+  it("INVALID_OUTPUT em JSON malformado", async () => {
+    getAiClientMock.mockReturnValue(
+      clientReturning({ text: "não é json", candidates: [{ finishReason: "STOP" }] }),
+    );
+    const r = await generateStructured("p", schema, { userId: "u", resource: "r" });
+    expect(r).toEqual({ ok: false, code: "INVALID_OUTPUT" });
+  });
+
+  it("INVALID_OUTPUT quando o schema falha", async () => {
+    getAiClientMock.mockReturnValue(
+      clientReturning({ text: '{"n":"x"}', candidates: [{ finishReason: "STOP" }] }),
+    );
+    const r = await generateStructured("p", schema, { userId: "u", resource: "r" });
+    expect(r).toEqual({ ok: false, code: "INVALID_OUTPUT" });
+  });
+});

--- a/src/lib/ai/generate.ts
+++ b/src/lib/ai/generate.ts
@@ -1,0 +1,137 @@
+import "server-only";
+import {
+  FinishReason,
+  type GenerateContentResponse,
+  type Schema,
+} from "@google/genai";
+import type { z } from "zod";
+import { getAiClient } from "./client";
+import { getAiConfig, isAiEnabled } from "./config";
+import { checkAiRateLimit } from "./rate-limit";
+import type { AiResult, AiUsage } from "./errors";
+
+export type GenerateOpts = {
+  userId: string;
+  /** Identificador estável do caso de uso (rate-limit + auditoria). Ex.: "insights.narrative". */
+  resource: string;
+  locale?: string;
+  system?: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+  /** AbortSignal externo, combinado com o timeout interno. */
+  signal?: AbortSignal;
+  /** Schema nativo do Gemini para geração estruturada (opcional; a validação final é sempre Zod). */
+  responseSchema?: Schema;
+};
+
+// finishReasons que indicam bloqueio por política — viram AiErrorCode "BLOCKED".
+const BLOCKED_REASONS = new Set<FinishReason>([
+  FinishReason.SAFETY,
+  FinishReason.RECITATION,
+  FinishReason.BLOCKLIST,
+  FinishReason.PROHIBITED_CONTENT,
+  FinishReason.SPII,
+  FinishReason.IMAGE_SAFETY,
+]);
+
+function extractUsage(res: GenerateContentResponse): AiUsage | undefined {
+  const u = res.usageMetadata;
+  if (!u) return undefined;
+  return { inputTokens: u.promptTokenCount, outputTokens: u.candidatesTokenCount };
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError")
+  );
+}
+
+async function callGemini(
+  prompt: string,
+  opts: GenerateOpts,
+  json: boolean,
+): Promise<AiResult<{ text: string; usage?: AiUsage }>> {
+  if (!isAiEnabled()) return { ok: false, code: "DISABLED" };
+
+  const rl = checkAiRateLimit(opts.userId, opts.resource);
+  if (!rl.ok) return { ok: false, code: "RATE_LIMITED" };
+
+  const client = getAiClient();
+  const cfg = getAiConfig();
+  if (!client || !cfg) return { ok: false, code: "DISABLED" };
+
+  const timeout = AbortSignal.timeout(cfg.timeoutMs);
+  const signal = opts.signal ? AbortSignal.any([opts.signal, timeout]) : timeout;
+
+  try {
+    const res = await client.models.generateContent({
+      model: cfg.model,
+      contents: prompt,
+      config: {
+        abortSignal: signal,
+        systemInstruction: opts.system,
+        temperature: opts.temperature,
+        maxOutputTokens: opts.maxOutputTokens ?? cfg.maxOutputTokens,
+        ...(json
+          ? {
+              responseMimeType: "application/json",
+              ...(opts.responseSchema ? { responseSchema: opts.responseSchema } : {}),
+            }
+          : {}),
+      },
+    });
+
+    const finishReason = res.candidates?.[0]?.finishReason;
+    if (finishReason && BLOCKED_REASONS.has(finishReason)) {
+      return { ok: false, code: "BLOCKED" };
+    }
+
+    const text = res.text;
+    if (!text || text.trim().length === 0) {
+      return { ok: false, code: "PROVIDER_ERROR" };
+    }
+
+    return { ok: true, data: { text, usage: extractUsage(res) } };
+  } catch (err) {
+    if (isAbortError(err)) return { ok: false, code: "TIMEOUT" };
+    // Não logar prompt/saída (podem conter PII). Apenas o recurso.
+    console.error("[ai] generateContent failed", { resource: opts.resource });
+    return { ok: false, code: "PROVIDER_ERROR" };
+  }
+}
+
+/** Geração de texto livre. Nunca lança. */
+export async function generateText(
+  prompt: string,
+  opts: GenerateOpts,
+): Promise<AiResult<string>> {
+  const res = await callGemini(prompt, opts, false);
+  if (!res.ok) return res;
+  return { ok: true, data: res.data.text, usage: res.data.usage };
+}
+
+/**
+ * Geração estruturada: pede JSON ao modelo e valida com Zod no servidor.
+ * `responseSchema` (opcional) é só um hint para o Gemini — a fonte da verdade é o Zod.
+ * JSON inválido ou que não passe no schema vira `INVALID_OUTPUT`. Nunca lança.
+ */
+export async function generateStructured<T>(
+  prompt: string,
+  schema: z.ZodType<T>,
+  opts: GenerateOpts,
+): Promise<AiResult<T>> {
+  const res = await callGemini(prompt, opts, true);
+  if (!res.ok) return res;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(res.data.text);
+  } catch {
+    return { ok: false, code: "INVALID_OUTPUT" };
+  }
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) return { ok: false, code: "INVALID_OUTPUT" };
+
+  return { ok: true, data: result.data, usage: res.data.usage };
+}

--- a/src/lib/ai/log.ts
+++ b/src/lib/ai/log.ts
@@ -1,0 +1,36 @@
+import "server-only";
+import { prisma } from "@/lib/prisma";
+import type { AiUsage } from "./errors";
+
+// Persiste metadados de cada geração de IA (sem PII bruta). `outputPreview` é
+// truncado; para features que lidam com PII (ex.: dados de convidados), passe null.
+// Best-effort: nunca lança.
+
+const PREVIEW_MAX = 280;
+
+export async function recordAiGeneration(entry: {
+  userId?: string | null;
+  resource: string;
+  model: string;
+  status: string;
+  usage?: AiUsage;
+  outputPreview?: string | null;
+}): Promise<void> {
+  try {
+    await prisma.aiGeneration.create({
+      data: {
+        userId: entry.userId ?? null,
+        resource: entry.resource,
+        model: entry.model,
+        status: entry.status,
+        inputTokens: entry.usage?.inputTokens ?? null,
+        outputTokens: entry.usage?.outputTokens ?? null,
+        outputPreview: entry.outputPreview
+          ? entry.outputPreview.slice(0, PREVIEW_MAX)
+          : null,
+      },
+    });
+  } catch {
+    console.error("[ai] failed to record generation", { resource: entry.resource });
+  }
+}

--- a/src/lib/ai/prompts.test.ts
+++ b/src/lib/ai/prompts.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { buildInsightsNarrativePrompt, type InsightsNarrativeInput } from "./prompts";
+
+const base: InsightsNarrativeInput = {
+  locale: "pt-BR",
+  coupleNames: "Ana & Beto",
+  daysToEvent: 120,
+  healthScore: 72,
+  money: {
+    budget: "R$ 100,00",
+    contracted: "R$ 70,00",
+    paid: "R$ 40,00",
+    cash: "R$ 35,00",
+    leftover: "R$ 5,00",
+    worstMonthlyBalance: "-R$ 2,00",
+  },
+  breakdown: [{ label: "Cobertura contratada", pct: 0.7 }],
+  alerts: ["Você está atrasado em fechar fornecedores."],
+  topCreep: [{ category: "Buffet", deltaLabel: "R$ 10,00", pct: 0.2 }],
+};
+
+describe("buildInsightsNarrativePrompt", () => {
+  it("delimita os dados do usuário e embute os números", () => {
+    const { system, user } = buildInsightsNarrativePrompt(base);
+    expect(system).toContain("português do Brasil");
+    expect(user).toContain("<dados>");
+    expect(user).toContain("</dados>");
+    expect(user).toContain("Ana & Beto");
+    expect(user).toContain("R$ 70,00");
+    expect(user).toContain("Buffet");
+  });
+
+  it("mapeia o locale para o nome do idioma", () => {
+    expect(buildInsightsNarrativePrompt({ ...base, locale: "en" }).system).toContain("English");
+    expect(buildInsightsNarrativePrompt({ ...base, locale: "es" }).system).toContain("español");
+  });
+
+  it("cai para pt-BR em locale desconhecido", () => {
+    expect(buildInsightsNarrativePrompt({ ...base, locale: "xx" }).system).toContain(
+      "português do Brasil",
+    );
+  });
+});

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,0 +1,79 @@
+// Construtores de prompt — funções PURAS (testáveis, sem I/O, sem server-only).
+// Dados do usuário entram como bloco DELIMITADO (nunca como instrução) para
+// reduzir prompt-injection. Valores monetários chegam já formatados pelo caller
+// (formatCurrency), evitando que o modelo precise interpretar centavos/moeda.
+
+const LANGUAGE_NAME: Record<string, string> = {
+  "pt-BR": "português do Brasil",
+  en: "English",
+  es: "español",
+};
+
+function languageName(locale: string): string {
+  return LANGUAGE_NAME[locale] ?? LANGUAGE_NAME["pt-BR"];
+}
+
+export type InsightsNarrativeInput = {
+  locale: string;
+  coupleNames: string | null;
+  daysToEvent: number;
+  healthScore: number;
+  money: {
+    budget: string;
+    contracted: string;
+    paid: string;
+    cash: string;
+    leftover: string;
+    worstMonthlyBalance: string;
+  };
+  breakdown: { label: string; pct: number }[];
+  alerts: string[];
+  topCreep: { category: string; deltaLabel: string; pct: number }[];
+};
+
+export function buildInsightsNarrativePrompt(input: InsightsNarrativeInput): {
+  system: string;
+  user: string;
+} {
+  const lang = languageName(input.locale);
+  const system = [
+    `Você é um assistente financeiro de casamento. Escreva SEMPRE em ${lang}.`,
+    "Produza um resumo curto (2 a 4 parágrafos OU até 6 marcadores) explicando a saúde financeira do casamento de forma acolhedora, porém honesta.",
+    "Baseie-se EXCLUSIVAMENTE nos dados do bloco DADOS. Nunca invente números, datas ou fornecedores.",
+    "Não apenas repita os números: interprete o que vai bem, o que é risco e sugira de 1 a 3 ações práticas.",
+    "Sem saudações ('Olá'), sem assinatura, sem tabelas. Apenas texto corrido ou marcadores.",
+  ].join(" ");
+
+  const data = {
+    casal: input.coupleNames,
+    diasParaOEvento: input.daysToEvent,
+    scoreSaude: input.healthScore,
+    orcamentoTotal: input.money.budget,
+    contratado: input.money.contracted,
+    pago: input.money.paid,
+    caixaAtual: input.money.cash,
+    sobraProjetada: input.money.leftover,
+    piorSaldoMensalProjetado: input.money.worstMonthlyBalance,
+    componentesDoScore: input.breakdown.map((b) => ({
+      nome: b.label,
+      percentual: Math.round(b.pct * 100),
+    })),
+    alertas: input.alerts,
+    categoriasComMaiorDesvio: input.topCreep.map((c) => ({
+      categoria: c.category,
+      desvio: c.deltaLabel,
+      percentual: Math.round(c.pct * 100),
+    })),
+  };
+
+  const user = [
+    "DADOS (use para escrever o resumo; não exiba como JSON):",
+    "<dados>",
+    JSON.stringify(data, null, 2),
+    "</dados>",
+    "",
+    "Escreva o resumo agora.",
+  ].join("\n");
+
+  return { system, user };
+}

--- a/src/lib/ai/rate-limit.ts
+++ b/src/lib/ai/rate-limit.ts
@@ -1,0 +1,23 @@
+import "server-only";
+import { rateLimit } from "@/lib/rate-limit";
+
+// Limita chamadas de IA por usuário + recurso (autenticado, então a chave usa
+// userId em vez de IP). Reaproveita o bucket in-memory de src/lib/rate-limit.ts.
+
+const DEFAULT_MAX = 20;
+const DEFAULT_WINDOW_MS = 5 * 60_000;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+export function checkAiRateLimit(
+  userId: string,
+  resource: string,
+): { ok: boolean; resetAt: number } {
+  const max = parsePositiveInt(process.env.AI_RATE_MAX, DEFAULT_MAX);
+  const windowMs = parsePositiveInt(process.env.AI_RATE_WINDOW_MS, DEFAULT_WINDOW_MS);
+  const r = rateLimit(`ai:${resource}:${userId}`, max, windowMs);
+  return { ok: r.ok, resetAt: r.resetAt };
+}

--- a/src/lib/ai/schemas.ts
+++ b/src/lib/ai/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+// Schemas Zod de SAÍDA das gerações estruturadas (texto→JSON). A validação no
+// servidor é a fonte da verdade — o responseSchema do Gemini é apenas um hint.
+// Limites explícitos (AGENTS.md §5.10). Novos schemas entram nas ondas seguintes
+// (itinerário de lua de mel, enxoval, timeline do dia, extração de contrato).
+
+export const BudgetBreakdownSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        categoryKey: z.string().max(64),
+        label: z.string().max(120),
+        estimatedPercent: z.number().min(0).max(100),
+        rationale: z.string().max(500),
+      }),
+    )
+    .max(25),
+});
+export type BudgetBreakdown = z.infer<typeof BudgetBreakdownSchema>;

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -32,7 +32,8 @@ export type AuditAction =
   | "CONNECT"
   | "DISCONNECT"
   | "ENABLE_2FA"
-  | "DISABLE_2FA";
+  | "DISABLE_2FA"
+  | "AI_GENERATE";
 
 export type AuditEntity =
   | "Vendor"
@@ -57,7 +58,8 @@ export type AuditEntity =
   | "Honeymoon"
   | "HoneymoonItem"
   | "TrousseauItem"
-  | "Broadcast";
+  | "Broadcast"
+  | "AiGeneration";
 
 export async function audit(
   entity: AuditEntity,

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,13 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.8.0",
+    date: "2026-06-09",
+    highlights: [
+      "🤖 **Assistente de IA (Google Gemini), opcional e desligado por padrão.** Na tela de **Insights**, gere um **resumo em linguagem natural** da saúde financeira do casamento — o que vai bem, os riscos e o que fazer a seguir. Ative em **Ajustes › Casamento** (requer chave de API configurada no servidor). Todo texto é rotulado como *gerado por IA* e deve ser revisado antes de usar.",
+    ],
+  },
+  {
     version: "0.7.9",
     date: "2026-06-08",
     highlights: [

--- a/src/lib/event-config.ts
+++ b/src/lib/event-config.ts
@@ -24,6 +24,7 @@ export type EventConfig = {
   saveTheDateExcludePadrinhos: boolean;
   rsvpReminderEnabled: boolean;
   rsvpReminderDays: number;
+  aiEnabled: boolean;
 };
 
 export async function getEventConfig(): Promise<EventConfig> {
@@ -60,6 +61,7 @@ export async function getEventConfig(): Promise<EventConfig> {
     saveTheDateExcludePadrinhos: settings.saveTheDateExcludePadrinhos,
     rsvpReminderEnabled: settings.rsvpReminderEnabled,
     rsvpReminderDays: settings.rsvpReminderDays,
+    aiEnabled: settings.aiEnabled,
   };
 }
 
@@ -111,6 +113,7 @@ export async function updateEventConfig(
         input.rsvpReminderEnabled === undefined ? undefined : input.rsvpReminderEnabled,
       rsvpReminderDays:
         input.rsvpReminderDays === undefined ? undefined : input.rsvpReminderDays,
+      aiEnabled: input.aiEnabled === undefined ? undefined : input.aiEnabled,
     },
   });
 
@@ -137,6 +140,7 @@ export async function updateEventConfig(
     saveTheDateExcludePadrinhos: updated.saveTheDateExcludePadrinhos,
     rsvpReminderEnabled: updated.rsvpReminderEnabled,
     rsvpReminderDays: updated.rsvpReminderDays,
+    aiEnabled: updated.aiEnabled,
   };
 }
 

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -323,6 +323,32 @@ export const HELP_ARTICLES: HelpArticle[] = [
     ],
   },
 
+  {
+    id: "ai-insights-narrative",
+    title: "Resumo com IA nos Insights",
+    category: "financial",
+    keywords: ["ia", "inteligência artificial", "gemini", "resumo", "insights", "assistente"],
+    icon: Sparkles,
+    summary: "Gere uma explicação em linguagem natural da sua saúde financeira (opcional).",
+    steps: [
+      {
+        title: "Ative a IA",
+        body: "Em Ajustes › Casamento, marque 'Ativar assistente de IA'. O recurso só funciona se houver uma chave de API (Google Gemini) configurada no servidor.",
+      },
+      {
+        title: "Gere o resumo",
+        body: "Na tela de Insights, clique em 'Gerar resumo com IA'. Em segundos aparece um texto explicando seu Health Score, fluxo de caixa e desvios de orçamento.",
+      },
+      {
+        title: "Revise antes de usar",
+        body: "O texto vem marcado como 'Gerado por IA'. Releia — a IA pode cometer erros. Use os botões Copiar ou Gerar de novo.",
+      },
+    ],
+    warnings: [
+      "Ao ativar a IA, dados do seu casamento são enviados ao provedor (Google) para gerar a resposta. Sem chave configurada e sem ativar, nada é enviado.",
+    ],
+  },
+
   // ============ vendors ============
   {
     id: "vendor-flow",

--- a/src/lib/reports/insights-snapshot.ts
+++ b/src/lib/reports/insights-snapshot.ts
@@ -1,0 +1,164 @@
+import { prisma } from "@/lib/prisma";
+import { getEventConfig, daysUntil } from "@/lib/event-config";
+import { resolveCategoryColor, resolveCategoryLabel } from "@/lib/categories";
+import {
+  buildCategoryWaterfall,
+  buildMonthlyCashflow,
+  buildPaymentHeatmap,
+  computeCategoryCreep,
+  computeHealthScore,
+  projectLeftoverUntilEvent,
+  type CategoryCreep,
+  type HealthScoreResult,
+  type MonthlyPoint,
+  type PaymentHeatCell,
+  type WaterfallBar,
+} from "@/lib/cashflow";
+import { buildPaymentSCurve, type PaymentCurvePoint } from "@/lib/reports/payment-curve";
+import { buildTaskBurndown, type BurndownPoint } from "@/lib/reports/task-burndown";
+
+export type InsightsSnapshot = {
+  eventDate: Date;
+  contingencyPercent: number;
+  currency: string;
+  coupleNames: string | null;
+  totals: { budget: number; contracted: number; paid: number; cash: number };
+  daysToEvent: number;
+  leftover: number;
+  cashflow: MonthlyPoint[];
+  worstMonthlyBalance: number;
+  health: HealthScoreResult;
+  creep: CategoryCreep[];
+  heatmap: PaymentHeatCell[];
+  sCurve: PaymentCurvePoint[];
+  burndown: BurndownPoint[];
+  waterfall: WaterfallBar[];
+};
+
+/**
+ * Agrega e calcula todos os indicadores da tela de Insights. Fonte única de
+ * verdade reutilizada pela página `/dashboard/insights` e pela narrativa de IA.
+ * Retorna `null` quando o evento ainda não tem data (onboarding incompleto).
+ */
+export async function loadInsightsSnapshot(
+  today: Date = new Date(),
+): Promise<InsightsSnapshot | null> {
+  const cfg = await getEventConfig();
+  if (!cfg.eventDate) return null;
+  const eventDate = cfg.eventDate;
+
+  const [vendors, payments, assets, incomes, tasks] = await Promise.all([
+    prisma.vendor.findMany({
+      where: { deletedAt: null },
+      include: { budgetItems: { where: { deletedAt: null } } },
+    }),
+    prisma.payment.findMany({
+      where: { deletedAt: null },
+      include: { vendor: { select: { id: true, name: true } } },
+      orderBy: { dueDate: "asc" },
+    }),
+    prisma.asset.findMany({ where: { deletedAt: null } }),
+    prisma.income.findMany({ where: { deletedAt: null } }),
+    prisma.task.findMany({ where: { deletedAt: null } }),
+  ]);
+
+  const totalBudget = vendors.reduce(
+    (s, v) => s + v.budgetItems.reduce((sum, b) => sum + (b.actualValue ?? b.estimatedValue), 0),
+    0,
+  );
+  const contracted = vendors.filter((v) => v.status === "CONTRACTED" || v.status === "FINALIZED");
+  const totalContracted = contracted.reduce(
+    (s, v) => s + v.budgetItems.reduce((sum, b) => sum + (b.actualValue ?? b.estimatedValue), 0),
+    0,
+  );
+  const totalPaid = payments.filter((p) => p.status === "PAID").reduce((s, p) => s + p.amount, 0);
+  const totalCash = assets.reduce((s, a) => s + a.amount, 0);
+
+  const cashflow = buildMonthlyCashflow({
+    startingCash: totalCash,
+    eventDate,
+    today,
+    incomes,
+    payments: payments.filter((p) => p.status === "PENDING"),
+  });
+
+  const worstMonthlyBalance = cashflow.length
+    ? Math.min(...cashflow.map((c) => c.ending))
+    : totalCash;
+
+  const tasksDone = tasks.filter((t) => t.status === "DONE").length;
+  const tasksOverdue = tasks.filter(
+    (t) => t.status !== "DONE" && t.deadline && new Date(t.deadline) < today,
+  ).length;
+
+  const daysToEvent = daysUntil(eventDate, today);
+  const health = computeHealthScore({
+    totalBudget,
+    totalContracted,
+    totalPaid,
+    totalCash,
+    daysToEvent,
+    totalTasks: tasks.length,
+    tasksDone,
+    tasksOverdue,
+    worstMonthlyBalance,
+  });
+
+  const creep = computeCategoryCreep(vendors, resolveCategoryColor, resolveCategoryLabel).filter(
+    (c) => c.estimated > 0,
+  );
+
+  const heatStart = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+  const heatmap = buildPaymentHeatmap(
+    payments.filter((p) => p.status === "PENDING"),
+    heatStart,
+    eventDate,
+  );
+
+  const sCurve = buildPaymentSCurve(
+    payments.map((p) => ({
+      amount: p.amount,
+      dueDate: p.dueDate,
+      paidAt: p.paidAt,
+      status: p.status,
+    })),
+    cfg.contingencyPercent,
+  );
+
+  const burndown = buildTaskBurndown(
+    tasks.map((t) => ({
+      status: t.status,
+      createdAt: t.createdAt,
+      deadline: t.deadline,
+      completedAt: t.completedAt,
+    })),
+    eventDate,
+    today,
+  );
+
+  const waterfall = buildCategoryWaterfall(creep);
+
+  const leftover = projectLeftoverUntilEvent({
+    totalAssets: totalCash,
+    remainingBudget: totalBudget - totalPaid,
+    contingencyAmount: Math.round(totalContracted * (cfg.contingencyPercent / 100)),
+  });
+
+  return {
+    eventDate,
+    contingencyPercent: cfg.contingencyPercent,
+    currency: cfg.currency,
+    coupleNames: cfg.coupleNames,
+    totals: { budget: totalBudget, contracted: totalContracted, paid: totalPaid, cash: totalCash },
+    daysToEvent,
+    leftover,
+    cashflow,
+    worstMonthlyBalance,
+    health,
+    creep,
+    heatmap,
+    sCurve,
+    burndown,
+    waterfall,
+  };
+}

--- a/src/messages/en/actions.json
+++ b/src/messages/en/actions.json
@@ -1,4 +1,16 @@
 {
+  "ai": {
+    "disabled": "The AI assistant is turned off.",
+    "noEventDate": "Set the wedding date before using AI.",
+    "errors": {
+      "DISABLED": "The AI assistant is turned off.",
+      "RATE_LIMITED": "Too many AI requests in a short time. Try again shortly.",
+      "TIMEOUT": "The AI took too long to respond. Please try again.",
+      "INVALID_OUTPUT": "The AI returned an invalid response. Please try again.",
+      "BLOCKED": "The AI blocked this request for safety reasons.",
+      "PROVIDER_ERROR": "Couldn't reach the AI service right now. Please try again."
+    }
+  },
   "asset": {
     "notFound": "Contribution not found",
     "errorCreate": "Failed to create contribution",

--- a/src/messages/en/common.json
+++ b/src/messages/en/common.json
@@ -154,6 +154,15 @@
     "current": "Current language",
     "selectHint": "Language used across the interface, emails and WhatsApp."
   },
+  "ai": {
+    "generatedBadge": "AI-generated",
+    "reviewNotice": "Review before using — AI can make mistakes.",
+    "copy": "Copy",
+    "copied": "Copied!",
+    "use": "Use",
+    "regenerate": "Regenerate",
+    "failed": "AI failed"
+  },
   "zod": {
     "required": "This field is required",
     "invalidEmail": "Invalid email",

--- a/src/messages/en/dashboard.json
+++ b/src/messages/en/dashboard.json
@@ -765,6 +765,12 @@
     }
   },
   "insights": {
+    "ai": {
+      "title": "AI summary",
+      "description": "Generate a plain-language explanation of your financial health.",
+      "button": "Generate AI summary",
+      "generating": "Generating…"
+    },
     "header": {
       "title": "Financial insights",
       "subtitle": "Projection, project health and per-category budget creep detector."
@@ -1324,6 +1330,9 @@
       "rsvpReminderEnabled": "Send automatic RSVP reminder",
       "rsvpReminderHint": "Nudges invited guests who haven't responded via WhatsApp/email. Only sends if you enable it.",
       "rsvpReminderDays": "Remind after (days since invite)",
+      "aiEnabled": "Enable AI assistant",
+      "aiEnabledHint": "Lets you generate AI summaries and drafts (Google Gemini). When enabled, your wedding data is sent to the provider to produce the response.",
+      "aiNotConfigured": "AI requires an API key configured on the server (GEMINI_API_KEY). Talk to whoever manages the installation.",
       "save": "Save",
       "toast": {
         "saved": "Settings saved",

--- a/src/messages/es/actions.json
+++ b/src/messages/es/actions.json
@@ -1,4 +1,16 @@
 {
+  "ai": {
+    "disabled": "El asistente de IA está desactivado.",
+    "noEventDate": "Define la fecha de la boda antes de usar la IA.",
+    "errors": {
+      "DISABLED": "El asistente de IA está desactivado.",
+      "RATE_LIMITED": "Demasiadas solicitudes de IA en poco tiempo. Inténtalo de nuevo en un momento.",
+      "TIMEOUT": "La IA tardó demasiado en responder. Inténtalo de nuevo.",
+      "INVALID_OUTPUT": "La IA devolvió una respuesta inválida. Inténtalo de nuevo.",
+      "BLOCKED": "La IA bloqueó esta solicitud por seguridad.",
+      "PROVIDER_ERROR": "No se pudo contactar con el servicio de IA ahora. Inténtalo de nuevo."
+    }
+  },
   "asset": {
     "notFound": "Aporte no encontrado",
     "errorCreate": "Error al crear el aporte",

--- a/src/messages/es/common.json
+++ b/src/messages/es/common.json
@@ -154,6 +154,15 @@
     "current": "Idioma actual",
     "selectHint": "Idioma usado en toda la interfaz, correos y WhatsApp."
   },
+  "ai": {
+    "generatedBadge": "Generado por IA",
+    "reviewNotice": "Revisa antes de usar — la IA puede equivocarse.",
+    "copy": "Copiar",
+    "copied": "¡Copiado!",
+    "use": "Usar",
+    "regenerate": "Generar de nuevo",
+    "failed": "Error de IA"
+  },
   "zod": {
     "required": "Este campo es obligatorio",
     "invalidEmail": "Correo inválido",

--- a/src/messages/es/dashboard.json
+++ b/src/messages/es/dashboard.json
@@ -765,6 +765,12 @@
     }
   },
   "insights": {
+    "ai": {
+      "title": "Resumen con IA",
+      "description": "Genera una explicación en lenguaje natural de tu salud financiera.",
+      "button": "Generar resumen con IA",
+      "generating": "Generando…"
+    },
     "header": {
       "title": "Insights financieros",
       "subtitle": "Proyección, salud del proyecto y detector de desvío del presupuesto por categoría."
@@ -1324,6 +1330,9 @@
       "rsvpReminderEnabled": "Enviar recordatorio de RSVP automático",
       "rsvpReminderHint": "Recuerda por WhatsApp/correo a los invitados que aún no respondieron. Solo envía si lo activas.",
       "rsvpReminderDays": "Recordar después de (días desde la invitación)",
+      "aiEnabled": "Activar asistente de IA",
+      "aiEnabledHint": "Permite generar resúmenes y textos con IA (Google Gemini). Al activarlo, los datos de tu boda se envían al proveedor para generar la respuesta.",
+      "aiNotConfigured": "La IA requiere una clave de API configurada en el servidor (GEMINI_API_KEY). Habla con quien administra la instalación.",
       "save": "Guardar",
       "toast": {
         "saved": "Configuración guardada",

--- a/src/messages/pt-BR/actions.json
+++ b/src/messages/pt-BR/actions.json
@@ -1,4 +1,16 @@
 {
+  "ai": {
+    "disabled": "O assistente de IA está desativado.",
+    "noEventDate": "Defina a data do casamento antes de usar a IA.",
+    "errors": {
+      "DISABLED": "O assistente de IA está desativado.",
+      "RATE_LIMITED": "Muitas solicitações de IA em pouco tempo. Tente novamente em instantes.",
+      "TIMEOUT": "A IA demorou para responder. Tente novamente.",
+      "INVALID_OUTPUT": "A IA devolveu uma resposta inválida. Tente novamente.",
+      "BLOCKED": "A IA bloqueou esta solicitação por segurança.",
+      "PROVIDER_ERROR": "Não foi possível falar com o serviço de IA agora. Tente novamente."
+    }
+  },
   "asset": {
     "notFound": "Aporte não encontrado",
     "errorCreate": "Erro ao criar aporte",

--- a/src/messages/pt-BR/common.json
+++ b/src/messages/pt-BR/common.json
@@ -154,6 +154,15 @@
     "current": "Idioma atual",
     "selectHint": "Idioma usado em toda a interface, emails e WhatsApp."
   },
+  "ai": {
+    "generatedBadge": "Gerado por IA",
+    "reviewNotice": "Revise antes de usar — a IA pode cometer erros.",
+    "copy": "Copiar",
+    "copied": "Copiado!",
+    "use": "Usar",
+    "regenerate": "Gerar de novo",
+    "failed": "Falha na IA"
+  },
   "zod": {
     "required": "Este campo é obrigatório",
     "invalidEmail": "Email inválido",

--- a/src/messages/pt-BR/dashboard.json
+++ b/src/messages/pt-BR/dashboard.json
@@ -765,6 +765,12 @@
     }
   },
   "insights": {
+    "ai": {
+      "title": "Resumo com IA",
+      "description": "Gere uma explicação em linguagem natural da sua saúde financeira.",
+      "button": "Gerar resumo com IA",
+      "generating": "Gerando…"
+    },
     "header": {
       "title": "Insights financeiros",
       "subtitle": "Projeção, saúde do projeto e detector de orçamento por categoria."
@@ -1324,6 +1330,9 @@
       "rsvpReminderEnabled": "Enviar lembrete de RSVP automático",
       "rsvpReminderHint": "Cutuca por WhatsApp/e-mail os convidados convidados que ainda não responderam. Só envia se você ativar.",
       "rsvpReminderDays": "Lembrar após (dias do convite)",
+      "aiEnabled": "Ativar assistente de IA",
+      "aiEnabledHint": "Permite gerar resumos e textos com IA (Google Gemini). Ao ativar, dados do seu casamento são enviados ao provedor para gerar a resposta.",
+      "aiNotConfigured": "A IA exige uma chave de API configurada no servidor (GEMINI_API_KEY). Fale com quem administra a instalação.",
       "save": "Salvar",
       "toast": {
         "saved": "Configurações salvas",

--- a/src/test-utils/empty-module.ts
+++ b/src/test-utils/empty-module.ts
@@ -1,0 +1,4 @@
+// Stub vazio para os marcadores `server-only` / `client-only` sob o Vitest.
+// O Next.js resolve esses módulos no build; o Vitest (Vite puro) não — então
+// o alias em vitest.config.ts aponta para este arquivo. Ver vitest.config.ts.
+export {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+
+// `server-only`/`client-only` são resolvidos pelo Next no build, mas não pelo
+// Vite/Vitest — apontamos para um stub vazio para testar módulos server-only.
+const emptyModule = fileURLToPath(new URL("./src/test-utils/empty-module.ts", import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     tsconfigPaths: true,
+    alias: {
+      "server-only": emptyModule,
+      "client-only": emptyModule,
+    },
   },
   test: {
     globals: false,


### PR DESCRIPTION
## Contexto

Primeira etapa (MVP) do rollout de IA generativa (Google Gemini) no Wedding Finance Planner. A IA é **opcional e desligada por padrão** — mantém a postura "privado por padrão" do projeto. Esta PR entrega a **fundação reutilizável** + a **primeira feature**: um resumo em linguagem natural da saúde financeira na tela de Insights.

Plano completo (validação por módulo + ondas 2-5) discutido e aprovado previamente.

## O que muda

**Fundação** `src/lib/ai/` — `config`, `client`, `errors`, `rate-limit`, `generate`, `log`, `prompts`, `schemas`, `aiAccess`.
- `generateText` / `generateStructured` **nunca lançam** (retornam `AiResult` discriminado); timeout via `AbortSignal`; structured output revalidado por Zod no servidor.
- Invocação **exclusivamente via Server Actions** (`GEMINI_API_KEY` 100% server-side); `import "server-only"` em toda a camada.
- SDK `@google/genai`; modelo padrão `gemini-2.5-flash` (parametrizável).

**Opt-in em dois níveis**
1. Env `GEMINI_API_KEY` (master switch) — sem chave, a UI nem renderiza os botões.
2. `EventSettings.aiEnabled` (toggle do casal em Ajustes › Casamento).

Gate único `aiFeatureEnabled()`.

**1ª feature — narrativa de Insights**
- `generateInsightsNarrative` (read-only, **não persiste no domínio**).
- Botão reutilizável `ai-generate-button.tsx` com selo "Gerado por IA" + aviso de revisão (copiar / gerar de novo).
- Dados via `insights-snapshot.ts`, extraído da página para evitar duplicação.

**Schema aditivo** (`db push`): model `AiGeneration` + `EventSettings.aiEnabled`. Auditoria `AI_GENERATE`.

**Segurança/privacidade**: IA nunca exposta na rota pública `/rsvp`; prompts montados server-side com dados delimitados (anti prompt-injection); sem PII em log; `AiGeneration.outputPreview` truncado.

**Docs/i18n/testes**: strings nos 3 catálogos (pt-BR/en/es), 25 testes novos, `docs/ia.md`, artigo no help, changelog 0.8.0, README e `.env.example`. Alias `server-only` no Vitest.

## Como testar
A IA está desligada (sem chave). Defina `GEMINI_API_KEY` no `.env`, ative o toggle em **Ajustes › Casamento** e use "Gerar resumo com IA" no topo dos Insights.

## Verificação
- ✅ `npm run lint` — limpo
- ✅ `npm run test:run` — 646 testes (71 arquivos)
- ✅ `npm run build` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)